### PR TITLE
Implement nicer import syntax "new import(...)

### DIFF
--- a/src/main/php/lang/AbstractClassLoader.class.php
+++ b/src/main/php/lang/AbstractClassLoader.class.php
@@ -142,7 +142,7 @@ abstract class AbstractClassLoader extends Object implements IClassLoader {
     if (0 === \xp::$cll) {
       $invocations= \xp::$cli;
       \xp::$cli= [];
-      foreach ($invocations as $inv) call_user_func($inv);
+      foreach ($invocations as $inv) call_user_func($inv, $name);
     }
     return $name;
   }

--- a/src/test/php/net/xp_framework/unittest/core/ImportTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ImportTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\types\ArrayList;
-new \import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
+new import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
 
 /**
  * Tests the XP Framework's import() functionality

--- a/src/test/php/net/xp_framework/unittest/core/extensions/ArrayListDemo.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/extensions/ArrayListDemo.class.php
@@ -2,7 +2,7 @@
 
 use util\cmd\Console;
 use lang\types\ArrayList;
-new \import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
+new import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
 
 /**
  * Demo class that uses the ArrayList extension methods

--- a/src/test/php/net/xp_framework/unittest/core/extensions/ArrayListExtensions.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/extensions/ArrayListExtensions.class.php
@@ -2,7 +2,6 @@
 
 use lang\types\ArrayList;
 
-
 /**
  * ArrayList extension methods
  *

--- a/src/test/php/net/xp_framework/unittest/core/extensions/ExtensionInvocationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/extensions/ExtensionInvocationTest.class.php
@@ -2,8 +2,8 @@
 
 use unittest\TestCase;
 use lang\types\ArrayList;
-new \import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
-new \import('net.xp_framework.unittest.core.extensions.ThrowableExtensions');
+new import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
+new import('net.xp_framework.unittest.core.extensions.ThrowableExtensions');
 
 /**
  * TestCase


### PR DESCRIPTION
In essence, this:

``` diff
-new \import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
+new import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
```
