### PR TITLE
Flush BufferedOutputStream on deletion

### DIFF
--- a/src/main/php/io/streams/BufferedOutputStream.class.php
+++ b/src/main/php/io/streams/BufferedOutputStream.class.php
@@ -52,4 +52,11 @@ class BufferedOutputStream extends \lang\Object implements OutputStream {
     $this->flush();
     $this->out->close();
   }
+
+  /**
+   * Destructor.
+   */
+  public function __destruct() {
+    $this->close();
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/io/streams/BufferedOutputStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/BufferedOutputStreamTest.class.php
@@ -53,4 +53,11 @@ class BufferedOutputStreamTest extends \unittest\TestCase {
     $this->out->close();
     $this->assertEquals('Hello', $this->mem->getBytes());
   }
+
+  #[@test]
+  public function flushedOnDestruction() {
+    $this->out->write('Hello');
+    delete($this->out);
+    $this->assertEquals('Hello', $this->mem->getBytes());
+  }
 }


### PR DESCRIPTION
This pull request changes the `io.streams.BufferedOutputStream` class to call `close()` and thus flush to the underlying output stream on destruction.

This way, when programs forgetting to call `flush()` or `close()` explicitely, the output will not "disappear magically".

/cc @kiesel 
