### PR TITLE
Implement TypeUnion type

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -458,6 +458,8 @@ function is($type, $object) {
     return (new \lang\MapType(substr($type, 2, -1)))->isInstance($object);
   } else if (0 === strncmp($type, '(function(', 10)) {
     return \lang\FunctionType::forName(substr($type, 1, -1))->isInstance($object);
+  } else if (strstr($type, '|')) {
+    return \lang\TypeUnion::forName($type)->isInstance($object);
   } else if (strstr($type, '?')) {
     return \lang\WildcardType::forName($type)->isInstance($object);
   } else {

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -158,6 +158,7 @@ class Type extends Object {
     // * D<K, V> is a generic type definition D with K and V components
     //   except if any of K, V contains a ?, in which case it's a wild 
     //   card type.
+    // * T1|T2 is a type union
     // * Anything else is a qualified or unqualified class name
     if (isset($primitives[$type])) {
       return Primitive::forName($primitives[$type]);
@@ -179,6 +180,8 @@ class Type extends Object {
       return FunctionType::forName(substr($type, 1, -1));
     } else if (0 === substr_compare($type, '*', -1)) {
       return new ArrayType(self::forName(substr($type, 0, -1)));
+    } else if (strstr($type, '|')) {
+      return TypeUnion::forName($type);
     } else if (false === ($p= strpos($type, '<'))) {
       $normalized= strtr($type, '\\', '.');
       return strstr($normalized, '.') ? XPClass::forName($normalized) : new XPClass($normalized);

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -176,8 +176,8 @@ class Type extends Object {
       return new ArrayType(self::forName(substr($type, 0, -2)));
     } else if (0 === substr_compare($type, '[:', 0, 2)) {
       return new MapType(self::forName(substr($type, 2, -1)));
-    } else if (0 === substr_compare($type, '(function(', 0, 10)) {
-      return FunctionType::forName(substr($type, 1, -1));
+    } else if ('(' === $type{0}) {
+      return self::forName(substr($type, 1, -1));
     } else if (0 === substr_compare($type, '*', -1)) {
       return new ArrayType(self::forName(substr($type, 0, -1)));
     } else if (strstr($type, '|')) {

--- a/src/main/php/lang/TypeUnion.class.php
+++ b/src/main/php/lang/TypeUnion.class.php
@@ -1,0 +1,154 @@
+<?php namespace lang;
+
+/**
+ * Represents a union of types
+ *
+ * @see   xp://lang.Type
+ * @test  xp://net.xp_framework.unittest.core.TypeUnionTest
+ */
+class TypeUnion extends Type {
+  private $types;
+
+  static function __static() { }
+
+  /**
+   * Creates a new type union instance
+   *
+   * @param  lang.Type[] $types
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct(array $types) {
+    if (sizeof($types) < 2) {
+      throw new IllegalArgumentException('A type union consists of at least 2 types');
+    }
+    $this->types= $types;
+    parent::__construct(implode('|', array_map(function($type) { return $type->getName(); }, $types)), null);
+  }
+
+  /**
+   * Gets types this union consists of
+   *
+   * @return  lang.Type[]
+   */
+  public function types() {
+    return $this->types;
+  }
+
+  /**
+   * Get a type instance for a given name
+   *
+   * @param   string name
+   * @return  self
+   * @throws  lang.IllegalArgumentException if the given name is not a union
+   */
+  public static function forName($name) {
+    $types= [];
+    for ($args= $name.'|', $o= 0, $brackets= 0, $i= 0, $s= strlen($args); $i < $s; $i++) {
+      if ('|' === $args{$i} && 0 === $brackets) {
+        $types[]= parent::forName(trim(substr($args, $o, $i- $o)));
+        $o= $i+ 1;
+      } else if ('(' === $args{$i}) {
+        $brackets++;
+      } else if (')' === $args{$i}) {
+        $brackets--;
+      }
+    }
+    return new self($types);
+  }
+
+  /**
+   * Returns type literal
+   *
+   * @return  string
+   */
+  public function literal() {
+    return '∪'.$this->component->literal();
+  }
+
+  /**
+   * Determines whether the specified object is an instance of this
+   * type. 
+   *
+   * @param   var obj
+   * @return  bool
+   */
+  public function isInstance($obj) {
+    foreach ($this->types as $type) {
+      if ($type->isInstance($obj)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns a new instance of this object
+   *
+   * @param   var value
+   * @return  var
+   */
+  public function newInstance($value= null) {
+    foreach ($this->types as $type) {
+      if ($type->isInstance($value)) return $type->newInstance($value);
+    }
+
+    throw new IllegalArgumentException('Cannot create instances of the '.$this->getName().' type from '.\xp::typeOf($value));
+  }
+
+  /**
+   * Cast a value to this type
+   *
+   * @param   var value
+   * @return  var
+   * @throws  lang.ClassCastException
+   */
+  public function cast($value) {
+    if (null === $value) {
+      return null;
+    } else {
+      foreach ($this->types as $type) {
+        if ($type->isInstance($value)) return $type->cast($value);
+      }
+    }
+
+    throw new ClassCastException('Cannot cast to the '.$this->getName().' type from '.\xp::typeOf($value));
+  }
+
+  /**
+   * Tests whether this type is assignable from another type
+   *
+   * ```php
+   * $union= TypeUnion::forName('int|string|lang.Throwable');
+   *
+   * // It's assignable to each of its components
+   * $union->isAssignableFrom('int')                          // TRUE
+   * $union->isAssignableFrom('string')                       // TRUE
+   * $union->isAssignableFrom('lang.XPException')             // TRUE
+   * $union->isAssignableFrom('bool')                         // FALSE
+   *
+   * // It's assignable to unions if the union consists completely
+   * // of types assignable to types in this union.
+   * $union->isAssignableFrom('int|string')                   // TRUE
+   * $union->isAssignableFrom('int|lang.XPException')         // TRUE
+   * $union->isAssignableFrom('int|string|lang.XPException')  // TRUE
+   * $union->isAssignableFrom('int|bool')                     // FALSE
+   * $union->isAssignableFrom('int|string|bool')              // FALSE
+   * $union->isAssignableFrom('int|string|util.Date')         // FALSE
+   * ```
+   *
+   * @param   var $from Either a type or a type name
+   * @return  bool
+   */
+  public function isAssignableFrom($from) {
+    $t= $from instanceof Type ? $from : Type::forName($from);
+    if ($t instanceof self) {
+      foreach ($t->types as $type) {
+        if (!$this->isAssignableFrom($type)) return false;
+      }
+      return true;
+    } else {
+      foreach ($this->types as $type) {
+        if ($type->isAssignableFrom($t)) return true;
+      }
+      return false;
+    }
+  }
+}

--- a/src/test/config/unittest/core.ini
+++ b/src/test/config/unittest/core.ini
@@ -222,6 +222,9 @@ class="net.xp_framework.unittest.core.WildcardTypeTest"
 [functiontype]
 class="net.xp_framework.unittest.core.FunctionTypeTest"
 
+[typeunion]
+class="net.xp_framework.unittest.core.TypeUnionTest"
+
 [systemexit]
 class="net.xp_framework.unittest.core.SystemExitTest"
 

--- a/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
@@ -283,4 +283,9 @@ class IsTest extends \unittest\TestCase {
   public function array_of_function_type() {
     $this->assertTrue(is('(function(): var)[]', [function() { }]));
   }
+
+  #[@test, @values([1, 'Test'])]
+  public function type_union($val) {
+    $this->assertTrue(is('int|string', $val));
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/core/TypeUnionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeUnionTest.class.php
@@ -72,7 +72,7 @@ class TypeUnionTest extends \unittest\TestCase {
   public function forName_from_Type_class($literal) {
     $this->assertEquals(
       new TypeUnion([Primitive::$STRING, Primitive::$INT]),
-      TypeUnion::forName($literal)
+      Type::forName($literal)
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/TypeUnionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeUnionTest.class.php
@@ -151,4 +151,20 @@ class TypeUnionTest extends \unittest\TestCase {
     $union= new TypeUnion([Primitive::$STRING, Primitive::$INT, $this->getClass()]);
     $this->assertFalse($union->isAssignableFrom($type));
   }
+
+  #[@test]
+  public function string_or_int_array() {
+    $this->assertEquals(
+      new TypeUnion([Primitive::$STRING, new ArrayType(Primitive::$INT)]),
+      Type::forName('string|int[]')
+    );
+  }
+
+  #[@test]
+  public function array_of_type_unions() {
+    $this->assertEquals(
+      new ArrayType(new TypeUnion([Primitive::$STRING, Primitive::$INT])),
+      Type::forName('(string|int)[]')
+    );
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/core/TypeUnionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeUnionTest.class.php
@@ -1,0 +1,154 @@
+<?php namespace net\xp_framework\unittest\core;
+
+use lang\TypeUnion;
+use lang\IllegalArgumentException;
+use lang\ClassCastException;
+use lang\Primitive;
+use lang\ArrayType;
+use lang\MapType;
+use lang\FunctionType;
+use lang\Type;
+
+class TypeUnionTest extends \unittest\TestCase {
+
+  /** @return var[][] */
+  private function instances() {
+    return [
+      [1, 'an int'],
+      ['Test', 'a string']
+    ];
+  }
+
+  /** @return var[][] */
+  private function instancesAndNull() {
+    return array_merge([[null, 'null']], $this->instances());
+  }
+
+  /** @return var[][] */
+  private function notInstances() {
+    return [
+      [1.0, 'a double'],
+      [true, 'a boolean'],
+      [[], 'an array'],
+      [$this, 'an object']
+    ];
+  }
+
+  /** @return var[][] */
+  private function notInstancesAndNull() {
+    return array_merge([[null, 'null']], $this->notInstances());
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function cannot_create_from_empty() {
+    new TypeUnion([]);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function cannot_create_from_single() {
+    new TypeUnion([Type::$VAR]);
+  }
+
+  #[@test]
+  public function can_create() {
+    new TypeUnion([Primitive::$STRING, Primitive::$INT]);
+  }
+
+  #[@test, @values([
+  #  'string|int',
+  #  'string | int'
+  #])]
+  public function forName($literal) {
+    $this->assertEquals(
+      new TypeUnion([Primitive::$STRING, Primitive::$INT]),
+      TypeUnion::forName($literal)
+    );
+  }
+
+  #[@test, @values([
+  #  'string|int',
+  #  'string | int'
+  #])]
+  public function forName_from_Type_class($literal) {
+    $this->assertEquals(
+      new TypeUnion([Primitive::$STRING, Primitive::$INT]),
+      TypeUnion::forName($literal)
+    );
+  }
+
+  #[@test]
+  public function types() {
+    $types= [Primitive::$STRING, Primitive::$INT];
+    $this->assertEquals($types, (new TypeUnion($types))->types());
+  }
+
+  #[@test, @values('instances')]
+  public function is_instance_of_a_string_int_union($value) {
+    $this->assertTrue((new TypeUnion([Primitive::$STRING, Primitive::$INT]))->isInstance($value));
+  }
+
+  #[@test, @values('notInstancesAndNull')]
+  public function is_not_instance_of_a_string_int_union($value) {
+    $this->assertFalse((new TypeUnion([Primitive::$STRING, Primitive::$INT]))->isInstance($value));
+  }
+
+  #[@test, @values('instances')]
+  public function new_instance_of_a_string_int_union($value) {
+    $this->assertEquals(
+      $value,
+      (new TypeUnion([Primitive::$STRING, Primitive::$INT]))->newInstance($value)
+    );
+  }
+
+  #[@test, @expect(IllegalArgumentException::class), @values('notInstancesAndNull')]
+  public function cannot_create_instances_of_a_string_int_union($value) {
+    $this->assertEquals(
+      $value,
+      (new TypeUnion([Primitive::$STRING, Primitive::$INT]))->newInstance($value)
+    );
+  }
+
+  #[@test, @values('instancesAndNull')]
+  public function cast_to_a_string_int_union($value) {
+    $this->assertEquals(
+      $value,
+      (new TypeUnion([Primitive::$STRING, Primitive::$INT]))->cast($value)
+    );
+  }
+
+  #[@test, @expect(ClassCastException::class), @values('notInstances')]
+  public function cannot_cast_to_a_string_int_union($value) {
+    $this->assertEquals(
+      $value,
+      (new TypeUnion([Primitive::$STRING, Primitive::$INT]))->cast($value)
+    );
+  }
+
+  #[@test, @values([
+  #  [Primitive::$INT],
+  #  [Primitive::$STRING],
+  #  [new XPClass(self::class)],
+  #  [new TypeUnion([Primitive::$STRING, Primitive::$INT])],
+  #  [new TypeUnion([Primitive::$STRING, Primitive::$INT, new XPClass(self::class)])]
+  #])]
+  public function is_assignable_from($type) {
+    $union= new TypeUnion([Primitive::$STRING, Primitive::$INT, $this->getClass()]);
+    $this->assertTrue($union->isAssignableFrom($type));
+  }
+
+  #[@test, @values([
+  #  [Type::$VAR],
+  #  [Type::$VOID],
+  #  [Primitive::$BOOL],
+  #  [new TypeUnion([Primitive::$STRING, Primitive::$BOOL])],
+  #  [new TypeUnion([Primitive::$STRING, Primitive::$INT, new XPClass(Type::class)])],
+  #  [new ArrayType(Type::$VAR)],
+  #  [new MapType(Type::$VAR)],
+  #  [new FunctionType([], Type::$VAR)],
+  #  [new XPClass(Type::class)]
+  #])]
+  public function is_not_assignable_from($type) {
+    $union= new TypeUnion([Primitive::$STRING, Primitive::$INT, $this->getClass()]);
+    $this->assertFalse($union->isAssignableFrom($type));
+  }
+}


### PR DESCRIPTION
Part of xp-framework/rfc#298

### Example

```php
$union= TypeUnion::forName('int|string');
$union->isInstance(1);        // TRUE
$union->isInstance('Hello');  // TRUE
$union->isInstance($this);    // FALSE
```

### TODO

* [x] Create `TypeUnion` class and tests
* [x] Add support in `is()` core functionality
* [x] Check ambiguities and how to resolve them

### See also
http://www.phpdoc.org/docs/latest/guides/types.html#multiple-types-combined