### PR TITLE
Text reader iteration

### DIFF
--- a/src/main/php/io/streams/LinesIn.class.php
+++ b/src/main/php/io/streams/LinesIn.class.php
@@ -16,19 +16,15 @@ class LinesIn extends \lang\Object implements \Iterator {
   /**
    * Creates a new lines instance
    *
-   * @param  var $arg Either a string, a TextReader or an InputStream
-   * @param  string $charset Only taken into account when passing strings or streams
+   * @param  var $arg Either TextReader, a channel, a string or an input stream
+   * @param  string $charset Not taken into account when created by a TextReader
    * @throws lang.IllegalArgumentException
    */
   public function __construct($arg, $charset= \xp::ENCODING) {
     if ($arg instanceof TextReader) {
       $this->reader= $arg;
-    } else if ($arg instanceof InputStream) {
-      $this->reader= new TextReader($arg, $charset);
-    } else if (is_string($arg)) {
-      $this->reader= new TextReader(new MemoryInputStream($arg), $charset);
     } else {
-      throw new IllegalArgumentException('Given argument is neither a TextReader nor an InputStream: '.\xp::typeOf($arg));
+      $this->reader= new TextReader($arg, $charset);
     }
   }
 

--- a/src/main/php/io/streams/LinesIn.class.php
+++ b/src/main/php/io/streams/LinesIn.class.php
@@ -1,0 +1,61 @@
+<?php namespace io\streams;
+
+use lang\IllegalArgumentException;
+
+/**
+ * Represents the lines inside an input stream of bytes, delimited
+ * by either Unix, Mac or Windows line endings.
+ *
+ * @see   xp://io.streams.TextReader#lines
+ * @test  xp://net.xp_framework.unittest.io.streams.LinesTest
+ */
+class LinesIn extends \lang\Object implements \Iterator {
+  const EOF = -1;
+  private $reader, $line, $number;
+
+  /**
+   * Creates a new lines instance
+   *
+   * @param  var $arg Either a string, a TextReader or an InputStream
+   * @param  string $charset Only taken into account when passing strings or streams
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct($arg, $charset= \xp::ENCODING) {
+    if ($arg instanceof TextReader) {
+      $this->reader= $arg;
+    } else if ($arg instanceof InputStream) {
+      $this->reader= new TextReader($arg, $charset);
+    } else if (is_string($arg)) {
+      $this->reader= new TextReader(new MemoryInputStream($arg), $charset);
+    } else {
+      throw new IllegalArgumentException('Given argument is neither a TextReader nor an InputStream: '.\xp::typeOf($arg));
+    }
+  }
+
+  /** @return string */
+  public function current() { return $this->line; }
+
+  /** @return int */
+  public function key() { return $this->number; }
+
+  /** @return bool */
+  public function valid() { return self::EOF !== $this->number; }
+
+  /** @return void */
+  public function next() {
+    if (self::EOF === $this->number) {
+      // Already at EOF, don't attempt further reads
+    } else if (null === ($this->line= $this->reader->readLine())) {
+      $this->number= self::EOF;
+    } else {
+      $this->number++;
+    }
+  }
+
+  /** @return void */
+  public function rewind() {
+    $this->reader->atBeginning() || $this->reader->reset();
+    $this->number= 0;
+    $this->next();
+  }
+}

--- a/src/main/php/io/streams/LinesIn.class.php
+++ b/src/main/php/io/streams/LinesIn.class.php
@@ -11,21 +11,23 @@ use lang\IllegalArgumentException;
  */
 class LinesIn extends \lang\Object implements \Iterator {
   const EOF = -1;
-  private $reader, $line, $number;
+  private $reader, $line, $number, $reset;
 
   /**
    * Creates a new lines instance
    *
    * @param  var $arg Either TextReader, a channel, a string or an input stream
    * @param  string $charset Not taken into account when created by a TextReader
+   * @param  bool $reset Whether to start from the beginning (default: true)
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($arg, $charset= \xp::ENCODING) {
+  public function __construct($arg, $charset= \xp::ENCODING, $reset= true) {
     if ($arg instanceof TextReader) {
       $this->reader= $arg;
     } else {
       $this->reader= new TextReader($arg, $charset);
     }
+    $this->reset= $reset;
   }
 
   /** @return string */
@@ -50,7 +52,9 @@ class LinesIn extends \lang\Object implements \Iterator {
 
   /** @return void */
   public function rewind() {
-    $this->reader->atBeginning() || $this->reader->reset();
+    if ($this->reset && !$this->reader->atBeginning()) {
+      $this->reader->reset();
+    }
     $this->number= 0;
     $this->next();
   }

--- a/src/main/php/io/streams/Reader.class.php
+++ b/src/main/php/io/streams/Reader.class.php
@@ -1,6 +1,7 @@
 <?php namespace io\streams;
 
 use lang\Closeable;
+use io\IOException;
 
 /**
  * Serves as an abstract base class for all other readers. A reader
@@ -36,7 +37,7 @@ abstract class Reader extends \lang\Object implements Closeable {
    */
   public function reset() {
     if (!$this->stream instanceof \Seekable) {
-      throw new \io\IOException('Underlying stream does not support seeking');
+      throw new IOException('Underlying stream does not support seeking');
     }
     $this->stream->seek(0, SEEK_SET);
   }

--- a/src/main/php/io/streams/TextReader.class.php
+++ b/src/main/php/io/streams/TextReader.class.php
@@ -174,6 +174,17 @@ class TextReader extends Reader {
     return $line;
   }
 
-  /** @return io.streams.LinesIn */
-  public function lines() { return new LinesIn($this); }
+  /**
+   * Reads all lines in this reader
+   *
+   * @return io.streams.LinesIn
+   */
+  public function lines() { return new LinesIn($this, $this->charset, true); }
+
+  /**
+   * Reads the lines starting at the current position
+   *
+   * @return io.streams.LinesIn
+   */
+  public function readLines() { return new LinesIn($this, $this->charset, false); }
 }

--- a/src/main/php/io/streams/TextReader.class.php
+++ b/src/main/php/io/streams/TextReader.class.php
@@ -1,7 +1,9 @@
 <?php namespace io\streams;
 
 use io\IOException;
+use io\Channel;
 use lang\FormatException;
+use lang\IllegalArgumentException;
 
 /**
  * Reads text from an underlying input stream, converting it from the
@@ -20,11 +22,20 @@ class TextReader extends Reader {
    * Constructor. Creates a new TextReader on an underlying input
    * stream with a given charset.
    *
-   * @param   io.streams.InputStream $stream
+   * @param   var $arg Either an input stream, a string or an I/O channel
    * @param   string $charset the charset the stream is encoded in or NULL to trigger autodetection by BOM
+   * @throws  lang.IllegalArgumentException
    */
-  public function __construct(InputStream $stream, $charset= null) {
-    parent::__construct($stream);
+  public function __construct($arg, $charset= null) {
+    if ($arg instanceof InputStream) {
+      parent::__construct($arg);
+    } else if ($arg instanceof Channel) {
+      parent::__construct($arg->in());
+    } else if (is_string($arg)) {
+      parent::__construct(new MemoryInputStream($arg));
+    } else {
+      throw new IllegalArgumentException('Given argument is neither an input stream, a channel nor a string: '.\xp::typeOf($arg));
+    }
     $this->charset= $charset ?: $this->detectCharset();
     $this->beginning= true;
   }

--- a/src/main/php/io/streams/TextWriter.class.php
+++ b/src/main/php/io/streams/TextWriter.class.php
@@ -1,5 +1,8 @@
 <?php namespace io\streams;
 
+use lang\IllegalArgumentException;
+use io\Channel;
+
 /**
  * Writes text from to underlying output stream. When writing lines,
  * uses the newLine property's bytes as newline separator, defaulting
@@ -16,11 +19,18 @@ class TextWriter extends Writer {
    * Constructor. Creates a new TextWriter on an underlying output
    * stream with a given charset.
    *
-   * @param   io.streams.OutputStream stream
-   * @param   string charset the charset the stream is encoded in.
+   * @param   var $arg Either an output stream or an I/O channel
+   * @param   string $charset the charset the stream is encoded in.
+   * @throws  lang.IllegalArgumentException
    */
-  public function __construct(OutputStream $stream, $charset= \xp::ENCODING) {
-    parent::__construct($stream);
+  public function __construct($arg, $charset= \xp::ENCODING) {
+    if ($arg instanceof OutputStream) {
+      parent::__construct($arg);
+    } else if ($arg instanceof Channel) {
+      parent::__construct($arg->out());
+    } else {
+      throw new IllegalArgumentException('Given argument is neither an input stream, a channel nor a string: '.\xp::typeOf($arg));
+    }
     $this->charset= $charset;
   }
 

--- a/src/main/php/io/streams/TextWriter.class.php
+++ b/src/main/php/io/streams/TextWriter.class.php
@@ -12,8 +12,8 @@ use io\Channel;
  * @ext     iconv
  */
 class TextWriter extends Writer {
-  protected $charset= '';
-  protected $newLine= "\n";
+  private $charset= '';
+  private $newLine= "\n";
 
   /**
    * Constructor. Creates a new TextWriter on an underlying output

--- a/src/test/config/unittest/io.ini
+++ b/src/test/config/unittest/io.ini
@@ -80,3 +80,6 @@ class="net.xp_framework.unittest.io.streams.StringReaderTest"
 
 [stringwriter]
 class="net.xp_framework.unittest.io.streams.StringWriterTest"
+
+[lines]
+class="net.xp_framework.unittest.io.streams.LinesInTest"

--- a/src/test/php/net/xp_framework/unittest/io/streams/LinesInTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/LinesInTest.class.php
@@ -1,0 +1,90 @@
+<?php namespace net\xp_framework\unittest\io\streams;
+
+use io\streams\TextReader;
+use io\streams\LinesIn;
+use io\streams\MemoryInputStream;
+use io\IOException;
+use lang\IllegalArgumentException;
+
+class LinesInTest extends \unittest\TestCase {
+
+  #[@test]
+  public function can_create_with_string() {
+    new LinesIn('');
+  }
+
+  #[@test]
+  public function can_create_with_stream() {
+    new LinesIn(new MemoryInputStream(''));
+  }
+
+  #[@test]
+  public function can_create_with_reader() {
+    new LinesIn(new TextReader(new MemoryInputStream(''), 'utf-8'));
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function raises_exception_for_incorrect_constructor_argument() {
+    new LinesIn(null);
+  }
+
+  #[@test, @values([
+  #  ["Line 1", [1 => 'Line 1']],
+  #  ["Line 1\n", [1 => 'Line 1']],
+  #  ["Line 1\nLine 2", [1 => 'Line 1', 2 => 'Line 2']],
+  #  ["Line 1\nLine 2\n", [1 => 'Line 1', 2 => 'Line 2']],
+  #  ["Line 1\n\nLine 3\n", [1 => 'Line 1', 2 => '', 3 => 'Line 3']],
+  #  ["Line 1\n\n\nLine 4\n", [1 => 'Line 1', 2 => '', 3 => '', 4 => 'Line 4']]
+  #])]
+  public function iterating_lines($input, $lines) {
+    $this->assertEquals($lines, iterator_to_array(new LinesIn($input)));
+  }
+
+  #[@test]
+  public function iterating_empty_input_returns_empty_array() {
+    $this->assertEquals([], iterator_to_array(new LinesIn('')));
+  }
+
+  #[@test]
+  public function can_iterate_twice_on_seekable() {
+    $fixture= new LinesIn("A\nB");
+    $this->assertEquals(
+      [[1 => 'A', 2 => 'B'], [1 => 'A', 2 => 'B']],
+      [iterator_to_array($fixture), iterator_to_array($fixture)]
+    );
+  }
+
+  #[@test, @values([
+  #  [new LinesIn("\xFC", "iso-8859-1")],
+  #  [new LinesIn(new MemoryInputStream("\xFC"), "iso-8859-1")],
+  #  [new LinesIn(new TextReader(new MemoryInputStream("\xFC"), "iso-8859-1"))]
+  #])]
+  public function input_is_encoded_to_utf8($arg) {
+    $this->assertEquals([1 => 'ü'], iterator_to_array($arg));
+  }
+
+  #[@test]
+  public function can_only_iterate_unseekable_once() {
+    $fixture= new LinesIn(newinstance('io.streams.InputStream', [], [
+      'bytes' => "A\nB\n",
+      'offset' => 0,
+      'read' => function($length= 8192) {
+        $chunk= substr($this->bytes, $this->offset, $length);
+        $this->offset+= strlen($chunk);
+        return $chunk;
+      },
+      'available' => function() {
+        return strlen($this->bytes) - $this->offset;
+      },
+      'close' => function() { }
+    ]));
+
+    $this->assertEquals([1 => 'A', 2 => 'B'], iterator_to_array($fixture));
+    try {
+      iterator_to_array($fixture);
+      $this->fail('No exception raised', null, 'io.IOException');
+    } catch (IOException $expected) {
+      // OK
+    }
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/io/streams/LinesInTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/LinesInTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
+use io\File;
 use io\streams\TextReader;
 use io\streams\LinesIn;
 use io\streams\MemoryInputStream;
@@ -16,6 +17,11 @@ class LinesInTest extends \unittest\TestCase {
   #[@test]
   public function can_create_with_stream() {
     new LinesIn(new MemoryInputStream(''));
+  }
+
+  #[@test]
+  public function can_create_with_channel() {
+    new LinesIn(new File(__FILE__));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
-use io\File;
 use io\streams\TextReader;
 use io\streams\InputStream;
 use io\streams\MemoryInputStream;
+use io\streams\MemoryOutputStream;
 use lang\IllegalArgumentException;
 
 /**
@@ -26,7 +26,10 @@ class TextReaderTest extends \unittest\TestCase {
 
   #[@test]
   public function can_create_with_channel() {
-    new TextReader(new File(__FILE__));
+    new TextReader(newinstance('io.Channel', [], [
+      'in'  => function() { return new MemoryInputStream(''); },
+      'out' => function() { return new MemoryOutputStream(); }
+    ]));
   }
 
   #[@test, @expect(IllegalArgumentException::class)]

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
-use unittest\TestCase;
+use io\File;
 use io\streams\TextReader;
 use io\streams\InputStream;
 use io\streams\MemoryInputStream;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
@@ -11,7 +12,27 @@ use io\streams\MemoryInputStream;
  * @see  http://de.wikipedia.org/wiki/China
  * @see  xp://io.streams.TextReader
  */
-class TextReaderTest extends TestCase {
+class TextReaderTest extends \unittest\TestCase {
+
+  #[@test]
+  public function can_create_with_string() {
+    new TextReader('');
+  }
+
+  #[@test]
+  public function can_create_with_stream() {
+    new TextReader(new MemoryInputStream(''));
+  }
+
+  #[@test]
+  public function can_create_with_channel() {
+    new TextReader(new File(__FILE__));
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function raises_exception_for_incorrect_constructor_argument() {
+    new TextReader(null);
+  }
 
   /**
    * Returns a text reader for a given input string.

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -7,79 +7,52 @@ use io\streams\MemoryInputStream;
 /**
  * TestCase
  *
- * @see      xp://io.streams.TextReader
+ * @see  http://de.wikipedia.org/wiki/China
+ * @see  xp://io.streams.TextReader
  */
 class TextReaderTest extends TestCase {
 
   /**
    * Returns a text reader for a given input string.
    *
-   * @param   string str
-   * @param   string charset
+   * @param   string $str
+   * @param   string $charset
    * @return  io.streams.TextReader
    */
   protected function newReader($str, $charset= \xp::ENCODING) {
     return new TextReader(new MemoryInputStream($str), $charset);
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function readOne() {
     $this->assertEquals('H', $this->newReader('Hello', 'iso-8859-1')->read(1));
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function readOneUtf8() {
     $this->assertEquals('Ü', $this->newReader('Übercoder', 'utf-8')->read(1));
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function readLength() {
     $this->assertEquals('Hello', $this->newReader('Hello')->read(5));
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function readLengthUtf8() {
     $this->assertEquals('Übercoder', $this->newReader('Übercoder', 'utf-8')->read(9));
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test, @expect('lang.FormatException')]
   public function readBrokenUtf8() {
     $this->newReader("Hello \334|", 'utf-8')->read(0x1000);
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test, @expect('lang.FormatException')]
   public function readMalformedUtf8() {
     $this->newReader("Hello \334bercoder", 'utf-8')->read(0x1000);
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function readingDoesNotContinueAfterBrokenCharacters() {
     $r= $this->newReader("Hello \334bercoder\n".str_repeat('*', 512), 'utf-8');
@@ -92,30 +65,16 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->read(512));
   }
 
-  /**
-   * Test reading Unicode which contains two characters not convertible
-   * to iso-8859-1, now works.
-   *
-   * @see     http://de.wikipedia.org/wiki/China
-   */
   #[@test, @values(['ˈçiːna', 'ˈkiːna', '中國 / 中国', 'Zhōngguó'])]
   public function readPreviouslyUnconvertible($value) {
     $this->assertEquals($value, $this->newReader($value, 'utf-8')->read());
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function read() {
     $this->assertEquals('Hello', $this->newReader('Hello')->read());
   }
 
-  /**
-   * Test reading a source returning encoded bytes only (no US-ASCII inbetween!)
-   *
-   */
   #[@test]
   public function encodedBytesOnly() {
     $this->assertEquals(
@@ -124,10 +83,6 @@ class TextReaderTest extends TestCase {
     );
   }
 
-  /**
-   * Test reading after EOF
-   *
-   */
   #[@test]
   public function readAfterEnd() {
     $r= $this->newReader('Hello');
@@ -135,10 +90,6 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->read());
   }
 
-  /**
-   * Test reading after EOF
-   *
-   */
   #[@test]
   public function readMultipleAfterEnd() {
     $r= $this->newReader('Hello');
@@ -147,10 +98,6 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->read());
   }
 
-  /**
-   * Test reading after EOF
-   *
-   */
   #[@test]
   public function readLineAfterEnd() {
     $r= $this->newReader('Hello');
@@ -158,10 +105,6 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->readLine());
   }
 
-  /**
-   * Test reading after EOF
-   *
-   */
   #[@test]
   public function readLineMultipleAfterEnd() {
     $r= $this->newReader('Hello');
@@ -170,28 +113,16 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->readLine());
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function readZero() {
     $this->assertEquals('', $this->newReader('Hello')->read(0));
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function readLineEmptyInput() {
     $this->assertNull($this->newReader('')->readLine());
   }
 
-  /**
-   * Test reading lines separated by "\n", "\r" and "\r\n"
-   *
-   */
   #[@test, @values(array(
   #  "Hello\nWorld\n", "Hello\rWorld\r", "Hello\r\nWorld\r\n",
   #  "Hello\nWorld", "Hello\rWorld", "Hello\r\nWorld"
@@ -203,10 +134,6 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->readLine());
   }
 
-  /**
-   * Test reading lines with one character separated by "\n", "\r" and "\r\n"
-   *
-   */
   #[@test, @values(array(
   #  "1\n2\n", "1\r2\r", "1\r\n2\r\n",
   #  "1\n2", "1\r2", "1\r\n2\r\n"
@@ -218,10 +145,6 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->readLine());
   }
 
-  /**
-   * Test reading an empty line
-   *
-   */
   #[@test]
   public function readEmptyLine() {
     $r= $this->newReader("Hello\n\nWorld");
@@ -231,10 +154,6 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->readLine());
   }
 
-  /**
-   * Test reading lines
-   *
-   */
   #[@test]
   public function readLinesUtf8() {
     $r= $this->newReader("\303\234ber\nCoder", 'utf-8');
@@ -243,102 +162,60 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->readLine());
   }
   
-  /**
-   * Test reading lines w/ autodetected encoding at iso-8859-1
-   *
-   */
   #[@test]
   public function readLinesAutodetectIso88591() {
     $r= $this->newReader("\334bercoder", null);
     $this->assertEquals('Übercoder', $r->readLine());
   }
   
-  /**
-   * Test reading from an encoding-autodetected stream when length of
-   * data does is insufficient for autodetection.
-   *
-   */
   #[@test]
   public function readShortLinesAutodetectIso88591() {
     $r= $this->newReader("\334", null);
     $this->assertEquals('Ü', $r->readLine());
   }
-  
-  
-  /**
-   * Test reading lines w/ autodetected encoding at utf-8
-   *
-   */
+
   #[@test]
   public function readLinesAutodetectUtf8() {
     $r= $this->newReader("\357\273\277\303\234bercoder", null);
     $this->assertEquals('Übercoder', $r->readLine());
   }
 
-  /**
-   * Test reading lines w/ autodetected encoding at utf-8
-   *
-   */
   #[@test]
   public function autodetectUtf8() {
     $r= $this->newReader("\357\273\277\303\234bercoder", null);
     $this->assertEquals('utf-8', $r->charset());
   }
 
-  /**
-   * Test reading lines w/ autodetected encoding at utf-16be
-   *
-   */
   #[@test]
   public function readLinesAutodetectUtf16BE() {
     $r= $this->newReader("\376\377\000\334\000b\000e\000r\000c\000o\000d\000e\000r", null);
     $this->assertEquals('Übercoder', $r->readLine());
   }
 
-  /**
-   * Test reading lines w/ autodetected encoding at utf-16be
-   *
-   */
   #[@test]
   public function autodetectUtf16Be() {
     $r= $this->newReader("\376\377\000\334\000b\000e\000r\000c\000o\000d\000e\000r", null);
     $this->assertEquals('utf-16be', $r->charset());
   }
   
-  /**
-   * Test reading lines w/ autodetected encoding at utf-16le
-   *
-   */
   #[@test]
   public function readLinesAutodetectUtf16Le() {
     $r= $this->newReader("\377\376\334\000b\000e\000r\000c\000o\000d\000e\000r\000", null);
     $this->assertEquals('Übercoder', $r->readLine());
   }
 
-  /**
-   * Test reading lines w/ autodetected encoding at utf-16le
-   *
-   */
   #[@test]
   public function autodetectUtf16Le() {
     $r= $this->newReader("\377\376\334\000b\000e\000r\000c\000o\000d\000e\000r\000", null);
     $this->assertEquals('utf-16le', $r->charset());
   }
 
-  /**
-   * Test reading lines w/ autodetected encoding at iso-8859-1
-   *
-   */
   #[@test]
   public function defaultCharsetIsIso88591() {
     $r= $this->newReader('Übercoder', null);
     $this->assertEquals('iso-8859-1', $r->charset());
   }
 
-  /**
-   * Test reading
-   *
-   */
   #[@test]
   public function bufferProblem() {
     $r= $this->newReader("Hello\rX");
@@ -347,11 +224,6 @@ class TextReaderTest extends TestCase {
     $this->assertNull($r->readLine());
   }
 
-  /**
-   * Test closing a reader twice has no effect.
-   *
-   * @see   xp://lang.Closeable#close
-   */
   #[@test]
   public function closingTwice() {
     $r= $this->newReader('');
@@ -359,10 +231,6 @@ class TextReaderTest extends TestCase {
     $r->close();
   }
 
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test]
   public function reset() {
     $r= $this->newReader('ABC');
@@ -371,10 +239,6 @@ class TextReaderTest extends TestCase {
     $this->assertEquals('ABC', $r->read(3));
 
   }
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test]
   public function resetWithBuffer() {
     $r= $this->newReader("Line 1\rLine 2");
@@ -384,10 +248,6 @@ class TextReaderTest extends TestCase {
     $this->assertEquals('Line 2', $r->readLine());
   }
 
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test]
   public function resetUtf8() {
     $r= $this->newReader("\357\273\277ABC", null);
@@ -396,10 +256,6 @@ class TextReaderTest extends TestCase {
     $this->assertEquals('ABC', $r->read(3));
   }
 
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test]
   public function resetUtf8WithoutBOM() {
     $r= $this->newReader('ABC', 'utf-8');
@@ -408,10 +264,6 @@ class TextReaderTest extends TestCase {
     $this->assertEquals('ABC', $r->read(3));
   }
 
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test]
   public function resetUtf16Le() {
     $r= $this->newReader("\377\376A\000B\000C\000", null);
@@ -420,10 +272,6 @@ class TextReaderTest extends TestCase {
     $this->assertEquals('ABC', $r->read(3));
   }
 
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test]
   public function resetUtf16LeWithoutBOM() {
     $r= $this->newReader("A\000B\000C\000", 'utf-16le');
@@ -432,10 +280,6 @@ class TextReaderTest extends TestCase {
     $this->assertEquals('ABC', $r->read(3));
   }
 
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test]
   public function resetUtf16Be() {
     $r= $this->newReader("\376\377\000A\000B\000C", null);
@@ -444,10 +288,6 @@ class TextReaderTest extends TestCase {
     $this->assertEquals('ABC', $r->read(3));
   }
 
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test]
   public function resetUtf16BeWithoutBOM() {
     $r= $this->newReader("\000A\000B\000C", 'utf-16be');
@@ -456,10 +296,6 @@ class TextReaderTest extends TestCase {
     $this->assertEquals('ABC', $r->read(3));
   }
 
-  /**
-   * Test resetting a reader
-   *
-   */
   #[@test, @expect(class= 'io.IOException', withMessage= 'Underlying stream does not support seeking')]
   public function resetUnseekable() {
     $r= new TextReader(newinstance('io.streams.InputStream', [], '{
@@ -470,89 +306,56 @@ class TextReaderTest extends TestCase {
     $r->reset();
   }
 
-  /**
-   * Test reading after character set auto-detection
-   */
   #[@test]
   public function readOneWithAutoDetectedIso88591Charset() {
     $this->assertEquals('H', $this->newReader('Hello', null)->read(1));
   }
 
-  /**
-   * Test reading after character set auto-detection
-   */
   #[@test]
   public function readOneWithAutoDetectedUtf16BECharset() {
     $this->assertEquals('H', $this->newReader("\376\377\0H\0e\0l\0l\0o", null)->read(1));
   }
 
-  /**
-   * Test reading after character set auto-detection
-   */
   #[@test]
   public function readOneWithAutoDetectedUtf16LECharset() {
     $this->assertEquals('H', $this->newReader("\377\376H\0e\0l\0l\0o\0", null)->read(1));
   }
 
-  /**
-   * Test reading after character set auto-detection
-   */
   #[@test]
   public function readOneWithAutoDetectedUtf8Charset() {
     $this->assertEquals('H', $this->newReader("\357\273\277Hello", null)->read(1));
   }
 
-  /**
-   * Test reading after character set auto-detection
-   */
   #[@test]
   public function readLineWithAutoDetectedIso88591Charset() {
     $this->assertEquals('H', $this->newReader("H\r\n", null)->readLine());
   }
 
-  /**
-   * Test reading after character set auto-detection
-   */
   #[@test]
   public function readLineWithAutoDetectedUtf16BECharset() {
     $this->assertEquals('H', $this->newReader("\376\377\0H\0\r\0\n", null)->readLine());
   }
 
-  /**
-   * Test reading after character set auto-detection
-   */
   #[@test]
   public function readLineWithAutoDetectedUtf16LECharset() {
     $this->assertEquals('H', $this->newReader("\377\376H\0\r\0\n\0", null)->readLine());
   }
 
-  /**
-   * Test reading after character set auto-detection
-   */
   #[@test]
   public function readLineWithAutoDetectedUtf8Charset() {
     $this->assertEquals('H', $this->newReader("\357\273\277H\r\n", null)->readLine());
   }
 
-  /**
-   * Test reading
-   */
   #[@test]
   public function readLineEmptyInputWithAutoDetectedIso88591Charset() {
     $this->assertNull($this->newReader('', null)->readLine());
   }
 
-  /**
-   * Test reading
-   */
   #[@test, @values(array(["\377", 'ÿ'], ["\377\377", 'ÿÿ'], ["\377\377\377", 'ÿÿÿ']))]
   public function readNonBOMInputWithAutoDetectedIso88591Charset($bytes, $characters) {
     $this->assertEquals($characters, $this->newReader($bytes, null)->read(0xFF));
   }
 
-  /**
-   * Test reading
-   */
   #[@test, @values(array(["\377", 'ÿ'], ["\377\377", 'ÿÿ'], ["\377\377\377", 'ÿÿÿ']))]
   public function readLineNonBOMInputWithAutoDetectedIso88591Charset($bytes, $characters) {
     $this->assertEquals($characters, $this->newReader($bytes, null)->readLine(0xFF));

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextWriterTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextWriterTest.class.php
@@ -1,17 +1,33 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
-use unittest\TestCase;
+use io\File;
 use lang\types\Character;
 use io\streams\TextWriter;
 use io\streams\MemoryOutputStream;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
  *
  * @see      xp://io.streams.TextWriter
  */
-class TextWriterTest extends TestCase {
+class TextWriterTest extends \unittest\TestCase {
   protected $out= null;
+
+  #[@test]
+  public function can_create_with_stream() {
+    new TextWriter(new MemoryOutputStream(''));
+  }
+
+  #[@test]
+  public function can_create_with_channel() {
+    new TextWriter(new File(__FILE__));
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function raises_exception_for_incorrect_constructor_argument() {
+    new TextWriter(null);
+  }
 
   /**
    * Returns a text writer for a given output string.
@@ -24,69 +40,41 @@ class TextWriterTest extends TestCase {
     return new TextWriter($this->out, $charset);
   }
   
-  /**
-   * Test writing text
-   *
-   */
   #[@test]
   public function write() {
     $this->newWriter()->write('Hello');
     $this->assertEquals('Hello', $this->out->getBytes());
   }
 
-  /**
-   * Test writing text
-   *
-   */
   #[@test]
   public function writeOne() {
     $this->newWriter()->write('H');
     $this->assertEquals('H', $this->out->getBytes());
   }
 
-  /**
-   * Test writing text
-   *
-   */
   #[@test]
   public function writeEmpty() {
     $this->newWriter()->write('');
     $this->assertEquals('', $this->out->getBytes());
   }
 
-  /**
-   * Test writing a text and a line
-   *
-   */
   #[@test]
   public function writeLine() {
     $this->newWriter()->writeLine('Hello');
     $this->assertEquals("Hello\n", $this->out->getBytes());
   }
 
-  /**
-   * Test writing a line
-   *
-   */
   #[@test]
   public function writeEmptyLine() {
     $this->newWriter()->writeLine();
     $this->assertEquals("\n", $this->out->getBytes());
   }
 
-  /**
-   * Test "\n" is the default line separator
-   *
-   */
   #[@test]
   public function unixLineSeparatorIsDefault() {
     $this->assertEquals("\n", $this->newWriter()->getNewLine());
   }
 
-  /**
-   * Test setNewLine() method
-   *
-   */
   #[@test]
   public function setNewLine() {
     $w= $this->newWriter();
@@ -94,111 +82,66 @@ class TextWriterTest extends TestCase {
     $this->assertEquals("\r", $w->getNewLine());
   }
 
-  /**
-   * Test withNewLine() method
-   *
-   */
   #[@test]
   public function withNewLine() {
     $w= $this->newWriter()->withNewLine("\r");
     $this->assertEquals("\r", $w->getNewLine());
   }
 
-  /**
-   * Test writing a line using the Windows line separator, "\r\n"
-   *
-   */
   #[@test]
   public function writeLineWindows() {
     $this->newWriter()->withNewLine("\r\n")->writeLine();
     $this->assertEquals("\r\n", $this->out->getBytes());
   }
 
-  /**
-   * Test writing a line using the Un*x line separator, "\n"
-   *
-   */
   #[@test]
   public function writeLineUnix() {
     $this->newWriter()->withNewLine("\n")->writeLine();
     $this->assertEquals("\n", $this->out->getBytes());
   }
 
-  /**
-   * Test writing a line using the Mac line separator, "\r"
-   *
-   */
   #[@test]
   public function writeLineMac() {
     $this->newWriter()->withNewLine("\r")->writeLine();
     $this->assertEquals("\r", $this->out->getBytes());
   }
 
-  /**
-   * Test text written is encoded in character set
-   *
-   */
   #[@test]
   public function writeUtf8() {
     $this->newWriter('utf-8')->write('Übercoder');
     $this->assertEquals("\303\234bercoder", $this->out->getBytes());
   }
 
-  /**
-   * Test text written is encoded in character set
-   *
-   */
   #[@test]
   public function writeLineUtf8() {
     $this->newWriter('utf-8')->writeLine('Übercoder');
     $this->assertEquals("\303\234bercoder\n", $this->out->getBytes());
   }
 
-  /**
-   * Test text written is encoded in character set
-   *
-   */
   #[@test]
   public function writeUtf8StringInstance() {
     $this->newWriter('utf-8')->write(new \lang\types\String('Übercoder'));
     $this->assertEquals("\303\234bercoder", $this->out->getBytes());
   }
 
-  /**
-   * Test text written is encoded in character set
-   *
-   */
   #[@test]
   public function writeLineUtf8StringInstance() {
     $this->newWriter('utf-8')->writeLine(new \lang\types\String('Übercoder'));
     $this->assertEquals("\303\234bercoder\n", $this->out->getBytes());
   }
 
-  /**
-   * Test text written is encoded in character set
-   *
-   */
   #[@test]
   public function writeUtf8CharacterInstance() {
     $this->newWriter('utf-8')->write(new Character('Ü'));
     $this->assertEquals("\303\234", $this->out->getBytes());
   }
 
-  /**
-   * Test text written is encoded in character set
-   *
-   */
   #[@test]
   public function writeLineUtf8CharacterInstance() {
     $this->newWriter('utf-8')->writeLine(new Character('Ü'));
     $this->assertEquals("\303\234\n", $this->out->getBytes());
   }
 
-  /**
-   * Test closing a reader twice has no effect.
-   *
-   * @see   xp://lang.Closeable#close
-   */
   #[@test]
   public function closingTwice() {
     $w= $this->newWriter('');
@@ -206,40 +149,24 @@ class TextWriterTest extends TestCase {
     $w->close();
   }
 
-  /**
-   * Test withBom() method
-   *
-   */
   #[@test]
   public function isoHasNoBom() {
     $this->newWriter('iso-8859-1')->withBom()->write('Hello');
     $this->assertEquals('Hello', $this->out->getBytes());
   }
  
-  /**
-   * Test withBom() method
-   *
-   */
   #[@test]
   public function utf8Bom() {
     $this->newWriter('utf-8')->withBom()->write('Hello');
     $this->assertEquals("\357\273\277Hello", $this->out->getBytes());
   }
 
-  /**
-   * Test withBom() method
-   *
-   */
   #[@test]
   public function utf16beBom() {
     $this->newWriter('utf-16be')->withBom()->write('Hello');
     $this->assertEquals("\376\377\0H\0e\0l\0l\0o", $this->out->getBytes());
   }
 
-  /**
-   * Test withBom() method
-   *
-   */
   #[@test]
   public function utf16leBom() {
     $this->newWriter('utf-16le')->withBom()->write('Hello');

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextWriterTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextWriterTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
-use io\File;
 use lang\types\Character;
 use io\streams\TextWriter;
+use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
 use lang\IllegalArgumentException;
 
@@ -16,12 +16,15 @@ class TextWriterTest extends \unittest\TestCase {
 
   #[@test]
   public function can_create_with_stream() {
-    new TextWriter(new MemoryOutputStream(''));
+    new TextWriter(new MemoryOutputStream());
   }
 
   #[@test]
   public function can_create_with_channel() {
-    new TextWriter(new File(__FILE__));
+    new TextWriter(newinstance('io.Channel', [], [
+      'in'  => function() { return new MemoryInputStream(''); },
+      'out' => function() { return new MemoryOutputStream(); }
+    ]));
   }
 
   #[@test, @expect(IllegalArgumentException::class)]


### PR DESCRIPTION
This pull request adds a new class `LinesIn` and a new method `TextReader::lines()` returning instanced of this class. With it the lines of the underlying stream can be iterated. Think of PHP's `file()` function but without first having to read the entire file into memory (plus, it works on any stream):

```php
use io\streams\TextReader;

$socket= ...;
$reader= new TextReader($socket);
foreach ($reader->lines() as $line) {
  // Process
}
```

Combining this with the great [Sequence](https://github.com/xp-forge/sequence) library would make the following possible:

```php
use io\File;
use io\streams\LinesIn;
use util\data\Sequence;
use util\data\Collectors;
use text\regex\Scanner;
use util\cmd\Console;

class Seq extends \lang\Object {

  public static function main($args) {
    $map= Sequence::of(new LinesIn(new File($args[0]), 'utf-8'))
      ->map('trim')
      ->filter(function($line) { return '' !== $line; })      // Ignore empty lines
      ->filter(function($line) { return '#' !== $line{0}; })  // Ignore comments
      ->map([new Scanner('%[^=]=%s'), 'match'])
      ->map(function($match) { return $match->group(0); })
      ->collect(Collectors::toMap(
        function($values) { return $values[1]; },
        function($values) { return isset($values[2]) ? $values[2] : null; }
      ))
    ;
    Console::writeLine($map);
  }
}
```

```sh
$ cat ini
# Ini file

key=value
color=green
runtime

$ xp Seq ini
util.collections.HashTable[3] {
  "key" => "value",
  "color" => "green",
  "runtime" => null
}
```