### PR TITLE
Feature: Field types via "var" tag.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,9 @@ XP Framework Core ChangeLog
 
 ### Features
 
+* Added support for `/** @var [type] */` for fields.
+  http://www.phpdoc.org/docs/latest/references/phpdoc/tags/var.html
+  (@thekid)
 * Added `lang.XPClass::isTrait()` and `lang.XPClass::getTraits()` methods.
   (@thekid)
 * Implemented xp-framework/core#60: Create anonymous instances from traits

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -297,7 +297,7 @@ class ClassParser extends \lang\Object {
    * @param  string $close
    * @param  int
    */
-  protected function matching($text, $open, $close) {
+  protected static function matching($text, $open, $close) {
     for ($braces= $open.$close, $i= 0, $b= 0, $s= strlen($text); $i < $s; $i+= strcspn($text, $braces, $i)) {
       if ($text{$i} === $open) {
         $b++;
@@ -315,13 +315,13 @@ class ClassParser extends \lang\Object {
    * @param  string $text
    * @return string
    */
-  protected function typeIn($text) {
+  public static function typeIn($text) {
     if (0 === strncmp($text, 'function(', 9)) {
-      $p= $this->matching($text, '(', ')');
+      $p= self::matching($text, '(', ')');
       $p+= strspn($text, ': ', $p);
-      return substr($text, 0, $p).$this->typeIn(substr($text, $p));
+      return substr($text, 0, $p).self::typeIn(substr($text, $p));
     } else if (strstr($text, '<')) {
-      $p= $this->matching($text, '<', '>');
+      $p= self::matching($text, '<', '>');
       return substr($text, 0, $p);
     } else {
       return substr($text, 0, strcspn($text, ' '));
@@ -424,15 +424,15 @@ class ClassParser extends \lang\Object {
           foreach ($matches as $match) {
             switch ($match[1]) {
               case 'param':
-                $details[1][$m][DETAIL_ARGUMENTS][$arg++]= $this->typeIn($match[2]);
+                $details[1][$m][DETAIL_ARGUMENTS][$arg++]= self::typeIn($match[2]);
                 break;
 
               case 'return':
-                $details[1][$m][DETAIL_RETURNS]= $this->typeIn($match[2]);
+                $details[1][$m][DETAIL_RETURNS]= self::typeIn($match[2]);
                 break;
 
               case 'throws': 
-                $details[1][$m][DETAIL_THROWS][]= $this->typeIn($match[2]);
+                $details[1][$m][DETAIL_THROWS][]= self::typeIn($match[2]);
                 break;
             }
           }

--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -47,8 +47,8 @@ class Field extends \lang\Object {
         if (isset($details[DETAIL_ANNOTATIONS]['type'])) return \lang\Type::forName($details[DETAIL_ANNOTATIONS]['type']);
       }
     } else {
-      if (preg_match('/@var (.+) \*\//', $raw, $matches)) {
-        return \lang\Type::forName($matches[1]);
+      if (preg_match('/@var\s*([^\r\n]+)/', $raw, $matches)) {
+        return \lang\Type::forName(ClassParser::typeIn($matches[1]));
       }
     }
 
@@ -67,8 +67,8 @@ class Field extends \lang\Object {
         if (isset($details[DETAIL_ANNOTATIONS]['type'])) return $details[DETAIL_ANNOTATIONS]['type'];
       }
     } else {
-      if (preg_match('/@var (.+) \*\//', $raw, $matches)) {
-        return $matches[1];
+      if (preg_match('/@var\s*([^\r\n]+)/', $raw, $matches)) {
+        return ClassParser::typeIn($matches[1]);
       }
     }
 

--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -41,9 +41,17 @@ class Field extends \lang\Object {
    * @return  lang.Type
    */
   public function getType() {
-    if ($details= \lang\XPClass::detailsForField($this->_reflect->getDeclaringClass()->getName(), $this->_reflect->getName())) {
-      if (isset($details[DETAIL_ANNOTATIONS]['type'])) return \lang\Type::forName($details[DETAIL_ANNOTATIONS]['type']);
+    $raw= $this->_reflect->getDocComment();
+    if (false === $raw) {
+      if ($details= \lang\XPClass::detailsForField($this->_reflect->getDeclaringClass()->getName(), $this->_reflect->getName())) {
+        if (isset($details[DETAIL_ANNOTATIONS]['type'])) return \lang\Type::forName($details[DETAIL_ANNOTATIONS]['type']);
+      }
+    } else {
+      if (preg_match('/@var (.+) \*\//', $raw, $matches)) {
+        return \lang\Type::forName($matches[1]);
+      }
     }
+
     return \lang\Type::$VAR;
   }
 
@@ -53,9 +61,17 @@ class Field extends \lang\Object {
    * @return  string
    */
   public function getTypeName() {
-    if ($details= \lang\XPClass::detailsForField($this->_reflect->getDeclaringClass()->getName(), $this->_reflect->getName())) {
-      if (isset($details[DETAIL_ANNOTATIONS]['type'])) return $details[DETAIL_ANNOTATIONS]['type'];
+    $raw= $this->_reflect->getDocComment();
+    if (false === $raw) {
+      if ($details= \lang\XPClass::detailsForField($this->_reflect->getDeclaringClass()->getName(), $this->_reflect->getName())) {
+        if (isset($details[DETAIL_ANNOTATIONS]['type'])) return $details[DETAIL_ANNOTATIONS]['type'];
+      }
+    } else {
+      if (preg_match('/@var (.+) \*\//', $raw, $matches)) {
+        return $matches[1];
+      }
     }
+
     return 'var';
   }
 

--- a/src/test/php/net/xp_framework/unittest/reflection/FieldsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/FieldsTest.class.php
@@ -364,7 +364,7 @@ class FieldsTest extends TestCase {
   }
 
   /**
-   * Tests retrieving the "date" field's is defined
+   * Tests retrieving the "date" field's is defined by `[@type]`
    *
    * @see     xp://lang.reflect.Field#getType
    */
@@ -374,13 +374,33 @@ class FieldsTest extends TestCase {
   }
 
   /**
-   * Tests retrieving the "date" field's is defined
+   * Tests retrieving the "date" field's is defined by `[@type]`
    *
    * @see     xp://lang.reflect.Field#getTypeName
    */
   #[@test]
   public function dateFieldTypeName() {
     $this->assertEquals('util.Date', $this->fixture->getField('date')->getTypeName());
+  }
+
+  /**
+   * Tests retrieving the "map" field's type is defined by `@var`
+   *
+   * @see     xp://lang.reflect.Field#getType
+   */
+  #[@test]
+  public function mapFieldType() {
+    $this->assertEquals(\lang\MapType::forName('[:lang.Object]'), $this->fixture->getField('map')->getType());
+  }
+
+  /**
+   * Tests retrieving the "map" field's type is defined by `@var`
+   *
+   * @see     xp://lang.reflect.Field#getTypeName
+   */
+  #[@test]
+  public function mapFieldTypeName() {
+    $this->assertEquals('[:lang.Object]', $this->fixture->getField('map')->getTypeName());
   }
 
   /**

--- a/src/test/php/net/xp_framework/unittest/reflection/TestClass.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TestClass.class.php
@@ -15,6 +15,7 @@ class TestClass extends AbstractTestClass implements Traceable {
   public
     #[@type('util.Date')]
     $date   = null,
+    /** @var [:lang.Object] */
     $map    = [];
   
   protected


### PR DESCRIPTION
The reflection API now honors the `@var` apidoc tag.

```php
class Example extends \lang\Object {
  /** @var string */
  protected $description;
}
```

See http://www.phpdoc.org/docs/latest/references/phpdoc/tags/var.html