### PR TITLE
Deprecate io.ZipFile

### DIFF
--- a/src/main/php/io/ZipFile.class.php
+++ b/src/main/php/io/ZipFile.class.php
@@ -3,6 +3,7 @@
 /**
  * Represents a zip file
  *
+ * @deprecated See https://github.com/xp-framework/core/pull/78
  * @see     xp://io.File
  * @see     php://zlib
  * @ext     zlib


### PR DESCRIPTION
This PR suggests to deprecate the `io.ZipFile` class. Its name may suggest functionality like the [io.archive.zip library](https://github.com/xp-framework/zip), which it doesn't support - instead, it reads GZIP compressed data:

```sh
$ xp -w '$f= new \io\ZipFile("file.gz"); $f->open(FILE_MODE_READ); var_dump($f->read());'
io.ZipFile(uri= C:\cygwin\home\Timm\devel\xp\core\file.gz, mode= rb)
```

This can also be done by using the `GzDecompressingInputStream` class though. It's also not limited to files, but wraps any other input stream.

```sh
$ xp -w '(new \io\streams\GzDecompressingInputStream((new \io\File("file.gz"))->in()))->read()'
Hello World
```