### PR TITLE
Support class literals

### DIFF
--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -732,7 +732,7 @@ class XPClass extends Type {
       $classloader= ClassLoader::getDefault();
     }
 
-    return $classloader->loadClass((string)$name);
+    return $classloader->loadClass(strtr($name, '\\', '.'));
   }
 
   /**

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -42,7 +42,8 @@ class ClassParser extends \lang\Object {
   }
 
   /**
-   * Resolves a class member, which is either a field or a constant.
+   * Resolves a class member, which is either a field, a class constant
+   * or the `ClassName::class` syntax, which returns the class' literal.
    *
    * @param  lang.XPClass $class
    * @param  var[] $token A token as returned by `token_get_all()`
@@ -67,6 +68,8 @@ class ClassParser extends \lang\Object {
           $field->getName()
         ));
       }
+    } else if (T_CLASS === $token[0]) {
+      return $class->literal();
     } else {
       return $class->getConstant($token[1]);
     }

--- a/src/test/php/net/xp_framework/unittest/annotations/ClassMemberParsingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/ClassMemberParsingTest.class.php
@@ -2,6 +2,7 @@
 
 use net\xp_framework\unittest\annotations\fixture\Namespaced;
 use lang\types\String;
+use lang\XPClass;
 
 /**
  * Tests the XP Framework's annotation parsing implementation
@@ -60,5 +61,25 @@ class ClassMemberParsingTest extends \unittest\TestCase {
   #[@test, @values([\net\xp_framework\unittest\annotations\ClassMemberParsingTest::$value])]
   public function static_member_via_fully_qualified_current($value) {
     $this->assertEquals('static', $value);
+  }
+
+  #[@test, @values([
+  #  self::class,
+  #  ClassMemberParsingTest::class,
+  #  \net\xp_framework\unittest\annotations\ClassMemberParsingTest::class
+  #])]
+  public function class_constant_referencing_this_class($value) {
+    $this->assertEquals($this->getClass()->literal(), $value);
+  }
+
+  #[@test, @values([
+  #  Namespaced::class,
+  #  \net\xp_framework\unittest\annotations\fixture\Namespaced::class
+  #])]
+  public function class_constant_referencing_foreign_class($value) {
+    $this->assertEquals(
+      XPClass::forName('net.xp_framework.unittest.annotations.fixture.Namespaced')->literal(),
+      $value
+    );
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeRefByLiteralLoadedOnDemand.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeRefByLiteralLoadedOnDemand.class.php
@@ -1,0 +1,8 @@
+<?php namespace net\xp_framework\unittest\reflection;
+
+/**
+ * Used by net.xp_framework.unittest.reflection.TypeTest::objectTypeLiteralLoadsIfNecessary
+ */
+class TypeRefByLiteralLoadedOnDemand extends \lang\Object {
+  
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeRefByNameLoadedOnDemand.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeRefByNameLoadedOnDemand.class.php
@@ -1,0 +1,8 @@
+<?php namespace net\xp_framework\unittest\reflection;
+
+/**
+ * Used by net.xp_framework.unittest.reflection.TypeTest::objectTypeLoadedIfNecessary
+ */
+class TypeRefByNameLoadedOnDemand extends \lang\Object {
+  
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -67,6 +67,33 @@ class TypeTest extends TestCase {
   }
 
   #[@test]
+  public function objectTypeLiteral() {
+    $this->assertEquals(XPClass::forName('lang.Object'), Type::forName('lang\\Object'));
+  }
+
+  #[@test]
+  public function objectTypeLiteralLoadedIfNecessary() {
+    $literal= 'net\\xp_framework\\unittest\\reflection\\TypeRefByLiteralLoadedOnDemand';
+
+    Type::forName($literal);
+    $this->assertTrue(class_exists($literal, false));
+  }
+
+  #[@test]
+  public function objectTypeLoadedIfNecessary() {
+    $literal= 'net\\xp_framework\\unittest\\reflection\\TypeRefByNameLoadedOnDemand';
+    $name= 'net.xp_framework.unittest.reflection.TypeRefByNameLoadedOnDemand';
+
+    Type::forName($name);
+    $this->assertTrue(class_exists($literal, false));
+  }
+
+  #[@test]
+  public function closureType() {
+    $this->assertEquals(new XPClass('Closure'), Type::forName('Closure'));
+  }
+
+  #[@test]
   public function generic() {
     $this->assertEquals(
       XPClass::forName('util.collections.Vector')->newGenericType([Primitive::$STRING]),

--- a/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
@@ -263,6 +263,14 @@ class XPClassTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function forName_supports_class_literals() {
+    $this->assertEquals(
+      $this->fixture,
+      XPClass::forName('net\\xp_framework\\unittest\\reflection\\TestClass')
+    );
+  }
+
+  #[@test]
   public function getClasses_returns_a_list_of_class_objects() {
     $this->assertInstanceOf('lang.XPClass[]', XPClass::getClasses());
   }


### PR DESCRIPTION
This pull request adds support for `::class` notation in annotations and changes `lang.XPClass::forName()` to be able to accept these.

```php
#[@test, @expect(IllegalArgumentException::class)]
public function unhandled() {
  ...
}
```

See https://wiki.php.net/rfc/class_name_scalars (added in PHP 5.5)