### PR TITLE
Introduce File mode constants

### DIFF
--- a/src/main/php/io/EncapsedStream.class.php
+++ b/src/main/php/io/EncapsedStream.class.php
@@ -50,10 +50,10 @@ class EncapsedStream extends Stream {
   /**
    * Open the stream. For EncapsedStream only reading is supported
    *
-   * @param   string mode default FILE_MODE_READ one of the FILE_MODE_* constants
+   * @param   string mode default File::READ one of the File::* constants
    */
-  public function open($mode= FILE_MODE_READ) {
-    if (FILE_MODE_READ !== $mode) throw new \lang\IllegalAccessException(
+  public function open($mode= File::READ) {
+    if (File::READ !== $mode) throw new \lang\IllegalAccessException(
       'EncapsedStream only supports reading but writing operation requested.'
     );
   }

--- a/src/main/php/io/File.class.php
+++ b/src/main/php/io/File.class.php
@@ -5,7 +5,7 @@ use io\streams\FileOutputStream;
 use lang\IllegalArgumentException;
 use lang\IllegalStateException;
 
-// Mode constants for open() method
+// Deprecated mode constants for open() method (use class constants!)
 define('FILE_MODE_READ',      'rb');          // Read
 define('FILE_MODE_READWRITE', 'rb+');         // Read/Write
 define('FILE_MODE_WRITE',     'wb');          // Write

--- a/src/main/php/io/File.class.php
+++ b/src/main/php/io/File.class.php
@@ -2,6 +2,8 @@
 
 use io\streams\FileInputStream;
 use io\streams\FileOutputStream;
+use lang\IllegalArgumentException;
+use lang\IllegalStateException;
 
 // Mode constants for open() method
 define('FILE_MODE_READ',      'rb');          // Read
@@ -19,12 +21,19 @@ define('FILE_MODE_READAPPEND','ab+');         // Append (Read/Write)
  * @test xp://net.xp_framework.unittest.io.FileIntegrationTest
  */
 class File extends \lang\Object implements Channel {
+  const READ =      'rb';          // Read
+  const READWRITE = 'rb+';         // Read/Write
+  const WRITE =     'wb';          // Write
+  const REWRITE =   'wb+';         // Read/Write, truncate on open
+  const APPEND =    'ab';          // Append (Read-only)
+  const READAPPEND ='ab+';         // Append (Read/Write)
+
   public 
     $uri=         '', 
     $filename=    '',
     $path=        '',
     $extension=   '',
-    $mode=        FILE_MODE_READ;
+    $mode=        self::READ;
   
   protected $_fd= null;
   
@@ -33,7 +42,7 @@ class File extends \lang\Object implements Channel {
    *
    * ```php
    * // via resource
-   * $f= new File(fopen('lang/Type.class.php', FILE_MODE_READ));
+   * $f= new File(fopen('lang/Type.class.php', File::READ));
    *
    * // via filename
    * $f= new File('lang/Type.class.php');
@@ -139,15 +148,15 @@ class File extends \lang\Object implements Channel {
    * @throws  lang.IllegalArgumentException in case an invalid file name was given
    */
   public function setURI($uri) {
-    static $allowed= array('xar://*', 'php://stderr', 'php://stdout', 'php://stdin', 'res://*');
+    static $allowed= ['xar://*', 'php://stderr', 'php://stdout', 'php://stdin', 'res://*'];
 
     // Check validity, handle scheme and non-scheme URIs
     $uri= (string)$uri;
     if (0 === strlen($uri) || false !== strpos($uri, "\0")) {
-      throw new \lang\IllegalArgumentException('Invalid filename "'.addcslashes($uri, "\0..\17").'"');
+      throw new IllegalArgumentException('Invalid filename "'.addcslashes($uri, "\0..\17").'"');
     } else if (false !== ($s= strpos($uri, '://'))) {
       if (!in_array($uri, $allowed) && !in_array(substr($uri, 0, 6).'*', $allowed)) {
-        throw new \lang\IllegalArgumentException('Invalid scheme URI "'.$uri.'"');
+        throw new IllegalArgumentException('Invalid scheme URI "'.$uri.'"');
       }
       $this->uri= $uri;
       $p= max($s+ 3, false === ($pq= strpos($uri, '?', $s)) ? -1 : $pq+ 1);
@@ -171,17 +180,17 @@ class File extends \lang\Object implements Channel {
   /**
    * Open the file
    *
-   * @param   string mode one of the FILE_MODE_* constants
+   * @param   string mode one of the File::* constants
    * @return  bool TRUE if file could be opened
    * @throws  io.FileNotFoundException in case the file is not found
    * @throws  io.IOException in case the file cannot be opened (e.g., lacking permissions)
    */
-  public function open($mode= FILE_MODE_READ) {
+  public function open($mode= self::READ) {
     $this->mode= $mode;
     if (
-      0 != strncmp('php://', $this->uri, 6) &&
-      (FILE_MODE_READ == $mode) && 
-      (!$this->exists())
+      self::READ === $mode && 
+      0 !== strncmp('php://', $this->uri, 6) &&
+      !$this->exists()
     ) throw new FileNotFoundException('File "'.$this->uri.'" not found');
     
     $this->_fd= fopen($this->uri, $this->mode);
@@ -590,7 +599,7 @@ class File extends \lang\Object implements Channel {
    */
   public function unlink() {
     if (is_resource($this->_fd)) {
-      throw new \lang\IllegalStateException('File still open');
+      throw new IllegalStateException('File still open');
     }
     if (false === unlink($this->uri)) {
       $e= new IOException('Cannot delete file '.$this->uri);
@@ -613,7 +622,7 @@ class File extends \lang\Object implements Channel {
    */
   public function move($target) {
     if (is_resource($this->_fd)) {
-      throw new \lang\IllegalStateException('File still open');
+      throw new IllegalStateException('File still open');
     }
     
     if ($target instanceof self) {
@@ -647,7 +656,7 @@ class File extends \lang\Object implements Channel {
    */
   public function copy($target) {
     if (is_resource($this->_fd)) {
-      throw new \lang\IllegalStateException('File still open');
+      throw new IllegalStateException('File still open');
     }
 
     if ($target instanceof self) {

--- a/src/main/php/io/FileUtil.class.php
+++ b/src/main/php/io/FileUtil.class.php
@@ -29,7 +29,7 @@ class FileUtil extends \lang\Object {
       } while (!$file->eof());
     } else {
       clearstatcache();
-      $file->open(FILE_MODE_READ);
+      $file->open(File::READ);
       $size= $file->size();
 
       // Read until EOF. Best case scenario is that this will run exactly once.
@@ -60,7 +60,7 @@ class FileUtil extends \lang\Object {
     if ($file->isOpen()) {
       return $file->write($data);
     } else {
-      $file->open(FILE_MODE_WRITE);
+      $file->open(File::WRITE);
       $written= $file->write($data);
       $file->close();
       return $written;

--- a/src/main/php/io/SpoolDirectory.class.php
+++ b/src/main/php/io/SpoolDirectory.class.php
@@ -1,7 +1,5 @@
 <?php namespace io;
 
-use io\Folder;
-
 /**
  * This class handles all neccessary file and directory operations
  * for doing reliable spool operations.
@@ -62,7 +60,7 @@ class SpoolDirectory extends \lang\Object {
       $abstract= date ('Y-m-d-H-i-s').'_'.$abstract;
     
     $f= new File ($this->_hNew->getURI().DIRECTORY_SEPARATOR.$abstract.'.spool');
-    $f->open (FILE_MODE_WRITE);
+    $f->open (File::WRITE);
     return $f;
   }
 
@@ -86,7 +84,7 @@ class SpoolDirectory extends \lang\Object {
   public function getNextSpoolEntry() {
     if (false !== ($entry= $this->_hTodo->getEntry())) {
       $f= new File ($this->_hTodo->getURI().DIRECTORY_SEPARATOR.$entry);
-      $f->open (FILE_MODE_READWRITE);
+      $f->open (File::READWRITE);
     }
     
     return $f;

--- a/src/main/php/io/TempFile.class.php
+++ b/src/main/php/io/TempFile.class.php
@@ -10,7 +10,7 @@ use lang\System;
  *   uses('io.TempFile');
  *
  *   $f= new TempFile();
- *   $f->open(FILE_MODE_WRITE);
+ *   $f->open(File::WRITE);
  *   $f->write('Hello');
  *   $f->close();
  *

--- a/src/main/php/io/ZipFile.class.php
+++ b/src/main/php/io/ZipFile.class.php
@@ -12,16 +12,16 @@ class ZipFile extends File {
   /**
    * Open the file
    *
-   * @param   string mode one of the FILE_MODE_* constants
+   * @param   string mode one of the File::* constants
    * @param   string compression default ''
    * @throws  io.FileNotFoundException in case the file is not found
    * @throws  io.IOException in case the file cannot be opened (e.g., lacking permissions)
    */
-  public function open($mode= FILE_MODE_READ, $compression= '') {
+  public function open($mode= File::READ, $compression= '') {
     $this->mode= $mode;
     if (
       ('php://' != substr($this->uri, 0, 6)) &&
-      (FILE_MODE_READ == $mode) && 
+      (File::READ == $mode) && 
       (!$this->exists())
     ) throw new FileNotFoundException('File "'.$this->uri.'" not found');
     

--- a/src/main/php/io/package-info.xp
+++ b/src/main/php/io/package-info.xp
@@ -21,7 +21,7 @@
  * one could use the following sourcecode:
  * <code>
  *   $f= new File(new Folder('c:'), 'autoexec.bat');
- *   $f->open(FILE_MODE_READ);
+ *   $f->open(File::READ);
  *   while ($chunk= $f->read()) {
  *     Console::writeLine($chunk);
  *   }
@@ -39,7 +39,7 @@
  * io.TempFile class:
  * <code>
  *   with ($t= new TempFile()); {
- *     $t->open(FILE_MODE_WRITE);
+ *     $t->open(File::WRITE);
  *     $t->write('Hello');
  *     $t->close();
  *   }

--- a/src/main/php/io/streams/FileInputStream.class.php
+++ b/src/main/php/io/streams/FileInputStream.class.php
@@ -17,7 +17,7 @@ class FileInputStream extends \lang\Object implements InputStream, Seekable {
    */
   public function __construct($file) {
     $this->file= $file instanceof File ? $file : new File($file);
-    $this->file->isOpen() || $this->file->open(FILE_MODE_READ);
+    $this->file->isOpen() || $this->file->open(File::READ);
   }
 
   /**

--- a/src/main/php/io/streams/FileOutputStream.class.php
+++ b/src/main/php/io/streams/FileOutputStream.class.php
@@ -18,7 +18,7 @@ class FileOutputStream extends \lang\Object implements OutputStream {
    */
   public function __construct($file, $append= false) {
     $this->file= $file instanceof File ? $file : new File($file);
-    $this->file->isOpen() || $this->file->open($append ? FILE_MODE_APPEND : FILE_MODE_WRITE);
+    $this->file->isOpen() || $this->file->open($append ? File::APPEND : File::WRITE);
   }
 
   /**

--- a/src/main/php/lang/ResourceProvider.class.php
+++ b/src/main/php/lang/ResourceProvider.class.php
@@ -42,7 +42,7 @@ class ResourceProvider extends Object {
     if ($mode !== 'r' && $mode !== 'rb') return false;
 
     $this->resource= $this->getLoader()->getResourceAsStream(self::$instance->translatePath($path));
-    $this->resource->open(FILE_MODE_READ);
+    $this->resource->open(File::READ);
 
     return true;
   }

--- a/src/main/php/lang/ResourceProvider.class.php
+++ b/src/main/php/lang/ResourceProvider.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang;
 
+use io\File;
+
 /**
  * Provides a resource through a scheme.
  *

--- a/src/main/php/lang/archive/Archive.class.php
+++ b/src/main/php/lang/archive/Archive.class.php
@@ -3,6 +3,7 @@
 use lang\ElementNotFoundException;
 use io\EncapsedStream;
 use io\FileUtil;
+use io\File;
 
 define('ARCHIVE_READ',             0x0000);
 define('ARCHIVE_CREATE',           0x0001);

--- a/src/main/php/lang/archive/Archive.class.php
+++ b/src/main/php/lang/archive/Archive.class.php
@@ -174,7 +174,7 @@ class Archive extends \lang\Object {
     );
     
     try {
-      $this->file->isOpen() || $this->file->open(FILE_MODE_READ);
+      $this->file->isOpen() || $this->file->open(File::READ);
       $this->file->seek($pos, SEEK_SET);
       $data= $this->file->read($this->_index[$id][0]);
     } catch (\lang\XPException $e) {
@@ -225,7 +225,7 @@ class Archive extends \lang\Object {
         if ($this->file->isOpen()) {
           $this->file->seek(0, SEEK_SET);
         } else {
-          $this->file->open(FILE_MODE_READ);
+          $this->file->open(File::READ);
         }
 
         // Read header
@@ -253,7 +253,7 @@ class Archive extends \lang\Object {
         if ($this->file->isOpen()) {
           return $this->file->tell() > 0 ? $this->file->truncate() : true;
         } else {
-          return $this->file->open(FILE_MODE_WRITE);
+          return $this->file->open(File::WRITE);
         }
     }
     

--- a/src/main/php/security/Policy.class.php
+++ b/src/main/php/security/Policy.class.php
@@ -69,7 +69,7 @@ class Policy extends \lang\Object {
     
     $policy= new Policy();
     
-    $stream->open(FILE_MODE_READ);
+    $stream->open(File::READ);
     $state= PF_ST_INITIAL;
     $num= 0;
     do {

--- a/src/main/php/security/auth/HtpasswdAuthenticator.class.php
+++ b/src/main/php/security/auth/HtpasswdAuthenticator.class.php
@@ -33,7 +33,7 @@ class HtpasswdAuthenticator extends \lang\Object implements Authenticator {
     if ($this->_file->lastModified() != $this->_modified) {
       $hash= [];
       try {
-        $this->_file->open(FILE_MODE_READ);
+        $this->_file->open(File::READ);
         while ($line= $this->_file->readLine()) {
           list($username, $crypt)= explode(':', $line, 2);
           $hash[$username]= $crypt;

--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -8,6 +8,8 @@ use io\streams\MemoryOutputStream;
 use io\streams\FileInputStream;
 use io\streams\TextReader;
 use text\TextTokenizer;
+use lang\FormatException;
+use lang\IllegalStateException;
 
 /**
  * An interface to property-files (aka "ini-files")
@@ -67,7 +69,7 @@ class Properties extends \lang\Object implements PropertyAccess {
         continue;                    
       } else if ('[' === $c) {
         if (false === ($p= strrpos($trimmedToken, ']'))) {
-          throw new \lang\FormatException('Unclosed section "'.$trimmedToken.'"');
+          throw new FormatException('Unclosed section "'.$trimmedToken.'"');
         }
         $section= substr($trimmedToken, 1, $p- 1);
         $this->_data[$section]= [];
@@ -92,7 +94,7 @@ class Properties extends \lang\Object implements PropertyAccess {
         // Arrays and maps: key[], key[0], key[assoc]
         if (']' === substr($key, -1)) {
           if (false === ($p= strpos($key, '['))) {
-            throw new \lang\FormatException('Invalid key "'.$key.'"');
+            throw new FormatException('Invalid key "'.$key.'"');
           }
           $offset= substr($key, $p+ 1, -1);
           $key= substr($key, 0, $p);
@@ -108,7 +110,7 @@ class Properties extends \lang\Object implements PropertyAccess {
           $this->_data[$section][$key]= $value;
         }
       } else if ('' !== trim($t)) {
-        throw new \lang\FormatException('Invalid line "'.$t.'"');
+        throw new FormatException('Invalid line "'.$t.'"');
       }
     }
   }
@@ -195,7 +197,7 @@ class Properties extends \lang\Object implements PropertyAccess {
   public function create() {
     if (null !== $this->_file) {
       $fd= new File($this->_file);
-      $fd->open(FILE_MODE_WRITE);
+      $fd->open(File::WRITE);
       $fd->close();
     }
     $this->_data= [];
@@ -583,7 +585,7 @@ class Properties extends \lang\Object implements PropertyAccess {
    */
   public function removeSection($section) {
     $this->_load();
-    if (!isset($this->_data[$section])) throw new \lang\IllegalStateException('Cannot remove nonexistant section "'.$section.'"');
+    if (!isset($this->_data[$section])) throw new IllegalStateException('Cannot remove nonexistant section "'.$section.'"');
     unset($this->_data[$section]);
   }
 
@@ -596,7 +598,7 @@ class Properties extends \lang\Object implements PropertyAccess {
    */
   public function removeKey($section, $key) {
     $this->_load();
-    if (!isset($this->_data[$section][$key])) throw new \lang\IllegalStateException('Cannot remove nonexistant key "'.$key.'" in "'.$section.'"');
+    if (!isset($this->_data[$section][$key])) throw new IllegalStateException('Cannot remove nonexistant key "'.$key.'" in "'.$section.'"');
     unset($this->_data[$section][$key]);
   }
 

--- a/src/main/php/util/cmd/SingleProcess.class.php
+++ b/src/main/php/util/cmd/SingleProcess.class.php
@@ -39,7 +39,7 @@ class SingleProcess extends \lang\Object {
    */
   public function lock() {
     try {
-      $this->lockfile->open(FILE_MODE_WRITE);
+      $this->lockfile->open(File::WRITE);
       $this->lockfile->lockExclusive();
     } catch (\io\IOException $e) {
       $this->lockfile->close();

--- a/src/main/php/xp/xar/instruction/DiffInstruction.class.php
+++ b/src/main/php/xp/xar/instruction/DiffInstruction.class.php
@@ -91,8 +91,8 @@ class DiffInstruction extends AbstractInstruction {
     with (
       $templ= new TempFile(),
       $tempr= new TempFile(),
-      $templ->open(FILE_MODE_WRITE),
-      $tempr->open(FILE_MODE_WRITE)
+      $templ->open(File::WRITE),
+      $tempr->open(File::WRITE)
     ); {
       $templ->write($left);
       $tempr->write($right);

--- a/src/test/php/net/xp_framework/unittest/io/EncapsedStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/EncapsedStreamTest.class.php
@@ -33,12 +33,12 @@ class EncapsedStreamTest extends TestCase {
   
   #[@test]
   public function open_for_reading() {
-    $this->newStream()->open(FILE_MODE_READ);
+    $this->newStream()->open(File::READ);
   }
 
   #[@test, @expect('lang.IllegalAccessException')]
   public function cannot_open_for_writing() {
-    $this->newStream()->open(FILE_MODE_WRITE);
+    $this->newStream()->open(File::WRITE);
   }
   
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/io/FileIntegrationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/FileIntegrationTest.class.php
@@ -1,17 +1,16 @@
 <?php namespace net\xp_framework\unittest\io;
 
-use unittest\TestCase;
 use io\File;
 use io\Folder;
 use lang\System;
-
+use unittest\PrerequisitesNotMetError;
 
 /**
  * TestCase
  *
  * @see      xp://io.File
  */
-class FileIntegrationTest extends TestCase {
+class FileIntegrationTest extends \unittest\TestCase {
   protected static $temp= null;
   protected $file= null;
   protected $folder= null;
@@ -24,10 +23,10 @@ class FileIntegrationTest extends TestCase {
   public static function verifyTempDir() {
     self::$temp= System::tempDir();
     if (!is_writeable(self::$temp)) {
-      throw new \unittest\PrerequisitesNotMetError('$TEMP is not writeable', null, array(self::$temp.' +w'));
+      throw new PrerequisitesNotMetError('$TEMP is not writeable', null, array(self::$temp.' +w'));
     }
     if (($df= disk_free_space(self::$temp)) < 10240) {
-      throw new \unittest\PrerequisitesNotMetError('Not enough space available in $TEMP', null, array(sprintf(
+      throw new PrerequisitesNotMetError('Not enough space available in $TEMP', null, array(sprintf(
         'df %s = %.0fk > 10k',
         self::$temp,
         $df / 1024
@@ -90,7 +89,7 @@ class FileIntegrationTest extends TestCase {
    * @throws  io.IOException
    */
   protected function writeData($file, $data= null, $append= false) {
-    $file->open($append ? FILE_MODE_APPEND : FILE_MODE_WRITE);
+    $file->open($append ? File::APPEND : File::WRITE);
     if (null === $data) {
       $written= 0;
     } else {
@@ -110,7 +109,7 @@ class FileIntegrationTest extends TestCase {
    * @return  string
    */
   protected function readData($file, $length= -1) {
-    $file->open(FILE_MODE_READ);
+    $file->open(File::READ);
     $data= $file->read($length < 0 ? $file->size() : $length);
     $file->close();
     return $data;
@@ -161,7 +160,7 @@ class FileIntegrationTest extends TestCase {
    */
   #[@test, @expect('lang.IllegalStateException')]
   public function cannotDeleteOpenFile() {
-    $this->file->open(FILE_MODE_WRITE);
+    $this->file->open(File::WRITE);
     $this->file->unlink();
   }
 
@@ -192,7 +191,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals($data, $this->file->read(strlen($data)));
       $this->file->close();
     }
@@ -207,7 +206,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals('', $this->file->read(0));
       $this->file->close();
     }
@@ -222,7 +221,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals($data, $this->file->read(strlen($data)));
       $this->assertFalse($this->file->read(1));
       $this->file->close();
@@ -238,7 +237,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals($data, $this->file->gets());
       $this->file->close();
     }
@@ -253,7 +252,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals('', $this->file->gets(0));
       $this->file->close();
     }
@@ -268,7 +267,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= "Hello\nWorld\n"); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals("Hello\n", $this->file->gets());
       $this->assertEquals("World\n", $this->file->gets());
       $this->file->close();
@@ -284,7 +283,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals('Hello', $this->file->gets());
       $this->assertFalse($this->file->gets());
       $this->file->close();
@@ -300,7 +299,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals($data, $this->file->readLine());
       $this->file->close();
     }
@@ -315,7 +314,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals('', $this->file->readLine(0));
       $this->file->close();
     }
@@ -330,7 +329,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= "Hello\nWorld\n"); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals('Hello', $this->file->readLine());
       $this->assertEquals('World', $this->file->readLine());
       $this->file->close();
@@ -346,7 +345,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals('Hello', $this->file->readLine());
       $this->assertFalse($this->file->readLine());
       $this->file->close();
@@ -362,7 +361,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals($data{0}, $this->file->readChar());
       $this->file->close();
     }
@@ -377,7 +376,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'Hello'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals($data{0}, $this->file->readChar());
       $this->assertEquals($data{1}, $this->file->readChar());
       $this->file->close();
@@ -393,7 +392,7 @@ class FileIntegrationTest extends TestCase {
     with ($data= 'H'); {
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals('H', $this->file->readChar());
       $this->assertFalse($this->file->readChar());
       $this->file->close();
@@ -410,7 +409,7 @@ class FileIntegrationTest extends TestCase {
       $this->writeData($this->file, $appear);
       $this->writeData($this->file, $data);
 
-      $this->file->open(FILE_MODE_READ);
+      $this->file->open(File::READ);
       $this->assertEquals($data, $this->file->read(strlen($data)));
       $this->file->close();
     }
@@ -436,7 +435,7 @@ class FileIntegrationTest extends TestCase {
    */
   #[@test, @expect('io.FileNotFoundException')]
   public function cannotOpenNonExistantForReading() {
-    $this->file->open(FILE_MODE_READ);
+    $this->file->open(File::READ);
   }
 
   /**
@@ -484,7 +483,7 @@ class FileIntegrationTest extends TestCase {
    */
   #[@test, @expect('lang.IllegalStateException')]
   public function cannotCopyOpenFile() {
-    $this->file->open(FILE_MODE_WRITE);
+    $this->file->open(File::WRITE);
     $this->file->copy('irrelevant');
   }
 
@@ -541,7 +540,7 @@ class FileIntegrationTest extends TestCase {
    */
   #[@test, @expect('lang.IllegalStateException')]
   public function cannotMoveOpenFile() {
-    $this->file->open(FILE_MODE_WRITE);
+    $this->file->open(File::WRITE);
     $this->file->move('irrelevant');
   }
 

--- a/src/test/php/net/xp_framework/unittest/reflection/ResourcesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ResourcesTest.class.php
@@ -55,7 +55,7 @@ class ResourcesTest extends TestCase {
   public function getResourceAsStream() {
     $stream= \lang\ClassLoader::getDefault()->getResourceAsStream('META-INF/manifest.ini');
     $this->assertInstanceOf('io.File', $stream);
-    $stream->open(FILE_MODE_READ);
+    $stream->open(File::READ);
     $this->assertManifestFile($stream->read($stream->size()));
     $stream->close();
   }


### PR DESCRIPTION
This pull request adds class constants instead of the global `FILE_MODE_*` constants. To adopt your code, replace "FILE_MODE_" by the string "File::" as seen in this PR's diffs.

```php
$f= new File('tests');
$f->open(File::READ);  // Instead of $f->open(FILE_MODE_READ);
...
$f->close();
```