### PR TITLE
Set status code to 516 to be able to distinguish from "regular" 500s

### DIFF
--- a/tools/web-main.php
+++ b/tools/web-main.php
@@ -10,7 +10,7 @@ $configd= ini_get('user_dir') ?: $webroot.'/etc';
 // this guarantees to at least send an error code.
 switch (php_sapi_name()) {
   case 'cgi':
-    header('Status: 516 Fatal Error');
+    header('Status: 516 Unrecoverable Error');
     break;
 
   case 'cli-server':
@@ -18,7 +18,7 @@ switch (php_sapi_name()) {
       return false;
     }
 
-    header('HTTP/1.0 516 Fatal Error');
+    header('HTTP/1.0 516 Unrecoverable Error');
     $_SERVER['SCRIPT_URL']= substr($_SERVER['REQUEST_URI'], 0, strcspn($_SERVER['REQUEST_URI'], '?#'));
     $_SERVER['SERVER_PROFILE']= getenv('SERVER_PROFILE');
     define('STDIN', fopen('php://stdin', 'rb'));
@@ -27,7 +27,7 @@ switch (php_sapi_name()) {
     break;
 
   default:
-    header('HTTP/1.0 516 Fatal Error');
+    header('HTTP/1.0 516 Unrecoverable Error');
 }
 ini_set('error_prepend_string', '<xmp>');
 ini_set('error_append_string', '</xmp>');


### PR DESCRIPTION
This pull request changes the behaviour of scriptlets to yield `HTTP/1.x 516` instead of 500. This HTTP status code is not standardized, and is derived from **500** + `E_CORE_ERROR(16)`.
