### PR TITLE
Cleanup: Deprecate raise

### DIFF
--- a/src/main/php/io/EncapsedStream.class.php
+++ b/src/main/php/io/EncapsedStream.class.php
@@ -1,6 +1,6 @@
 <?php namespace io;
 
-
+use lang\MethodNotImplementedException;
 
 /**
  * Encapsulated / embedded stream
@@ -84,7 +84,7 @@ class EncapsedStream extends Stream {
    * @return  bool
    */
   public function truncate($size= 0) {
-    raise('lang.MethodNotImplementedException', 'Truncation not supported');
+    throw new MethodNotImplementedException('Truncation not supported');
   }
   
   /**

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -402,7 +402,7 @@ function uses() {
 }
 // }}}
 
-// {{{ proto void raise (string classname, var* args)
+// {{{ proto deprecated void raise (string classname, var* args)
 //     throws an exception by a given class name
 function raise($classname) {
   try {

--- a/src/main/php/lang/AbstractClassLoader.class.php
+++ b/src/main/php/lang/AbstractClassLoader.class.php
@@ -93,13 +93,13 @@ abstract class AbstractClassLoader extends Object implements IClassLoader {
       // a "soft" dependency, one that is only required at runtime, was
       // not loaded, the class itself has been declared.
       if (class_exists($decl, false) || interface_exists($decl, false) || trait_exists($decl, false)) {
-        raise('lang.ClassDependencyException', $class, [$this], $e);
+        throw new ClassDependencyException($class, [$this], $e);
       }
 
       // If otherwise, a "hard" dependency could not be loaded, eg. the
       // base class or a required interface and thus the class could not
       // be declared.
-      raise('lang.ClassLinkageException', $class, [$this], $e);
+      throw new ClassLinkageException($class, [$this], $e);
     }
     \xp::$cll--;
     if (false === $r) {
@@ -136,7 +136,7 @@ abstract class AbstractClassLoader extends Object implements IClassLoader {
       \xp::$sn[$class]= $name;
     } else {
       unset(\xp::$cl[$class]);
-      raise('lang.ClassFormatException', 'Class "'.$class.'" not declared in loaded file');
+      throw new ClassFormatException('Class "'.$class.'" not declared in loaded file');
     }
 
     method_exists($name, '__static') && \xp::$cli[]= [$name, '__static'];

--- a/src/main/php/lang/ArrayType.class.php
+++ b/src/main/php/lang/ArrayType.class.php
@@ -86,12 +86,12 @@ class ArrayType extends Type {
       $self= [];
       $c= $this->componentType();
       foreach ($value as $i => $element) {
-        if (!is_int($i)) raise('lang.IllegalArgumentException', 'Cannot create instances of the '.$this->getName().' type from [:var]');
+        if (!is_int($i)) throw new IllegalArgumentException('Cannot create instances of the '.$this->getName().' type from [:var]');
         $self[]= $c->cast($element);
       }
       return $self;
     } else {
-      raise('lang.IllegalArgumentException', 'Cannot create instances of the '.$this->getName().' type from '.\xp::typeOf($value));
+      throw new IllegalArgumentException('Cannot create instances of the '.$this->getName().' type from '.\xp::typeOf($value));
     }
   }
 
@@ -108,12 +108,12 @@ class ArrayType extends Type {
     } else if (is_array($value)) {
       $c= $this->componentType();
       foreach ($value as $i => $element) {
-        if (!is_int($i)) raise('lang.ClassCastException', 'Cannot cast to the '.$this->getName().' type from [:var]');
+        if (!is_int($i)) throw new ClassCastException('Cannot cast to the '.$this->getName().' type from [:var]');
         $value[$i]= $c->cast($element);
       }
       return $value;
     } else {
-      raise('lang.ClassCastException', 'Cannot cast to the '.$this->getName().' type from '.\xp::typeOf($value));
+      throw new ClassCastException('Cannot cast to the '.$this->getName().' type from '.\xp::typeOf($value));
     }
   }
 

--- a/src/main/php/lang/ClassLoader.class.php
+++ b/src/main/php/lang/ClassLoader.class.php
@@ -100,7 +100,7 @@ final class ClassLoader extends Object implements IClassLoader {
     } else if (is_file($element)) {
       return self::registerLoader(ArchiveClassLoader::instanceFor($element), $before);
     }
-    raise('lang.ElementNotFoundException', 'Element "'.$element.'" not found');
+    throw new ElementNotFoundException('Element "'.$element.'" not found');
   }
   
   /**
@@ -138,7 +138,7 @@ final class ClassLoader extends Object implements IClassLoader {
   public static function declareModule($l) {
     $moduleInfo= $l->getResource('module.xp');
     if (!preg_match('/module ([a-z_\/\.-]+)(.*){/', $moduleInfo, $m)) {
-      raise('lang.ElementNotFoundException', 'Missing or malformed module-info in '.$l->toString());
+      throw new ElementNotFoundException('Missing or malformed module-info in '.$l->toString());
     }
 
     $decl= strtr($m[1], '.-/', '___').'Module';
@@ -543,7 +543,7 @@ final class ClassLoader extends Object implements IClassLoader {
     foreach (self::$delegates as $delegate) {
       if ($delegate->providesResource($string)) return $delegate->getResource($string);
     }
-    raise('lang.ElementNotFoundException', sprintf(
+    throw new ElementNotFoundException(sprintf(
       'No classloader provides resource "%s" {%s}',
       $string,
       \xp::stringOf(self::getLoaders())
@@ -561,7 +561,7 @@ final class ClassLoader extends Object implements IClassLoader {
     foreach (self::$delegates as $delegate) {
       if ($delegate->providesResource($string)) return $delegate->getResourceAsStream($string);
     }
-    raise('lang.ElementNotFoundException', sprintf(
+    throw new ElementNotFoundException(sprintf(
       'No classloader provides resource "%s" {%s}',
       $string,
       \xp::stringOf(self::getLoaders())

--- a/src/main/php/lang/DynamicClassLoader.class.php
+++ b/src/main/php/lang/DynamicClassLoader.class.php
@@ -143,7 +143,7 @@ class DynamicClassLoader extends AbstractClassLoader {
    * @throws  lang.ElementNotFoundException in case the resource cannot be found
    */
   public function getResource($filename) {
-    raise('lang.ElementNotFoundException', 'Could not load resource '.$filename);
+    throw new ElementNotFoundException('Could not load resource '.$filename);
   }
   
   /**
@@ -154,7 +154,7 @@ class DynamicClassLoader extends AbstractClassLoader {
    * @throws  lang.ElementNotFoundException in case the resource cannot be found
    */
   public function getResourceAsStream($filename) {
-    raise('lang.ElementNotFoundException', 'Could not load resource '.$filename);
+    throw new ElementNotFoundException('Could not load resource '.$filename);
   }
   
   /**
@@ -169,7 +169,7 @@ class DynamicClassLoader extends AbstractClassLoader {
   public function stream_open($path, $mode, $options, $opened_path) {
     sscanf($path, 'dyn://%[^$]', $this->current);
     if (!isset(self::$bytes[$this->current])) {
-      raise('lang.ElementNotFoundException', 'Could not load '.$this->current);
+      throw new ElementNotFoundException('Could not load '.$this->current);
     }
     return true;
   }

--- a/src/main/php/lang/Enum.class.php
+++ b/src/main/php/lang/Enum.class.php
@@ -98,7 +98,7 @@ abstract class Enum extends Object {
    * @throws  lang.CloneNotSupportedException
    */
   public final function __clone() {
-    raise('lang.CloneNotSupportedException', 'Enums cannot be cloned');
+    throw new CloneNotSupportedException('Enums cannot be cloned');
   }
 
   /**

--- a/src/main/php/lang/FileSystemClassLoader.class.php
+++ b/src/main/php/lang/FileSystemClassLoader.class.php
@@ -108,7 +108,7 @@ class FileSystemClassLoader extends AbstractClassLoader {
    */
   public function getResource($filename) {
     if (!is_file($fn= $this->path.strtr($filename, '/', DIRECTORY_SEPARATOR))) {
-      return raise('lang.ElementNotFoundException', 'Could not load resource '.$filename);
+      throw new ElementNotFoundException('Could not load resource '.$filename);
     }
     return file_get_contents($fn);
   }
@@ -122,7 +122,7 @@ class FileSystemClassLoader extends AbstractClassLoader {
    */
   public function getResourceAsStream($filename) {
     if (!is_file($fn= $this->path.strtr($filename, '/', DIRECTORY_SEPARATOR))) {
-      return raise('lang.ElementNotFoundException', 'Could not load resource '.$filename);
+      throw new ElementNotFoundException('Could not load resource '.$filename);
     }
     return new \io\File($fn);   // Trigger autoloading!
   }

--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -263,7 +263,7 @@ class FunctionType extends Type {
    * @return  var
    */
   public function newInstance($value= null) {
-    return $this->verified($value, function($m) use($value) { raise('lang.IllegalArgumentException', sprintf(
+    return $this->verified($value, function($m) use($value) { throw new IllegalArgumentException(sprintf(
       'Cannot create instances of the %s type from %s: %s',
       $this->getName(),
       \xp::typeOf($value),
@@ -279,7 +279,7 @@ class FunctionType extends Type {
    * @throws  lang.ClassCastException
    */
   public function cast($value) {
-    return null === $value ? null : $this->verified($value, function($m) use($value) { raise('lang.ClassCastException', sprintf(
+    return null === $value ? null : $this->verified($value, function($m) use($value) { throw new ClassCastException(sprintf(
       'Cannot cast %s to the %s type: %s',
       \xp::typeOf($value),
       $this->getName(),

--- a/src/main/php/lang/MapType.class.php
+++ b/src/main/php/lang/MapType.class.php
@@ -86,12 +86,12 @@ class MapType extends Type {
       $self= [];
       $c= $this->componentType();
       foreach ($value as $k => $element) {
-        if (is_int($k)) raise('lang.IllegalArgumentException', 'Cannot create instances of the '.$this->getName().' type from var[]');
+        if (is_int($k)) throw new IllegalArgumentException('Cannot create instances of the '.$this->getName().' type from var[]');
         $self[$k]= $c->cast($element);
       }
       return $self;
     } else {
-      raise('lang.IllegalArgumentException', 'Cannot create instances of the '.$this->getName().' type from '.\xp::typeOf($value));
+      throw new IllegalArgumentException('Cannot create instances of the '.$this->getName().' type from '.\xp::typeOf($value));
     }
   }
 
@@ -108,12 +108,12 @@ class MapType extends Type {
     } else if (is_array($value)) {
       $c= $this->componentType();
       foreach ($value as $k => $element) {
-        if (is_int($k)) raise('lang.ClassCastException', 'Cannot cast to the '.$this->getName().' type from var[]');
+        if (is_int($k)) throw new ClassCastException('Cannot cast to the '.$this->getName().' type from var[]');
         $value[$k]= $c->cast($element);
       }
       return $value;
     } else {
-      raise('lang.ClassCastException', 'Cannot cast to the '.$this->getName().' type from '.\xp::typeOf($value));
+      throw new ClassCastException('Cannot cast to the '.$this->getName().' type from '.\xp::typeOf($value));
     }
   }
 

--- a/src/main/php/lang/Primitive.class.php
+++ b/src/main/php/lang/Primitive.class.php
@@ -173,7 +173,7 @@ class Primitive extends Type {
    */
   public function newInstance($value= null) {
     return $this->coerce($value, function($value) {
-      raise('lang.IllegalArgumentException', 'Cannot create instances of '.$this->getName().' from '.\xp::typeOf($value));
+      throw new IllegalArgumentException('Cannot create instances of '.$this->getName().' from '.\xp::typeOf($value));
     });
   }
 
@@ -186,7 +186,7 @@ class Primitive extends Type {
    */
   public function cast($value) {
     return null === $value ? null : $this->coerce($value, function($value) {
-      raise('lang.ClassCastException', 'Cannot cast to '.$this->getName().' from '.\xp::typeOf($value));
+      throw new ClassCastException('Cannot cast to '.$this->getName().' from '.\xp::typeOf($value));
     });
   }
 

--- a/src/main/php/lang/ResourceProvider.class.php
+++ b/src/main/php/lang/ResourceProvider.class.php
@@ -91,7 +91,7 @@ class ResourceProvider extends Object {
    * @return  int
    */
   public function stream_write($data) {
-    raise('lang.MethodNotImplementedException', 'Not writeable.', __METHOD__);
+    throw new MethodNotImplementedException('Not writeable.', __METHOD__);
   }
   
   /**

--- a/src/main/php/lang/Runtime.class.php
+++ b/src/main/php/lang/Runtime.class.php
@@ -135,7 +135,7 @@ class Runtime extends Object {
    * @param   string message default NULL
    */
   public static function halt($code= 0, $message= null) {
-    raise('lang.SystemExit', $code, $message);
+    throw new SystemExit($code, $message);
   }
 
   /**

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -226,7 +226,7 @@ class Type extends Object {
    */
   public function cast($value) {
     if (self::$VAR === $this) return $value;
-    raise('lang.ClassCastException', 'Cannot cast '.\xp::typeOf($value).' to the void type');
+    throw new ClassCastException('Cannot cast '.\xp::typeOf($value).' to the void type');
   }
 
   /**

--- a/src/main/php/lang/WildcardType.class.php
+++ b/src/main/php/lang/WildcardType.class.php
@@ -129,7 +129,7 @@ class WildcardType extends Type {
     if ($value instanceof Generic && $this->assignableFromClass($value->getClass())) {
       return $value;
     }
-    raise('lang.ClassCastException', 'Cannot cast '.\xp::typeOf($value).' to the '.$this->getName().' type');
+    throw new ClassCastException('Cannot cast '.\xp::typeOf($value).' to the '.$this->getName().' type');
   }
 
   /**

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -4,6 +4,7 @@ use lang\reflect\Method;
 use lang\reflect\Field;
 use lang\reflect\Constructor;
 use lang\reflect\Package;
+use lang\ElementNotFoundException;
 
 define('DETAIL_ARGUMENTS',      1);
 define('DETAIL_RETURNS',        2);
@@ -189,7 +190,7 @@ class XPClass extends Type {
     if ($this->hasMethod($name)) {
       return new Method($this->_class, $this->_reflect->getMethod($name));
     }
-    raise('lang.ElementNotFoundException', 'No such method "'.$name.'" in class '.$this->name);
+    throw new ElementNotFoundException('No such method "'.$name.'" in class '.$this->name);
   }
   
   /**
@@ -230,7 +231,7 @@ class XPClass extends Type {
     if ($this->hasConstructor()) {
       return new Constructor($this->_class, $this->_reflect->getMethod('__construct')); 
     }
-    raise('lang.ElementNotFoundException', 'No constructor in class '.$this->name);
+    throw new ElementNotFoundException('No constructor in class '.$this->name);
   }
   
   /**
@@ -279,7 +280,7 @@ class XPClass extends Type {
     if ($this->hasField($name)) {
       return new Field($this->_class, $this->_reflect->getProperty($name));
     }
-    raise('lang.ElementNotFoundException', 'No such field "'.$name.'" in class '.$this->name);
+    throw new ElementNotFoundException('No such field "'.$name.'" in class '.$this->name);
   }
   
   /**
@@ -323,8 +324,7 @@ class XPClass extends Type {
     if ($this->hasConstant($constant)) {
       return $this->_reflect->getConstant($constant);
     }
-    
-    raise('lang.ElementNotFoundException', 'No such constant "'.$constant.'" in class '.$this->name);
+    throw new ElementNotFoundException('No such constant "'.$constant.'" in class '.$this->name);
   }
 
   /**
@@ -349,7 +349,7 @@ class XPClass extends Type {
     } else if (is($this->name, $value)) {
       return $value;
     }
-    raise('lang.ClassCastException', 'Cannot cast '.\xp::typeOf($value).' to '.$this->name);
+    throw new ClassCastException('Cannot cast '.\xp::typeOf($value).' to '.$this->name);
   }
   
   /**
@@ -554,10 +554,9 @@ class XPClass extends Type {
     if (!$details || !($key 
       ? @array_key_exists($key, @$details['class'][DETAIL_ANNOTATIONS][$name]) 
       : @array_key_exists($name, @$details['class'][DETAIL_ANNOTATIONS])
-    )) return raise(
-      'lang.ElementNotFoundException', 
-      'Annotation "'.$name.($key ? '.'.$key : '').'" does not exist'
-    );
+    )) {
+      throw new ElementNotFoundException('Annotation "'.$name.($key ? '.'.$key : '').'" does not exist');
+    }
 
     return ($key 
       ? $details['class'][DETAIL_ANNOTATIONS][$name][$key] 

--- a/src/main/php/lang/archive/ArchiveClassLoader.class.php
+++ b/src/main/php/lang/archive/ArchiveClassLoader.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\archive;
 
 use lang\AbstractClassLoader;
-
+use lang\ElementNotFoundException;
 
 /** 
  * Loads XP classes from a XAR (XP Archive)
@@ -111,7 +111,7 @@ class ArchiveClassLoader extends AbstractClassLoader {
   public function getResource($string) {
     if (false !== ($r= file_get_contents($this->archive.$string))) return $r;
     \xp::gc(__FILE__);
-    raise('lang.ElementNotFoundException', 'Could not load resource '.$string);
+    throw new ElementNotFoundException('Could not load resource '.$string);
   }
   
   /**
@@ -123,7 +123,7 @@ class ArchiveClassLoader extends AbstractClassLoader {
    */
   public function getResourceAsStream($string) {
     if (!file_exists($fn= $this->archive.$string)) {
-      return raise('lang.ElementNotFoundException', 'Could not load resource '.$string);
+      throw new ElementNotFoundException('Could not load resource '.$string);
     }
     return new \io\File($fn);
   }

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -3,6 +3,8 @@
 use lang\XPClass;
 use lang\IllegalStateException;
 use lang\IllegalAccessException;
+use lang\ElementNotFoundException;
+use lang\ClassFormatException;
 
 /**
  * Parses classes for class meta information (apidoc, return and 
@@ -111,7 +113,7 @@ class ClassParser extends \lang\Object {
         } else if ('(' === $tokens[$i]) {
           // Skip
         } else if (',' === $tokens[$i]) {
-          $element || raise('lang.IllegalStateException', 'Parse error: Malformed array - no value before comma');
+          if (!$element) throw new IllegalStateException('Parse error: Malformed array - no value before comma');
           $value[$key]= $element[0];
           $element= null;
           $key= sizeof($value);
@@ -121,7 +123,7 @@ class ClassParser extends \lang\Object {
         } else if (T_WHITESPACE === $tokens[$i][0]) {
           continue;
         } else {
-          $element && raise('lang.IllegalStateException', 'Parse error: Malformed array - missing comma');
+          if ($element) throw new IllegalStateException('Parse error: Malformed array - missing comma');
           $element= [$this->valueOf($tokens, $i, $context, $imports)];
         }
       }
@@ -141,7 +143,7 @@ class ClassParser extends \lang\Object {
       } else if (defined($tokens[$i][1])) {
         return constant($tokens[$i][1]);
       } else {
-        raise('lang.ElementNotFoundException', 'Undefined constant "'.$tokens[$i][1].'"');
+        throw new ElementNotFoundException('Undefined constant "'.$tokens[$i][1].'"');
       }
     } else if (T_NEW === $tokens[$i][0]) {
       $type= '';
@@ -283,9 +285,9 @@ class ClassParser extends \lang\Object {
         }
       }
     } catch (\lang\XPException $e) {
-      raise('lang.ClassFormatException', $e->getMessage().' in '.$place, $e);
+      throw new ClassFormatException($e->getMessage().' in '.$place, $e);
     }
-    raise('lang.ClassFormatException', 'Parse error: Unterminated '.$states[$state].' in '.$place);
+    throw new ClassFormatException('Parse error: Unterminated '.$states[$state].' in '.$place);
   }
 
   /**

--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -105,10 +105,9 @@ class Field extends \lang\Object {
     if (!$details || !($key 
       ? array_key_exists($key, @$details[DETAIL_ANNOTATIONS][$name]) 
       : array_key_exists($name, @$details[DETAIL_ANNOTATIONS])
-    )) return raise(
-      'lang.ElementNotFoundException', 
-      'Annotation "'.$name.($key ? '.'.$key : '').'" does not exist'
-    );
+    )) {
+      throw new ElementNotFoundException('Annotation "'.$name.($key ? '.'.$key : '').'" does not exist');
+    }
 
     return ($key 
       ? $details[DETAIL_ANNOTATIONS][$name][$key] 

--- a/src/main/php/lang/reflect/Module.class.php
+++ b/src/main/php/lang/reflect/Module.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\reflect;
 
 use lang\IClassLoader;
+use lang\ElementNotFoundException;
 
 /**
  * Represents a module
@@ -101,7 +102,7 @@ class Module extends \lang\Object {
    */
   public static function forName($name) {
     if (!isset(self::$registered[$name])) {
-      raise('lang.ElementNotFoundException', 'No module "'.$name.'" declared');
+      throw new ElementNotFoundException('No module "'.$name.'" declared');
     }
     return self::$registered[$name];
   }

--- a/src/main/php/lang/reflect/Package.class.php
+++ b/src/main/php/lang/reflect/Package.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\reflect;
 
+use lang\ElementNotFoundException;
+
 /**
  * Represents a package
  *
@@ -172,7 +174,7 @@ class Package extends \lang\Object {
     $p->name= rtrim($name, '.');   // Normalize
 
     if (!\lang\ClassLoader::getDefault()->providesPackage($p->name)) {
-      raise('lang.ElementNotFoundException', 'No classloaders provide '.$name);
+      throw new ElementNotFoundException('No classloaders provide '.$name);
     }
     return $p;
   }

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\reflect;
 
+use lang\ElementNotFoundException;
+
 /**
  * Represents a method's parameter
  *
@@ -167,11 +169,10 @@ class Parameter extends \lang\Object {
       !isset($details[DETAIL_TARGET_ANNO][$n]) || !($key 
         ? array_key_exists($key, (array)@$details[DETAIL_TARGET_ANNO][$n][$name]) 
         : array_key_exists($name, (array)@$details[DETAIL_TARGET_ANNO][$n])
-      ) 
-    ) return raise(
-      'lang.ElementNotFoundException', 
-      'Annotation "'.$name.($key ? '.'.$key : '').'" does not exist'
-    );
+      )
+    ) {
+      throw new ElementNotFoundException('Annotation "'.$name.($key ? '.'.$key : '').'" does not exist');
+    }
 
     return ($key 
       ? $details[DETAIL_TARGET_ANNO][$n][$name][$key] 

--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\reflect;
 
+use lang\ElementNotFoundException;
+
 /**
  * Base class for methods and constructors. Note that the methods provided
  * in this class (except for getName()) are implemented using a tokenizer
@@ -213,10 +215,9 @@ class Routine extends \lang\Object {
     if (!$details || !($key 
       ? array_key_exists($key, @$details[DETAIL_ANNOTATIONS][$name]) 
       : array_key_exists($name, @$details[DETAIL_ANNOTATIONS])
-    )) return raise(
-      'lang.ElementNotFoundException', 
-      'Annotation "'.$name.($key ? '.'.$key : '').'" does not exist'
-    );
+    )) {
+      throw new ElementNotFoundException('Annotation "'.$name.($key ? '.'.$key : '').'" does not exist');
+    }
 
     return ($key 
       ? $details[DETAIL_ANNOTATIONS][$name][$key] 

--- a/src/main/php/lang/types/ArrayList.class.php
+++ b/src/main/php/lang/types/ArrayList.class.php
@@ -1,5 +1,8 @@
 <?php namespace lang\types;
 
+use lang\IndexOutOfBoundsException;
+use lang\IllegalArgumentException;
+
 /**
  * Represents a "numeric" array
  *
@@ -67,7 +70,7 @@ class ArrayList extends \lang\Object implements \ArrayAccess, \IteratorAggregate
    */
   public function offsetGet($offset) {
     if ($offset >= $this->length || $offset < 0) {
-      raise('lang.IndexOutOfBoundsException', 'Offset '.$offset.' out of bounds');
+      throw new IndexOutOfBoundsException('Offset '.$offset.' out of bounds');
     }
     return $this->values[$offset];
   }
@@ -81,11 +84,11 @@ class ArrayList extends \lang\Object implements \ArrayAccess, \IteratorAggregate
    */
   public function offsetSet($offset, $value) {
     if (!is_int($offset)) {
-      throw new \lang\IllegalArgumentException('Incorrect type '.gettype($offset).' for index');
+      throw new IllegalArgumentException('Incorrect type '.gettype($offset).' for index');
     }
     
     if ($offset >= $this->length || $offset < 0) {
-      raise('lang.IndexOutOfBoundsException', 'Offset '.$offset.' out of bounds');
+      throw new IndexOutOfBoundsException('Offset '.$offset.' out of bounds');
     }
     $this->values[$offset]= $value;
   }
@@ -106,7 +109,7 @@ class ArrayList extends \lang\Object implements \ArrayAccess, \IteratorAggregate
    * @param   int offset
    */
   public function offsetUnset($offset) {
-    throw new \lang\IllegalArgumentException('Cannot remove from immutable list');
+    throw new IllegalArgumentException('Cannot remove from immutable list');
   }
 
   /**

--- a/src/main/php/lang/types/ArrayMap.class.php
+++ b/src/main/php/lang/types/ArrayMap.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\types;
 
+use lang\IndexOutOfBoundsException;
+
 /**
  * Represents a mapped array
  *
@@ -48,7 +50,7 @@ class ArrayMap extends \lang\Object implements \ArrayAccess, \IteratorAggregate 
    */
   public function offsetGet($key) {
     if (!isset($this->values[$key])) {
-      raise('lang.IndexOutOfBoundsException', 'No element for key "'.$key.'"');
+      throw new IndexOutOfBoundsException('No element for key "'.$key.'"');
     }
     return $this->values[$key];
   }

--- a/src/main/php/lang/types/Bytes.class.php
+++ b/src/main/php/lang/types/Bytes.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\types;
 
+use lang\IndexOutOfBoundsException;
+
 /**
  * Represents a list of bytes
  *
@@ -74,7 +76,7 @@ class Bytes extends \lang\Object implements \ArrayAccess, \IteratorAggregate {
    */
   public function offsetGet($offset) {
     if ($offset >= $this->size || $offset < 0) {
-      raise('lang.IndexOutOfBoundsException', 'Offset '.$offset.' out of bounds');
+      throw new IndexOutOfBoundsException('Offset '.$offset.' out of bounds');
     }
     $n= ord($this->buffer{$offset});
     return new Byte($n < 128 ? $n : $n - 256);
@@ -93,7 +95,7 @@ class Bytes extends \lang\Object implements \ArrayAccess, \IteratorAggregate {
       $this->buffer.= $this->asByte($value);
       $this->size++;
     } else if ($offset >= $this->size || $offset < 0) {
-      raise('lang.IndexOutOfBoundsException', 'Offset '.$offset.' out of bounds');
+      throw new IndexOutOfBoundsException('Offset '.$offset.' out of bounds');
     } else {
       $this->buffer{$offset}= $this->asByte($value);
     }
@@ -117,7 +119,7 @@ class Bytes extends \lang\Object implements \ArrayAccess, \IteratorAggregate {
    */
   public function offsetUnset($offset) {
     if ($offset >= $this->size || $offset < 0) {
-      raise('lang.IndexOutOfBoundsException', 'Offset '.$offset.' out of bounds');
+      throw new IndexOutOfBoundsException('Offset '.$offset.' out of bounds');
     }
     $this->buffer= (
       substr($this->buffer, 0, $offset).

--- a/src/main/php/lang/types/Number.class.php
+++ b/src/main/php/lang/types/Number.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\types;
 
+use lang\MethodNotImplementedException;
+
 /**
  * The abstract class Number is the superclass of classes representing
  * numbers
@@ -30,7 +32,7 @@ abstract class Number extends \lang\Object {
    * @throws  lang.IllegalArgumentException
    */
   public static function valueOf($value) {
-    raise('lang.MethodNotImplementedException', 'Abstract base class', __METHOD__);
+    throw new MethodNotImplementedException('Abstract base class', __METHOD__);
   }
 
   /**

--- a/src/main/php/lang/types/String.class.php
+++ b/src/main/php/lang/types/String.class.php
@@ -1,5 +1,8 @@
 <?php namespace lang\types;
 
+use lang\IndexOutOfBoundsException;
+use lang\IllegalArgumentException;
+
 if (extension_loaded('mbstring')) {
   mb_internal_encoding(\xp::ENCODING);
   class __str {
@@ -101,12 +104,12 @@ class String extends \lang\Object implements \ArrayAccess {
     }
     
     if ($offset >= $this->length || $offset < 0) {
-      raise('lang.IndexOutOfBoundsException', 'Offset '.$offset.' out of bounds');
+      throw new IndexOutOfBoundsException('Offset '.$offset.' out of bounds');
     }
     
     $char= $this->asIntern($value);
     if (1 != __str::len($char)) {
-      throw new \lang\IllegalArgumentException('Set only allows to set one character!');
+      throw new IllegalArgumentException('Set only allows to set one character!');
     }
     
     $this->buffer= (
@@ -133,7 +136,7 @@ class String extends \lang\Object implements \ArrayAccess {
    */
   public function offsetUnset($offset) {
     if ($offset >= $this->length || $offset < 0) {
-      raise('lang.IndexOutOfBoundsException', 'Offset '.$offset.' out of bounds');
+      throw new IndexOutOfBoundsException('Offset '.$offset.' out of bounds');
     }
     $this->buffer= (
       __str::substr($this->buffer, 0, $offset).
@@ -161,7 +164,7 @@ class String extends \lang\Object implements \ArrayAccess {
    */
   public function charAt($offset) {
     if ($offset >= $this->length || $offset < 0) {
-      raise('lang.IndexOutOfBoundsException', 'Offset '.$offset.' out of bounds');
+      throw new IndexOutOfBoundsException('Offset '.$offset.' out of bounds');
     }
     return new Character(__str::substr($this->buffer, $offset, 1), \xp::ENCODING);
   }

--- a/src/main/php/util/PropertyExpansion.class.php
+++ b/src/main/php/util/PropertyExpansion.class.php
@@ -1,5 +1,7 @@
 <?php namespace util;
 
+use lang\ElementNotFoundException;
+
 /**
  * Expands variables inside property files.
  *
@@ -15,7 +17,7 @@ class PropertyExpansion extends \lang\Enum {
     $this->impl['env']= function($name, $default= null) {
       if (false === ($value= getenv($name))) {
         if (null === ($value= $default)) {
-          raise("lang.ElementNotFoundException", "Environment variable ".$name." doesn\'t exist");
+          throw new ElementNotFoundException('Environment variable "'.$name.'" doesn\'t exist');
         }
       }
       return $value;

--- a/src/main/php/util/PropertyManager.class.php
+++ b/src/main/php/util/PropertyManager.class.php
@@ -1,5 +1,7 @@
 <?php namespace util;
 
+use lang\ElementNotFoundException;
+
 /**
  * Property-Manager
  * 
@@ -162,7 +164,7 @@ class PropertyManager extends \lang\Object {
 
     switch (sizeof($found)) {
       case 1: return $found[0];
-      case 0: raise('lang.ElementNotFoundException', sprintf(
+      case 0: throw new ElementNotFoundException(sprintf(
         'Cannot find properties "%s" in any of %s',
         $name,
         \xp::stringOf(array_values($this->provider))

--- a/src/main/php/xp/install/Installation.class.php
+++ b/src/main/php/xp/install/Installation.class.php
@@ -1,6 +1,7 @@
 <?php namespace xp\install;
 
 use io\Folder;
+use lang\ElementNotFoundException;
 
 /**
  * Installation
@@ -39,7 +40,7 @@ class Installation extends \lang\Object {
     foreach ($this->cl as $loader) {
       if ($loader->providesResource($name)) return $loader->getResource($name);
     }
-    raise('lang.ElementNotFoundException', $name);
+    throw new ElementNotFoundException($name);
   }
   
   /**

--- a/src/main/php/xp/runtime/Reflect.class.php
+++ b/src/main/php/xp/runtime/Reflect.class.php
@@ -5,6 +5,7 @@ use io\File;
 use io\Folder;
 use lang\XPClass;
 use lang\reflect\Modifiers;
+use lang\ElementNotFoundException;
 
 /**
  * Dumps reflection information about a class
@@ -274,7 +275,7 @@ class Reflect extends \lang\Object {
         return $package;
       }
     }
-    raise('lang.ElementNotFoundException', 'Cannot derive package name from '.$q);
+    throw new ElementNotFoundException('Cannot derive package name from '.$q);
   }
 
   /**

--- a/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
@@ -112,27 +112,6 @@ class ExceptionsTest extends TestCase {
     $this->assertEquals($e->toString(), $out->getBytes());
   }
   
-  #[@test]
-  public function raiseWithOneArgument() {
-    try {
-      raise('lang.IllegalArgumentException', 'This is the message');
-      $this->fail('Exception has not been thrown', NULL, NULL);
-    } catch (\lang\IllegalArgumentException $e) {
-      $this->assertEquals('This is the message', $e->getMessage());
-    }
-  }
-  
-  #[@test]
-  public function raiseWithMoreArguments() {
-    try {
-      raise('lang.MethodNotImplementedException', 'This is the message', __FUNCTION__);
-      $this->fail('Exception has not been thrown', NULL, NULL);
-    } catch (\lang\MethodNotImplementedException $e) {
-      $this->assertEquals('This is the message', $e->getMessage());
-      $this->assertEquals(__FUNCTION__, $e->method);
-    }
-  }
-
   #[@test, @expect('lang.IllegalArgumentException')]
   public function withCause_must_be_a_throwable() {
     new \lang\XPException('Message', 'Anything...');

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassFromUriTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassFromUriTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use unittest\TestCase;
-
+use lang\MethodNotImplementedException;
 
 /**
  * TestCase for resolving classes from URIs using the `loadUri()` method.
@@ -18,7 +18,7 @@ abstract class ClassFromUriTest extends TestCase {
    * @return  net.xp_framework.unittest.reflection.ClassFromUriBase
    */
   protected static function baseImpl() {
-    raise('lang.MethodNotImplementedException', 'Implement in subclass!', __FUNCTION__);
+    throw new MethodNotImplementedException('Implement in subclass!', __FUNCTION__);
   }
 
   /**

--- a/src/test/php/net/xp_framework/unittest/reflection/LoaderProviding.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/LoaderProviding.class.php
@@ -3,6 +3,7 @@
 use lang\IClassLoader;
 use lang\Object;
 use lang\ElementNotFoundException;
+use lang\MethodNotImplementedException;
 
 /**
  * A class loader dummy providing elements supplied to its constructor.
@@ -53,6 +54,6 @@ class LoaderProviding extends Object implements IClassLoader {
 
   /** @return io.Stream */
   public function getResourceAsStream($name) {
-    raise('lang.MethodNotImplementedException', __METHOD__);
+    throw new MethodNotImplementedException(__METHOD__);
   }
 }


### PR DESCRIPTION
This pull request deprecates the `raise()` core functionality and rewrites all occurrences to use the `throw` statement.

See https://github.com/xp-framework/rfc/issues/298