### PR TITLE
Feature: Unicode unittest icons

### DIFF
--- a/src/main/php/xp/unittest/DefaultListener.class.php
+++ b/src/main/php/xp/unittest/DefaultListener.class.php
@@ -161,9 +161,11 @@ class DefaultListener extends \lang\Object implements TestListener, ColorizingLi
     }
 
     $this->out->writeLinef(
-      "\n%s%s: %d/%d run (%d skipped), %d succeeded, %d failed%s",
-      $this->colored ? ($fail ? "\033[41;1;37m" : "\033[42;1;37m") : '',
-      $fail ? 'FAIL' : 'OK',
+      "\n%s: %d/%d run (%d skipped), %d succeeded, %d failed%s",
+      ($this->colored
+        ? ($fail ? "\033[41;1;37m✗" : "\033[42;1;37m✓")
+        : ($fail ? 'FAIL' : 'OK')
+      ),
       $result->runCount(),
       $result->count(),
       $result->skipCount(),


### PR DESCRIPTION
 Use ✓ and ✗ for success and failure if in terminal color mode. See feature request #55 

*Note: This will break cases when the unittest command was used in conjuction with `|grep "OK"`. Don't do this! - use the exit code instead.*