### PR TITLE
Implement Console::writeLines()

### DIFF
--- a/src/main/php/util/cmd/Console.class.php
+++ b/src/main/php/util/cmd/Console.class.php
@@ -80,7 +80,18 @@ class Console extends \lang\Object {
     $a= func_get_args();
     call_user_func_array(array(self::$out, 'writeLine'), $a);
   }
-  
+
+  /**
+   * Writes lines to standard output
+   *
+   * @param   var* args
+   */
+  public static function writeLines() {
+    foreach (func_get_args() as $line) {
+      call_user_func_array(array(self::$out, 'writeLine'), (array)$line);
+    }
+  }
+
   /**
    * Write a formatted string to standard output
    *

--- a/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
@@ -179,6 +179,16 @@ class ConsoleTest extends TestCase {
   }
 
   #[@test]
+  public function writeLines() {
+    Console::writeLines(
+      ['Hello ', $this->getName()],
+      ['Second line'],
+      'Third line'
+    );
+    $this->assertEquals("Hello writeLines\nSecond line\nThird line\n", $this->streams[1]->getBytes());
+  }
+
+  #[@test]
   public function writeLine_to_standard_out() {
     Console::$out->writeLine('.');
     $this->assertEquals(".\n", $this->streams[1]->getBytes());


### PR DESCRIPTION
This pull request adds a new method `writeLines()` to the `util.cmd.Console` class:

```php
$power= 6100;
Console::writeLines(
  ['Power: ', $power],
  ['Produced by ', $this, ' on ', Date::now()],
  'Three'
);
```