### PR TITLE
Static T::type() method

### DIFF
--- a/src/main/php/lang/Object.class.php
+++ b/src/main/php/lang/Object.class.php
@@ -58,7 +58,17 @@ class Object implements Generic { use \__xp;
   public function getClass() {
     return new XPClass($this);
   }
-  
+
+  /**
+   * Returns the runtime class of a class.
+   *
+   * @return  lang.XPClass runtime class
+   * @see     xp://lang.XPClass
+   */
+  public static function type() {
+    return new XPClass(get_called_class());
+  }
+
   /**
    * Creates a string representation of this object. In general, the toString 
    * method returns a string that "textually represents" this object. The result 

--- a/src/main/php/lang/Throwable.class.php
+++ b/src/main/php/lang/Throwable.class.php
@@ -273,4 +273,14 @@ class Throwable extends \Exception implements Generic { use \__xp;
   public function getClass() {
     return new XPClass($this);
   }
+
+  /**
+   * Returns the runtime class of a class.
+   *
+   * @return  lang.XPClass runtime class
+   * @see     xp://lang.XPClass
+   */
+  public static function type() {
+    return new XPClass(get_called_class());
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/core/ObjectTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ObjectTest.class.php
@@ -72,6 +72,16 @@ class ObjectTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function static_type_method_returns_XPClass_for_Object() {
+    $this->assertEquals(XPClass::forName('lang.Object'), Object::type());
+  }
+
+  #[@test]
+  public function static_type_method_returns_XPClass_for_XPClass() {
+    $this->assertEquals(XPClass::forName('lang.XPClass'), XPClass::type());
+  }
+
+  #[@test]
   public function toString_returns_fully_qualified_class_name_and_its_hash_code() {
     $o= new Object();
     $this->assertEquals("lang.Object {\n  __id => \"".$o->hashCode()."\"\n}", $o->toString());

--- a/tools/lang.base.php
+++ b/tools/lang.base.php
@@ -47,7 +47,6 @@ trait __xp {
     throw new Error('Call to undefined method '.\xp::nameOf($self).'::'.$name.'() from scope '.\xp::nameOf($scope));
   }
   // }}}
-
 }
 // }}}
 


### PR DESCRIPTION
This pull request implements xp-framework/rfc#280 and adds a static `type()` method to the root objects.

``` sh
$ xp -w '\util\Date::type()'
lang.XPClass<util.Date>

$ xp -w 'self::type()'
lang.XPClass<xp.runtime.Dump>
```
