### PR TITLE
Fix Protocol::handleDisconnect() invocation

### DIFF
--- a/src/main/php/peer/server/Server.class.php
+++ b/src/main/php/peer/server/Server.class.php
@@ -213,7 +213,7 @@ class Server extends \lang\Object {
         // Check if we got an EOF from the client - in this file the connection
         // was gracefully closed.
         if (!$handles[$index]->isConnected() || $handles[$index]->eof()) {
-          $this->protocol->handleDisconnect($handles[$h]);
+          $this->protocol->handleDisconnect($handles[$index]);
           $handles[$index]->close();
           unset($handles[$index]);
           unset($lastAction[$index]);


### PR DESCRIPTION
This pull request fixes handleDisconnect() invocations on server protocols by passing in the correct socket.

Given a protocol implementation would try to invoke methods on the socket inside `handleDisconnect()`, the following would happen:

```
Exception lang.Error (Fatal error: Call to a member function close() on a non-object in ...)
  at peer.server.Server::service() [line 216 of Server.class.php] Undefined offset: 200
  at <main>::__output((0xae)'', 9) [line 0 of StackTraceElement.class.php]
```
