### PR TITLE
Be able to refer to instance methods via string

### DIFF
--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -193,7 +193,7 @@ class FunctionType extends Type {
         $r= new \ReflectionMethod($class, '__construct');
         if (!$this->verify($r, $this->signature, $false, $r->getDeclaringClass())) return false;
       } else {
-        if (!$this->returns->isAssignableFrom(Type::forName(\xp::nameOf($class)))) return $false('Class type mismatch');
+        if (!$this->returns->isAssignableFrom(new XPClass($class))) return $false('Class type mismatch');
       }
       $c= new \ReflectionClass($class);
       if (!$c->isInstantiable()) return $false(\xp::nameOf($class).' cannot be instantiated');

--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -210,7 +210,7 @@ class FunctionType extends Type {
         if (null === $this->signature) {
           $verify= null;
         } else {
-          if (empty($this->signature) || !$this->signature[0]->isAssignableFrom(new XPClass($r->getDeclaringClass()))) {
+          if (empty($this->signature) || !$this->signature[0]->isAssignableFrom(new XPClass($class))) {
             return $false('Method '.\xp::nameOf($class).'::'.$method.' requires instance of class as first parameter');
           }
           $verify= array_slice($this->signature, 1);

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -528,6 +528,15 @@ class FunctionTypeTest extends \unittest\TestCase {
   #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
   #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
   #])]
+  public function reference_to_instance_method_is_instance_with_exact_class($value) {
+    $type= new FunctionType([XPClass::forName('net.xp_framework.unittest.core.FunctionTypeTest')], Primitive::$STRING);
+    $this->assertTrue($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
   public function reference_to_instance_method_is_instance_with_parent_class($value) {
     $type= new FunctionType([XPClass::forName('lang.Object')], Primitive::$STRING);
     $this->assertTrue($type->isInstance($value));

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -512,6 +512,17 @@ class FunctionTypeTest extends \unittest\TestCase {
   #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
   #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
   #])]
+  public function reference_to_instance_method_creating_new_instances($value) {
+    $type= new FunctionType([XPClass::forName('unittest.TestCase')], Primitive::$STRING);
+    $f= $type->newInstance($value);
+    $this->assertEquals($this->getName(), $f($this));
+    $this->assertEquals($this->getName(true), $f($this, true));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
   public function reference_to_instance_method_can_be_invoked($value) {
     $type= new FunctionType([XPClass::forName('unittest.TestCase')], Primitive::$STRING);
     $this->assertEquals($this->getName(), $type->invoke($value, [$this]));

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -218,15 +218,6 @@ class FunctionTypeTest extends \unittest\TestCase {
     $this->assertFalse((new FunctionType([], Primitive::$INT))->isInstance([$this, 'getName']));
   }
 
-  #[@test, @values([
-  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
-  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
-  #])]
-  public function array_referencing_instance_method_via_string_is_not_instance($value) {
-    $type= new FunctionType([], Primitive::$STRING);
-    $this->assertFalse($type->isInstance($value));
-  }
-
   #[@test]
   public function array_referencing_non_existant_instance_method_is_not_instance() {
     $type= new FunctionType([], Primitive::$STRING);
@@ -264,9 +255,7 @@ class FunctionTypeTest extends \unittest\TestCase {
   #  0, -1, 0.5, true, false, '', 'Test',
   #  [[]], [['key' => 'value']],
   #  [['non-existant', 'method']], [['lang.XPClass', 'non-existant']],
-  #  [[null, 'method']], [[new \lang\Object(), 'non-existant']],
-  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
-  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #  [[null, 'method']], [[new \lang\Object(), 'non-existant']]
   #])]
   public function cannot_cast_this($value) {
     (new FunctionType([Type::$VAR], Type::$VAR))->cast($value);
@@ -392,9 +381,7 @@ class FunctionTypeTest extends \unittest\TestCase {
   #  0, -1, 0.5, true, false, '', 'Test',
   #  [[]], [['key' => 'value']],
   #  [['non-existant', 'method']], [['lang.XPClass', 'non-existant']],
-  #  [[null, 'method']], [[new \lang\Object(), 'non-existant']],
-  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
-  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #  [[null, 'method']], [[new \lang\Object(), 'non-existant']]
   #])]
   public function cannot_create_instances_from($value) {
     (new FunctionType([], Type::$VAR))->newInstance($value);
@@ -465,8 +452,6 @@ class FunctionTypeTest extends \unittest\TestCase {
   #  [[]], [['key' => 'value']],
   #  [['non-existant', 'method']], [['lang.XPClass', 'non-existant']],
   #  [[null, 'method']], [[new \lang\Object(), 'non-existant']],
-  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
-  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName'],
   #  function() { }
   #])]
   public function invoke_not_instance($value) {
@@ -501,5 +486,35 @@ class FunctionTypeTest extends \unittest\TestCase {
   public function cast_loads_class_if_necessary_with_method() {
     $t= new FunctionType([Type::$VAR], Primitive::$VOID);
     $t->cast('net.xp_framework.unittest.core.FunctionTypeMethodFixture::method');
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_is_instance($value) {
+    $type= new FunctionType([XPClass::forName('unittest.TestCase')], Primitive::$STRING);
+    $this->assertTrue($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_can_be_cast($value) {
+    $type= new FunctionType([XPClass::forName('unittest.TestCase')], Primitive::$STRING);
+    $f= $type->cast($value);
+    $this->assertEquals($this->getName(), $f($this));
+    $this->assertEquals($this->getName(true), $f($this, true));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_can_be_invoked($value) {
+    $type= new FunctionType([XPClass::forName('unittest.TestCase')], Primitive::$STRING);
+    $this->assertEquals($this->getName(), $type->invoke($value, [$this]));
+    $this->assertEquals($this->getName(true), $type->invoke($value, [$this, true]));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -501,6 +501,78 @@ class FunctionTypeTest extends \unittest\TestCase {
   #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
   #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
   #])]
+  public function reference_to_instance_method_is_instance_with_optional_arg($value) {
+    $type= new FunctionType([XPClass::forName('unittest.TestCase'), Primitive::$BOOL], Primitive::$STRING);
+    $this->assertTrue($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_is_not_instance_with_optional_arg_mismatch($value) {
+    $type= new FunctionType([XPClass::forName('unittest.TestCase'), Primitive::$INT], Primitive::$STRING);
+    $this->assertFalse($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_is_instance_with_null_signature($value) {
+    $type= new FunctionType(null, Primitive::$STRING);
+    $this->assertTrue($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_is_instance_with_parent_class($value) {
+    $type= new FunctionType([XPClass::forName('lang.Object')], Primitive::$STRING);
+    $this->assertTrue($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_is_instance_with_interface($value) {
+    $type= new FunctionType([XPClass::forName('lang.Generic')], Primitive::$STRING);
+    $this->assertTrue($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_is_instance_with_var($value) {
+    $type= new FunctionType([Type::$VAR], Primitive::$STRING);
+    $this->assertTrue($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_is_not_instance_with_class_mismatch($value) {
+    $type= new FunctionType([XPClass::forName('lang.XPClass')], Primitive::$STRING);
+    $this->assertFalse($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
+  public function reference_to_instance_method_is_not_instance_without_class($value) {
+    $type= new FunctionType([], Primitive::$STRING);
+    $this->assertFalse($type->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [['net.xp_framework.unittest.core.FunctionTypeTest', 'getName']],
+  #  ['net.xp_framework.unittest.core.FunctionTypeTest::getName']
+  #])]
   public function reference_to_instance_method_can_be_cast($value) {
     $type= new FunctionType([XPClass::forName('unittest.TestCase')], Primitive::$STRING);
     $f= $type->cast($value);


### PR DESCRIPTION
This PR enables the following:

```php
class Person extends \lang\Object {
  private $name;
  public function __construct($name) { $this->name= $name; }
  public function name() { return $this->name; }
}

// [Timm, Test]
$names= Sequence::of(new Person('Timm'), new Person('Test'))
  ->map('Person::name')
  ->toArray()
;
```

Previously, you'd have to write:

```php
// [Timm, Test]
$names= Sequence::of(new Person('Timm'), new Person('Test'))
  ->map(function($person) { return $person->name(); })
  ->toArray()
;
```

*(Examples use the awesome [sequence library](https://github.com/xp-forge/sequence/))*