### PR TITLE
Deprecate null

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -237,7 +237,7 @@ final class xp {
   }
   // }}}
 
-  // {{{ proto <null> null()
+  // {{{ proto deprecated <null> null()
   //     Runs a fatal-error safe version of null
   static function null() {
     return xp::$null;
@@ -285,7 +285,7 @@ final class xp {
 }
 // }}}
 
-// {{{ final class null
+// {{{ final deprecated class null
 final class null {
 
   // {{{ proto __construct(void)

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -703,7 +703,7 @@ set_include_path(rtrim(implode(PATH_SEPARATOR, xp::$classpath), PATH_SEPARATOR))
 spl_autoload_register(function($class) {
   $name= strtr($class, '\\', '.');
   $cl= xp::$loader->findClass($name);
-  if ($cl instanceof null) return false;
+  if (null === $cl) return false;
   $cl->loadClass0($name);
   return true;
 });

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -423,17 +423,18 @@ function ensure(&$t) {
 }
 // }}}
 
-// {{{ proto Generic cast (Generic expression, string type)
-//     Casts an expression.
-function cast(Generic $expression= null, $type) {
-  if (null === $expression) {
-    return xp::null();
-  } else if (\lang\XPClass::forName($type)->isInstance($expression)) {
-    return $expression;
+// {{{ proto Generic cast (var expression, var type[, bool nullsafe= true])
+//     Casts an expression NULL-safe
+function cast($expression, $type, $nullsafe= true) {
+  if (null === $expression && $nullsafe) {
+    raise('lang.ClassCastException', 'Cannot cast NULL to '.$type);
+  } else if ($type instanceof \lang\Type) {
+    return $type->cast($expression);
+  } else {
+    return Type::forName($type)->cast($expression);
   }
-
-  raise('lang.ClassCastException', 'Cannot cast '.xp::typeOf($expression).' to '.$type);
 }
+// }}}
 
 // {{{ proto bool is(string type, var object)
 //     Checks whether a given object is an instance of the type given

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -423,15 +423,15 @@ function ensure(&$t) {
 }
 // }}}
 
-// {{{ proto Generic cast (var expression, var type[, bool nullsafe= true])
-//     Casts an expression NULL-safe
-function cast($expression, $type, $nullsafe= true) {
-  if (null === $expression && $nullsafe) {
+// {{{ proto Generic cast (var arg, var type[, bool nullsafe= true])
+//     Casts an arg NULL-safe
+function cast($arg, $type, $nullsafe= true) {
+  if (null === $arg && $nullsafe) {
     raise('lang.ClassCastException', 'Cannot cast NULL to '.$type);
   } else if ($type instanceof \lang\Type) {
-    return $type->cast($expression);
+    return $type->cast($arg);
   } else {
-    return Type::forName($type)->cast($expression);
+    return Type::forName($type)->cast($arg);
   }
 }
 // }}}

--- a/src/main/php/lang/ClassLoader.class.php
+++ b/src/main/php/lang/ClassLoader.class.php
@@ -479,7 +479,7 @@ final class ClassLoader extends Object implements IClassLoader {
     foreach (self::$delegates as $delegate) {
       if ($delegate->providesClass($class)) return $delegate;
     }
-    return \xp::null();
+    return null;
   }
 
   /**
@@ -492,7 +492,7 @@ final class ClassLoader extends Object implements IClassLoader {
     foreach (self::$delegates as $delegate) {
       if ($delegate->providesUri($uri)) return $delegate;
     }
-    return \xp::null();
+    return null;
   }
 
   /**
@@ -505,7 +505,7 @@ final class ClassLoader extends Object implements IClassLoader {
     foreach (self::$delegates as $delegate) {
       if ($delegate->providesPackage($package)) return $delegate;
     }
-    return \xp::null();
+    return null;
   }    
   
   /**
@@ -529,7 +529,7 @@ final class ClassLoader extends Object implements IClassLoader {
     foreach (self::$delegates as $delegate) {
       if ($delegate->providesResource($name)) return $delegate;
     }
-    return \xp::null();
+    return null;
   }    
 
   /**

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -209,9 +209,7 @@ class Process extends Object {
       }
     }
 
-    $self->in= \xp::null();
-    $self->out= \xp::null();
-    $self->err= \xp::null();
+    $self->in= $self->out= $self->err= null;
     return $self;
   }
   

--- a/src/main/php/lang/Wildcard.class.php
+++ b/src/main/php/lang/Wildcard.class.php
@@ -11,7 +11,7 @@ class Wildcard extends Type {
   public static $ANY;
 
   static function __static() {
-    self::$ANY= new self('?', \xp::null());
+    self::$ANY= new self('?', null);
   }
 
   /**

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -344,12 +344,14 @@ class XPClass extends Type {
    * @throws  lang.ClassCastException
    */
   public function cast($value) {
-    if (null === $value) {
-      return \xp::null();
-    } else if (is($this->name, $value)) {
+    if (null === $value) return null;
+
+    $literal= literal($this->name);
+    if ($value instanceof $literal) {
       return $value;
+    } else {
+      throw new ClassCastException('Cannot cast '.\xp::typeOf($value).' to '.$this->name);
     }
-    throw new ClassCastException('Cannot cast '.\xp::typeOf($value).' to '.$this->name);
   }
   
   /**

--- a/src/main/php/unittest/TestResult.class.php
+++ b/src/main/php/unittest/TestResult.class.php
@@ -73,10 +73,10 @@ class TestResult extends \lang\Object {
    */
   public function outcomeOf(TestCase $test) {
     $key= $test->hashCode();
-    foreach (array($this->succeeded, $this->failed, $this->skipped) as $lookup) {
+    foreach ([$this->succeeded, $this->failed, $this->skipped] as $lookup) {
       if (isset($lookup[$key])) return $lookup[$key];
     }
-    return \xp::null();
+    return null;
   }
 
   /**

--- a/src/main/php/unittest/web/WebTestCase.class.php
+++ b/src/main/php/unittest/web/WebTestCase.class.php
@@ -140,7 +140,7 @@ abstract class WebTestCase extends TestCase {
         $this->cookies[$this->conn->getUrl()->getHost()][$cookie->getName()]= $cookie;
       }
     } catch (\lang\XPException $e) {
-      $this->response= \xp::null();
+      $this->response= null;
       $this->fail($relative, $e, null);
     }
   }

--- a/src/main/php/util/CompositeProperties.class.php
+++ b/src/main/php/util/CompositeProperties.class.php
@@ -9,8 +9,16 @@ use lang\IllegalArgumentException;
  * @test   xp://net.xp_framework.unittest.util.CompositePropertiesTest
  */
 class CompositeProperties extends \lang\Object implements PropertyAccess {
+  private static $NONEXISTANT;
   protected $props  = [];
   private $sections = null;
+
+  static function __static() {
+
+    // This is never returned from any read*() method and can help us
+    // distinguish whether we read a value or not.
+    self::$NONEXISTANT= function() { };
+  }
 
   /**
    * Constructor
@@ -33,8 +41,7 @@ class CompositeProperties extends \lang\Object implements PropertyAccess {
    */
   public function add(PropertyAccess $a) {
     foreach ($this->props as $p) {
-      if ($p === $a) return;
-      if ($p->equals($a)) return;
+      if ($p === $a || $p->equals($a)) return;
     }
 
     $this->props[]= $a;
@@ -61,8 +68,8 @@ class CompositeProperties extends \lang\Object implements PropertyAccess {
    */
   private function _read($method, $section, $key, $default) {
     foreach ($this->props as $p) {
-      $value= call_user_func([$p, $method], $section, $key, \xp::null());
-      if (\xp::null() !== $value) return $value;
+      $value= $p->{$method}($section, $key, self::$NONEXISTANT);
+      if (self::$NONEXISTANT !== $value) return $value;
     }
 
     return $default;

--- a/src/main/php/util/Filters.class.php
+++ b/src/main/php/util/Filters.class.php
@@ -1,6 +1,7 @@
 <?php namespace util;
 
 use lang\IllegalArgumentException;
+use lang\IllegalStateException;
 
 /**
  * Instances of this class act on a list of given filters, accepting
@@ -51,10 +52,10 @@ class Filters extends \lang\Object implements Filter {
    * @throws  lang.IllegalArgumentException if accept is neither a closure nor NULL
    */
   #[@generic(params= 'util.Filter<T>[]')]
-  public function __construct(array $list= array(), $accept= null) {
+  public function __construct(array $list= [], $accept= null) {
     $this->list= $list;
     if (null === $accept) {
-      $this->accept= \xp::null();
+      $this->accept= function($list, $e) { throw new IllegalStateException('No accepting closure set'); };
     } else if ($accept instanceof \Closure) {
       $this->accept= $accept;
     } else {

--- a/src/main/php/util/cmd/Console.class.php
+++ b/src/main/php/util/cmd/Console.class.php
@@ -48,7 +48,23 @@ class Console extends \lang\Object {
       self::$out= new StringWriter(new ConsoleOutputStream(STDOUT));
       self::$err= new StringWriter(new ConsoleOutputStream(STDERR));
     } else {
-      self::$in= self::$out= self::$err= \xp::null();
+      self::$in= newinstance('io.streams.InputStreamReader', [null], '{
+        public function __construct($in) { }
+        public function getStream() { return null; }
+        public function raise() { throw new \lang\IllegalStateException("There is no console present"); }
+        public function read($count= 8192) { $this->raise(); }
+        public function readLine() { $this->raise(); }
+      }');
+      self::$out= self::$err= newinstance('io.streams.OutputStreamWriter', [null], '{
+        public function __construct($out) { }
+        public function getStream() { return null; }
+        public function flush() { $this->raise(); }
+        public function raise() { throw new \lang\IllegalStateException("There is no console present"); }
+        public function write() { $this->raise(); }
+        public function writeLine() { $this->raise(); }
+        public function writef() { $this->raise(); }
+        public function writeLinef() { $this->raise(); }
+      }');
     }
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
@@ -18,19 +18,34 @@ class CastingTest extends TestCase implements Runnable {
 
   #[@test]
   public function newinstance() {
-    $runnable= newinstance('lang.Runnable', [], array(
+    $runnable= newinstance('lang.Runnable', [], [
       'run' => function() { return 'Test'; }
-    ));
+    ]);
     $this->assertEquals('Test', cast($runnable, 'lang.Runnable')->run());
   }
 
-  #[@test]
+  #[@test, @expect('lang.ClassCastException')]
   public function null() {
-    $this->assertEquals(\xp::null(), cast(NULL, 'lang.Object'));
+    cast(null, 'lang.Object');
+  }
+
+  #[@test, @expect('lang.ClassCastException')]
+  public function is_nullsafe_per_default() {
+    cast(null, 'lang.Runnable')->run();
+  }
+
+  #[@test]
+  public function passig_null_allowed_when_nullsafe_set_to_false() {
+    $this->assertNull(cast(null, 'lang.Object', false));
   }
 
   #[@test]
   public function thisClass() {
+    $this->assertTrue($this === cast($this, $this->getClass()));
+  }
+
+  #[@test]
+  public function thisClassName() {
     $this->assertTrue($this === cast($this, $this->getClassName()));
   }
 
@@ -64,17 +79,12 @@ class CastingTest extends TestCase implements Runnable {
     cast(new \lang\Object(), 'lang.types.String');
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect('lang.IllegalStateException')]
   public function nonExistant() {
     cast($this, '@@NON_EXISTANT_CLASS@@');
   }
 
-  #[@test, @expect('lang.NullPointerException')]
-  public function npe() {
-    cast(NULL, 'lang.Runnable')->run();
-  }
-
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect('lang.ClassCastException')]
   public function primitive() {
     cast('primitive', 'lang.Object');
   }

--- a/src/test/php/net/xp_framework/unittest/core/CloningTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CloningTest.class.php
@@ -10,6 +10,7 @@ use lang\CloneNotSupportedException;
  */
 class CloningTest extends TestCase {
 
+  /** @deprecated */
   #[@test, @expect('lang.NullPointerException')]
   public function cloningOfNulls() {
     clone(\xp::null());

--- a/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
@@ -9,10 +9,10 @@ use util\collections\Vector;
  */
 class IsTest extends \unittest\TestCase {
 
+  /** @deprecated */
   #[@test]
   public function xpNullIsNull() {
     $this->assertTrue(is(NULL, \xp::null()));
-    $this->assertFalse(is(NULL, 1));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/core/NullTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NullTest.class.php
@@ -2,6 +2,8 @@
 
 /**
  * Tests the "NULL-safe" xp::null.
+ *
+ * @deprecated
  */
 class NullTest extends \unittest\TestCase {
 

--- a/src/test/php/net/xp_framework/unittest/core/RuntimeInstantiationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/RuntimeInstantiationTest.class.php
@@ -180,7 +180,7 @@ class RuntimeInstantiationTest extends \unittest\TestCase {
       }"));
 
       echo "+OK exiting";
-      xp::null()->error();
+      throw new \lang\Error("Uncaught");
     ', 255);
     $this->assertEquals('+OK exiting', substr($out, 0, 11), $out);
     $this->assertEquals('+OK Shutdown hook run', substr($out, -21), $out);

--- a/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
@@ -31,6 +31,7 @@ class StringOfTest extends \unittest\TestCase {
     $this->assertEquals($expected, \xp::stringOf($value));
   }
 
+  /** @deprecated */
   #[@test]
   public function xpnull_representation() {
     $this->assertEquals('<null>', \xp::stringOf(\xp::null()));

--- a/src/test/php/net/xp_framework/unittest/core/XpTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/XpTest.class.php
@@ -47,6 +47,7 @@ class XpTest extends \unittest\TestCase {
     $this->assertEquals([], \xp::$errors);
   }
 
+  /** @deprecated */
   #[@test]
   public function null() {
     $this->assertEquals('null', get_class(\xp::null()));

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassCastingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassCastingTest.class.php
@@ -39,7 +39,7 @@ class ClassCastingTest extends TestCase {
 
   #[@test]
   public function thisClassCastingNull() {
-    $this->assertEquals(\xp::null(), $this->getClass()->cast(null));
+    $this->assertNull($this->getClass()->cast(null));
   }
 
   #[@test, @expect('lang.ClassCastException')]

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
@@ -116,7 +116,7 @@ class ClassLoaderTest extends \unittest\TestCase {
 
   #[@test]
   public function findNullClass() {
-    $this->assertEquals(\xp::null(), ClassLoader::getDefault()->findClass(null));
+    $this->assertNull(ClassLoader::getDefault()->findClass(null));
   }
 
   #[@test]
@@ -234,10 +234,7 @@ class ClassLoaderTest extends \unittest\TestCase {
 
   #[@test]
   public function cannotFindNontExistantUri() {
-    $this->assertEquals(
-      \xp::null(),
-      ClassLoader::getDefault()->findUri('non/existant/Class.class.php')
-    );
+    $this->assertNull(ClassLoader::getDefault()->findUri('non/existant/Class.class.php'));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/tests/AssertionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/tests/AssertionsTest.class.php
@@ -168,6 +168,7 @@ class AssertionsTest extends \unittest\TestCase {
     $this->assertInstanceOf('lang.Generic', null);
   }    
 
+  /** @deprecated */
   #[@test, @expect('unittest.AssertionFailedError')]
   public function xpNullIsNotAnInstanceOfGeneric() {
     $this->assertInstanceOf('lang.Generic', \xp::null());

--- a/src/test/php/net/xp_framework/unittest/util/FiltersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FiltersTest.class.php
@@ -1,13 +1,13 @@
 <?php namespace net\xp_framework\unittest\util;
  
-use unittest\TestCase;
 use util\Filters;
 use util\Filter;
+use lang\IllegalStateException;
 
 /**
  * Test Filters class
  */
-class FiltersTest extends TestCase {
+class FiltersTest extends \unittest\TestCase {
 
   /**
    * Helper method
@@ -78,7 +78,7 @@ class FiltersTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.NullPointerException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function accept_called_without_accepting_function_set() {
     create('new util.Filters<int>')
       ->add(newinstance('util.Filter<int>', [], ['accept' => function($e) { return $e > 1; }]))

--- a/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
@@ -243,9 +243,9 @@ class ConsoleTest extends TestCase {
   #[@test]
   public function initialize_without_console() {
     $this->initialize(false, function() {
-      $this->assertEquals(\xp::null(), Console::$in);
-      $this->assertEquals(\xp::null(), Console::$out);
-      $this->assertEquals(\xp::null(), Console::$err);
+      $this->assertEquals(null, Console::$in->getStream());
+      $this->assertEquals(null, Console::$out->getStream());
+      $this->assertEquals(null, Console::$err->getStream());
     });
   }
 }


### PR DESCRIPTION
This pull request deprecates `xp::null()` and rewrites the code base to do without it.

Notable BC breaks:
* The call `XPClass::forName($name)->cast(null)` returns `null` now, and no longer the null-safe null. This way it's consistent with e.g. `Primitive::cast()` though. If you want null-safe casts, use the global `cast($expr, $type)` function.
* The class loading APIs will return `null` from their find*() methods now. To check, you need to use `null === $result` instead of `$result instanceof null`, which I couldn't find anywhere in the codebase or any project.

See https://github.com/xp-framework/rfc/issues/298