### PR TITLE
Feature: Newinstance with traits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ php:
 
 matrix:
   allow_failures:
-    - php: nightly hhvm
+    - php: nightly
+    - php: hhvm-nightly
 
 before_script:
   - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.2/setup' -O - | php

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Finally, start `xp -v` to see it working:
 
 ```sh
 $ xp -v
-XP 6.0.0-dev { PHP 5.6.4 & ZE 2.6.0 } @ Windows NT SLATE 6.2 build 9200 (Windows 8) i586
+XP 6.0.0-dev { PHP 5.6.7 & ZE 2.6.0 } @ Windows NT SLATE 6.2 build 9200 (Windows 8) i586
 Copyright (c) 2001-2015 the XP group
 FileSystemCL<...\xp\core\src\main\php\>
 FileSystemCL<...\xp\core\src\test\php\>

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -577,11 +577,11 @@ function newinstance($spec, $args, $def= null) {
   }
 
   if (interface_exists($type)) {
-    $decl= 'class %s extends \\lang\\Object implements \\'.$type;
+    $decl= ['kind' => 'class', 'extends' => ['lang.Object'], 'implements' => ['\\'.$type], 'use' => []];
   } else if (trait_exists($type)) {
-    $decl= ['kind' => 'class', 'extends' => 'lang.Object', 'implements' => [], 'use' => [$type]];
+    $decl= ['kind' => 'class', 'extends' => ['lang.Object'], 'implements' => [], 'use' => ['\\'.$type]];
   } else {
-    $decl= 'class %s extends \\'.$type;
+    $decl= ['kind' => 'class', 'extends' => ['\\'.$type], 'implements' => [], 'use' => []];
   }
   $defined= \lang\ClassLoader::defineType($annotations.$name, $decl, $def);
 

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -578,6 +578,8 @@ function newinstance($spec, $args, $def= null) {
 
   if (interface_exists($type)) {
     $decl= 'class %s extends \\lang\\Object implements \\'.$type;
+  } else if (trait_exists($type)) {
+    $decl= ['kind' => 'class', 'extends' => 'lang.Object', 'implements' => [], 'use' => [$type]];
   } else {
     $decl= 'class %s extends \\'.$type;
   }

--- a/src/main/php/lang/ClassLoader.class.php
+++ b/src/main/php/lang/ClassLoader.class.php
@@ -317,6 +317,11 @@ final class ClassLoader extends Object implements IClassLoader {
           $constructor= self::defineForward('__construct', $ctor->getParameters(), 'parent::__construct(%s);');
         } else {
           $constructor= self::defineForward('__construct', [], '');
+          foreach ($declaration['use'] as $use) {
+            if ($ctor= (new \ReflectionClass(self::classLiteral($use)))->getConstructor()) {
+              $constructor= self::defineForward('__construct', $ctor->getParameters(), 'parent:__construct(%s);');
+            }
+          }
         }
         $bytes= 'static $__func= []; '.$constructor.$bytes;
       }

--- a/src/main/php/lang/ClassLoader.class.php
+++ b/src/main/php/lang/ClassLoader.class.php
@@ -40,12 +40,14 @@ use lang\reflect\Module;
  * @see   xp://lang.reflect.Package#loadClass
  */
 final class ClassLoader extends Object implements IClassLoader {
+  private static $VARIADIC;
   protected static
     $delegates = [],
     $modules   = [];
 
   static function __static() {
     $modules= [];
+    self::$VARIADIC= method_exists('ReflectionParameter', 'isVariadic');
     
     // Scan include-path, setting up classloaders for each element
     foreach (\xp::$classpath as $element) {
@@ -224,6 +226,10 @@ final class ClassLoader extends Object implements IClassLoader {
         $sig.= ', callable $'.$p;
       } else if (null !== ($restriction= $param->getClass())) {
         $sig.= ', \\'.$restriction->getName().' $'.$p;
+      } else if (self::$VARIADIC && $param->isVariadic()) {
+        $sig.= ', ...$'.$p;
+        $pass.= ', ...$'.$p;
+        continue;
       } else {
         $sig.= ', $'.$p;
       }

--- a/src/main/php/lang/ClassLoader.class.php
+++ b/src/main/php/lang/ClassLoader.class.php
@@ -318,10 +318,15 @@ final class ClassLoader extends Object implements IClassLoader {
         } else {
           $constructor= self::defineForward('__construct', [], '');
           foreach ($declaration['use'] as $use) {
-            if ($ctor= (new \ReflectionClass(self::classLiteral($use)))->getConstructor()) {
-              $constructor= self::defineForward('__construct', $ctor->getParameters(), 'parent:__construct(%s);');
+            $trait= self::classLiteral($use);
+            if ($ctor= (new \ReflectionClass($trait))->getConstructor()) {
+              $bytes.= 'use '.$trait.' { __construct as __trait; }';
+              $constructor= self::defineForward('__construct', $ctor->getParameters(), 'self::__trait(%s);');
+            } else {
+              $bytes.= 'use '.$trait.';';
             }
           }
+          $declaration['use']= [];
         }
         $bytes= 'static $__func= []; '.$constructor.$bytes;
       }

--- a/src/test/php/net/xp_framework/unittest/core/ListOf.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ListOf.class.php
@@ -1,0 +1,11 @@
+<?php namespace net\xp_framework\unittest\core;
+
+trait ListOf {
+  private $elements;
+
+  /** @param var[] $initial */
+  public function __construct(array $initial) { $this->elements= $initial; }
+
+  /** @return var[] */
+  public function elements() { return $this->elements; }
+}

--- a/src/test/php/net/xp_framework/unittest/core/Named.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/Named.class.php
@@ -1,0 +1,8 @@
+<?php namespace net\xp_framework\unittest\core;
+
+trait Named {
+  private $name;
+
+  /** @return string */
+  public function name() { return $this->name; }
+}

--- a/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
@@ -121,6 +121,30 @@ class NewInstanceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function new_trait_with_body_as_string() {
+    $o= newinstance('net.xp_framework.unittest.core.Named', ['Test'], '{
+      public function __construct($name) { $this->name= $name; }
+    }');
+    $this->assertEquals('Test', $o->name());
+  }
+
+  #[@test]
+  public function new_trait_with_body_as_closuremap() {
+    $o= newinstance('net.xp_framework.unittest.core.Named', ['Test'], [
+      '__construct' => function($name) { $this->name= $name; }
+    ]);
+    $this->assertEquals('Test', $o->name());
+  }
+
+  #[@test]
+  public function new_trait_with_annotations() {
+    $o= newinstance('#[@test] net.xp_framework.unittest.core.Named', [], [
+      'run' => function() { }
+    ]);
+    $this->assertTrue($o->getClass()->hasAnnotation('test'));
+  }
+
+  #[@test]
   public function arguments_are_passed_to_constructor() {
     $instance= newinstance('lang.Object', [$this], '{
       public $test= null;

--- a/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
@@ -146,6 +146,12 @@ class NewInstanceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function new_trait_with_constructor() {
+    $o= newinstance('net.xp_framework.unittest.core.ListOf', [[1, 2, 3]], []);
+    $this->assertEquals([1, 2, 3], $o->elements());
+  }
+
+  #[@test]
   public function arguments_are_passed_to_constructor() {
     $instance= newinstance('lang.Object', [$this], '{
       public $test= null;


### PR DESCRIPTION
This pull request adds support for creating anonymous classes from traits.

Using this trait:
```php
trait Named {
  private $name;

  /** @return string */
  public function name() { return $this->name; }
}
```
The call here:
```php
$named= newinstance('Named', ['Test'], [
  '__construct' => function($name) { $this->name= $name; }
]);
```
Generates code equivalent to:
```php
class Named·1 extends \lang\Object {
  use Named;

  public function __construct($name) { $this->name= $name; }
}
```

Finally, calling the trait method will yield:
```php
$named->name();  // "Test"
```