### PR TITLE
Feature: Support invokeables

### DIFF
--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -165,7 +165,7 @@ class FunctionType extends Type {
         if ($this->verify($r, $this->signature, $false)) {
           return $return ? $r->getClosure() : true;
         }
-      } else {;
+      } else {
         return $false('Function "'.$arg.'" does not exist');
       }
     } else if (is_array($arg) && 2 === sizeof($arg)) {

--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -165,11 +165,16 @@ class FunctionType extends Type {
         if ($this->verify($r, $this->signature, $false)) {
           return $return ? $r->getClosure() : true;
         }
-      } else {
+      } else {;
         return $false('Function "'.$arg.'" does not exist');
       }
     } else if (is_array($arg) && 2 === sizeof($arg)) {
       return $this->verifiedMethod($arg[0], $arg[1], $false, $return);
+    } else if (method_exists($arg, '__invoke')) {
+      $inv= new \ReflectionMethod($arg, '__invoke');
+      if ($this->verify($inv, $this->signature, $false)) {
+        return $return ? $inv->getClosure($arg) : true;
+      }
     } else {
       return $false('Unsupported type');
     }

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeInvokeable.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeInvokeable.class.php
@@ -1,0 +1,13 @@
+<?php namespace net\xp_framework\unittest\core;
+
+/**
+ * Class for FunctionTypeTest
+ */
+class FunctionTypeInvokeable extends \lang\Object {
+
+  /**
+   * @param  var $arg
+   * @return var
+   */
+  public function __invoke($arg) { return $arg; }
+}

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -620,13 +620,13 @@ class FunctionTypeTest extends \unittest\TestCase {
   public function casting_invokeable() {
     $type= new FunctionType([Type::$VAR], Type::$VAR);
     $inv= new FunctionTypeInvokeable();
-    $this->assertEquals($inv, $type->cast($inv));
+    $this->assertInstanceOf('Closure', $type->cast($inv));
   }
 
   #[@test]
   public function new_instance_of_invokeable() {
     $type= new FunctionType([Type::$VAR], Type::$VAR);
     $inv= new FunctionTypeInvokeable();
-    $this->assertEquals($inv, $type->newInstance($inv));
+    $this->assertInstanceOf('Closure', $type->newInstance($inv));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -609,4 +609,24 @@ class FunctionTypeTest extends \unittest\TestCase {
     $this->assertEquals($this->getName(), $type->invoke($value, [$this]));
     $this->assertEquals($this->getName(true), $type->invoke($value, [$this, true]));
   }
+
+  #[@test]
+  public function invokeable_is_instance() {
+    $type= new FunctionType([Type::$VAR], Type::$VAR);
+    $this->assertTrue($type->isInstance(new FunctionTypeInvokeable()));
+  }
+
+  #[@test]
+  public function casting_invokeable() {
+    $type= new FunctionType([Type::$VAR], Type::$VAR);
+    $inv= new FunctionTypeInvokeable();
+    $this->assertEquals($inv, $type->cast($inv));
+  }
+
+  #[@test]
+  public function new_instance_of_invokeable() {
+    $type= new FunctionType([Type::$VAR], Type::$VAR);
+    $inv= new FunctionTypeInvokeable();
+    $this->assertEquals($inv, $type->newInstance($inv));
+  }
 }


### PR DESCRIPTION
This pull request supports the [__invoke()](http://php.net/manual/en/language.oop5.magic.php#object.invoke) method for function types:

```php
class Test extends \lang\Object {
  public function __invoke($arg) { return 'Test'; }
}

$inv= FunctionType::forName('function(var): var')->cast(new Test());
$result= $inv();   // 'Test'
```