### PR TITLE
Move static initializer from Throwable -> XPClass

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -117,7 +117,7 @@ final class xp {
       if (0 === xp::$cll) {
         $invocations= xp::$cli;
         xp::$cli= [];
-        foreach ($invocations as $inv) call_user_func($inv, $name);
+        foreach ($invocations as $inv) $inv($name);
       }
 
       return $name;
@@ -390,7 +390,7 @@ function uses() {
         $trace= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
         $scope= literal($trace[2]['args'][0]);
       }
-      call_user_func([$class, '__import'], $scope);
+      $class::__import($scope);
     }
 
     $short= substr($str, strrpos($str, '.') + 1);

--- a/src/main/php/lang/Throwable.class.php
+++ b/src/main/php/lang/Throwable.class.php
@@ -17,25 +17,6 @@ class Throwable extends \Exception implements Generic { use \__xp;
     $cause    = null,
     $message  = '',
     $trace    = [];
-  
-  static function __static() {
-  
-    // Workaround for missing detail information about return types in
-    // builtin classes.
-    \xp::$meta['php.Exception']= [
-      'class' => [4 => null, []],
-      0 => [],
-      1 => [
-        'getMessage'       => [1 => [], 'string', [], null, []],
-        'getCode'          => [1 => [], 'int', [], null, []],
-        'getFile'          => [1 => [], 'string', [], null, []],
-        'getLine'          => [1 => [], 'int', [], null, []],
-        'getTrace'         => [1 => [], 'var[]', [], null, []],
-        'getPrevious'      => [1 => [], 'lang.Throwable', [], null, []],
-        'getTraceAsString' => [1 => [], 'string', [], null, []]
-      ]
-    ];
-  }
 
   /**
    * Constructor

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -57,7 +57,24 @@ class XPClass extends Type {
   private $_class;
   private $_reflect= null;
 
-  static function __static() { }
+  static function __static() {
+
+    // Workaround for missing detail information about return types in
+    // builtin classes.
+    \xp::$meta['php.Exception']= [
+      'class' => [4 => null, []],
+      0 => [],
+      1 => [
+        'getMessage'       => [1 => [], 'string', [], null, []],
+        'getCode'          => [1 => [], 'int', [], null, []],
+        'getFile'          => [1 => [], 'string', [], null, []],
+        'getLine'          => [1 => [], 'int', [], null, []],
+        'getTrace'         => [1 => [], 'var[]', [], null, []],
+        'getPrevious'      => [1 => [], 'lang.Throwable', [], null, []],
+        'getTraceAsString' => [1 => [], 'string', [], null, []]
+      ]
+    ];
+  }
 
   /**
    * Constructor


### PR DESCRIPTION
This way, we don't execute it for every subclass of Throwable, which there are quite a bit of.

This PR has been backported to XP 5, see xp-framework/xp-framework#377