### PR TITLE
Introduce Archive constants

### DIFF
--- a/src/main/php/io/collections/ArchiveCollection.class.php
+++ b/src/main/php/io/collections/ArchiveCollection.class.php
@@ -1,5 +1,7 @@
 <?php namespace io\collections;
 
+use lang\archive\Archive;
+
 /**
  * Archive collection
  *

--- a/src/main/php/io/collections/ArchiveCollection.class.php
+++ b/src/main/php/io/collections/ArchiveCollection.class.php
@@ -47,7 +47,7 @@ class ArchiveCollection extends \lang\Object implements IOCollection {
    *
    */
   public function open() { 
-    $this->archive->isOpen() || $this->archive->open(ARCHIVE_READ);
+    $this->archive->isOpen() || $this->archive->open(Archive::READ);
     reset($this->archive->_index);
     $this->_dirs= [];
   }

--- a/src/main/php/io/collections/ArchiveElement.class.php
+++ b/src/main/php/io/collections/ArchiveElement.class.php
@@ -20,7 +20,7 @@ class ArchiveElement extends \lang\Object implements IOElement {
    * @param   string name
    */
   public function __construct(Archive $archive, $name) {
-    $archive->isOpen() || $archive->open(ARCHIVE_READ);
+    $archive->isOpen() || $archive->open(Archive::READ);
     $this->archive= $archive;
     $this->name= $name;
   }

--- a/src/main/php/lang/archive/Archive.class.php
+++ b/src/main/php/lang/archive/Archive.class.php
@@ -4,6 +4,7 @@ use lang\ElementNotFoundException;
 use io\EncapsedStream;
 use io\FileUtil;
 
+// Deprecated
 define('ARCHIVE_READ',             0x0000);
 define('ARCHIVE_CREATE',           0x0001);
 define('ARCHIVE_HEADER_SIZE',      0x0100);
@@ -15,7 +16,7 @@ define('ARCHIVE_INDEX_ENTRY_SIZE', 0x0100);
  * Usage example (Creating):
  * ```php
  * $a= new Archive(new File('soap.xar'));
- * $a->open(ARCHIVE_CREATE);
+ * $a->open(self::CREATE);
  * $a->addFile(
  *   'webservices/soap/SOAPMessage.class.php'
  *   new File($path, 'xml/soap/SOAPMessage.class.php')
@@ -35,6 +36,11 @@ define('ARCHIVE_INDEX_ENTRY_SIZE', 0x0100);
  * @see   http://java.sun.com/javase/6/docs/api/java/util/jar/package-summary.html
  */
 class Archive extends \lang\Object {
+  const READ =              0x0000;
+  const CREATE =            0x0001;
+  const HEADER_SIZE =       0x0100;
+  const INDEX_ENTRY_SIZE =  0x0100;
+
   public
     $file     = null,
     $version  = 2;
@@ -131,7 +137,7 @@ class Archive extends \lang\Object {
    * Get entry (iterative use)
    * <code>
    *   $a= new Archive(new File('port.xar'));
-   *   $a->open(ARCHIVE_READ);
+   *   $a->open(self::READ);
    *   while ($id= $a->getEntry()) {
    *     var_dump($id);
    *   }
@@ -168,8 +174,8 @@ class Archive extends \lang\Object {
 
     // Calculate starting position      
     $pos= (
-      ARCHIVE_HEADER_SIZE + 
-      sizeof(array_keys($this->_index)) * ARCHIVE_INDEX_ENTRY_SIZE +
+      self::HEADER_SIZE + 
+      sizeof(array_keys($this->_index)) * self::INDEX_ENTRY_SIZE +
       $this->_index[$id][1]
     );
     
@@ -198,8 +204,8 @@ class Archive extends \lang\Object {
 
     // Calculate starting position      
     $pos= (
-      ARCHIVE_HEADER_SIZE + 
-      sizeof(array_keys($this->_index)) * ARCHIVE_INDEX_ENTRY_SIZE +
+      self::HEADER_SIZE + 
+      sizeof(array_keys($this->_index)) * self::INDEX_ENTRY_SIZE +
       $this->_index[$id][1]
     );
     
@@ -209,7 +215,7 @@ class Archive extends \lang\Object {
   /**
    * Open this archive
    *
-   * @param   int mode default ARCHIVE_READ one of ARCHIVE_READ | ARCHIVE_CREATE
+   * @param   int mode default self::READ one of self::READ | self::CREATE
    * @return  bool success
    * @throws  lang.IllegalArgumentException in case an illegal mode was specified
    * @throws  lang.FormatException in case the header is malformed
@@ -221,7 +227,7 @@ class Archive extends \lang\Object {
     ];
     
     switch ($mode) {
-      case ARCHIVE_READ:      // Load
+      case self::READ:      // Load
         if ($this->file->isOpen()) {
           $this->file->seek(0, SEEK_SET);
         } else {
@@ -229,7 +235,7 @@ class Archive extends \lang\Object {
         }
 
         // Read header
-        $header= $this->file->read(ARCHIVE_HEADER_SIZE);
+        $header= $this->file->read(self::HEADER_SIZE);
         $data= unpack('a3id/c1version/V1indexsize/a*reserved', $header);
 
         // Check header integrity
@@ -244,12 +250,12 @@ class Archive extends \lang\Object {
         
         // Read index
         for ($i= 0; $i < $data['indexsize']; $i++) {
-          $entry= unpack($unpack[$this->version], $this->file->read(ARCHIVE_INDEX_ENTRY_SIZE));
+          $entry= unpack($unpack[$this->version], $this->file->read(self::INDEX_ENTRY_SIZE));
           $this->_index[rtrim($entry['id'], "\0")]= [$entry['size'], $entry['offset'], null];
         }
         return true;
         
-      case ARCHIVE_CREATE:    // Create
+      case self::CREATE:    // Create
         if ($this->file->isOpen()) {
           return $this->file->tell() > 0 ? $this->file->truncate() : true;
         } else {

--- a/src/main/php/xp/xar/instruction/CreateInstruction.class.php
+++ b/src/main/php/xp/xar/instruction/CreateInstruction.class.php
@@ -73,7 +73,7 @@ class CreateInstruction extends AbstractInstruction {
    * @return  void
    */
   public function perform() {
-    $this->archive->open(ARCHIVE_CREATE);
+    $this->archive->open(Archive::CREATE);
     $this->addAll($this->getArguments(), new Path(realpath(getcwd())));
     $this->archive->create();
   }

--- a/src/main/php/xp/xar/instruction/DiffInstruction.class.php
+++ b/src/main/php/xp/xar/instruction/DiffInstruction.class.php
@@ -15,14 +15,14 @@ class DiffInstruction extends AbstractInstruction {
    * @return  int
    */
   public function perform() {
-    $this->archive->open(ARCHIVE_READ);
+    $this->archive->open(Archive::READ);
     
     $args= $this->getArguments();
     if (!isset($args[0]) || !file_exists(current($args)))
       throw new \lang\IllegalArgumentException('No archive to compare given or not found.');
 
     $cmp= new \lang\archive\Archive(new \io\File(current($args)));
-    $cmp->open(ARCHIVE_READ);
+    $cmp->open(Archive::READ);
     
     return $this->compare($this->archive, $cmp);
   }

--- a/src/main/php/xp/xar/instruction/ExtractInstruction.class.php
+++ b/src/main/php/xp/xar/instruction/ExtractInstruction.class.php
@@ -42,7 +42,7 @@ class ExtractInstruction extends AbstractInstruction {
    * @return  int
    */
   public function perform() {
-    $this->archive->open(ARCHIVE_READ);
+    $this->archive->open(Archive::READ);
     
     $args= $this->getArguments();
     while ($entry= $this->archive->getEntry()) {

--- a/src/main/php/xp/xar/instruction/MergeInstruction.class.php
+++ b/src/main/php/xp/xar/instruction/MergeInstruction.class.php
@@ -15,12 +15,12 @@ class MergeInstruction extends AbstractInstruction {
    * @return  int
    */
   public function perform() {
-    $this->archive->open(ARCHIVE_CREATE);
+    $this->archive->open(Archive::CREATE);
 
     $args= $this->getArguments();
     foreach ($args as $arg) {
       $archive= new Archive(new File($arg));
-      $archive->open(ARCHIVE_READ);
+      $archive->open(Archive::READ);
 
       while ($entry= $archive->getEntry()) {
 

--- a/src/main/php/xp/xar/instruction/ShowInstruction.class.php
+++ b/src/main/php/xp/xar/instruction/ShowInstruction.class.php
@@ -37,7 +37,7 @@ class ShowInstruction extends AbstractInstruction {
    * @return  int
    */
   public function perform() {
-    $this->archive->open(ARCHIVE_READ);
+    $this->archive->open(Archive::READ);
     
     $args= $this->getArguments();
     while ($entry= $this->archive->getEntry()) {

--- a/src/test/php/net/xp_framework/unittest/archive/ArchiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/archive/ArchiveTest.class.php
@@ -31,7 +31,7 @@ abstract class ArchiveTest extends TestCase {
    * @throws  unittest.AssertionFailedError
    */
   protected function assertEntries(Archive $a, array $entries) {
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $actual= [];
     while ($key= $a->getEntry()) {
       $actual[$key]= $a->extract($key);
@@ -58,55 +58,55 @@ abstract class ArchiveTest extends TestCase {
   #[@test, @expect('lang.FormatException')]
   public function open_non_archive() {
     $a= new Archive($this->file(0));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
   }
 
   #[@test]
   public function version_equals_stream_version() {
     $a= new Archive($this->file($this->version()));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertEquals($this->version(), $a->version);
   }
 
   #[@test]
   public function version_equals_resource_version() {
     $a= new Archive($this->getClass()->getPackage()->getResourceAsStream('v'.$this->version().'.xar'));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertEquals($this->version(), $a->version);
   }
 
   #[@test]
   public function contains_non_existant() {
     $a= new Archive($this->file($this->version()));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertFalse($a->contains('DOES-NOT-EXIST'));
   }
 
   #[@test, @expect('lang.ElementNotFoundException')]
   public function extract_non_existant() {
     $a= new Archive($this->file($this->version()));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $a->extract('DOES-NOT-EXIST');
   }
 
   #[@test]
   public function entries_for_empty_archive_are_an_empty_array() {
     $a= new Archive($this->file($this->version()));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertEntries($a, []);
   }
 
   #[@test]
   public function contains_existant() {
     $a= new Archive($this->getClass()->getPackage()->getResourceAsStream('v'.$this->version().'.xar'));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertTrue($a->contains('contained.txt'));
   }
 
   #[@test]
   public function entries_contain_file() {
     $a= new Archive($this->getClass()->getPackage()->getResourceAsStream('v'.$this->version().'.xar'));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertEntries($a, ['contained.txt' => "This file is contained in an archive!\n"]);
   }
 
@@ -114,7 +114,7 @@ abstract class ArchiveTest extends TestCase {
   public function creating_empty_archive() {
     $out= new MemoryOutputStream();
     $a= new Archive(new File(Streams::writeableFd($out)));
-    $a->open(ARCHIVE_CREATE);
+    $a->open(Archive::CREATE);
     $a->create();
     
     $file= new File(Streams::readableFd(new MemoryInputStream($out->getBytes())));
@@ -130,7 +130,7 @@ abstract class ArchiveTest extends TestCase {
 
     $out= new MemoryOutputStream();
     $a= new Archive(new File(Streams::writeableFd($out)));
-    $a->open(ARCHIVE_CREATE);
+    $a->open(Archive::CREATE);
     foreach ($contents as $filename => $bytes) {
       $a->addBytes($filename, $bytes);
     };

--- a/src/test/php/net/xp_framework/unittest/archive/ArchiveV2Test.class.php
+++ b/src/test/php/net/xp_framework/unittest/archive/ArchiveV2Test.class.php
@@ -15,7 +15,7 @@ class ArchiveV2Test extends ArchiveTest {
   #[@test]
   public function read_empty_archive_with_version_1() {
     $a= new Archive($this->file(1));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertEquals(1, $a->version);
     $this->assertEntries($a, []);
   }
@@ -23,21 +23,21 @@ class ArchiveV2Test extends ArchiveTest {
   #[@test]
   public function archive_with_version_1() {
     $a= new Archive($this->getClass()->getPackage()->getResourceAsStream('v1.xar'));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertEquals(1, $a->version);
   }
 
   #[@test]
   public function archive_version_1_contains_contained_text_file() {
     $a= new Archive($this->getClass()->getPackage()->getResourceAsStream('v1.xar'));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertTrue($a->contains('contained.txt'));
   }
 
   #[@test]
   public function archive_version_1_contents() {
     $a= new Archive($this->getClass()->getPackage()->getResourceAsStream('v1.xar'));
-    $a->open(ARCHIVE_READ);
+    $a->open(Archive::READ);
     $this->assertEntries($a, ['contained.txt' => "This file is contained in an archive!\n"]);
   }
 }

--- a/src/test/php/net/xp_framework/unittest/io/collections/ArchiveCollectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/ArchiveCollectionTest.class.php
@@ -20,7 +20,7 @@ class ArchiveCollectionTest extends TestCase {
   public function setUp() {
     $this->file= new TempFile();
     $this->archive= new Archive($this->file);
-    $this->archive->open(ARCHIVE_CREATE);
+    $this->archive->open(Archive::CREATE);
     $this->archive->addBytes('lang/Object.xp', 'class Object { }');
     $this->archive->addBytes('lang/Type.xp', 'class Type extends Object { }');
     $this->archive->addBytes('lang/reflect/Method.xp', 'class Method extends Object { }');

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassFromArchiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassFromArchiveTest.class.php
@@ -36,7 +36,7 @@ class ClassFromArchiveTest extends ClassFromUriTest {
 
       public function create() {
         $this->t= new \lang\archive\Archive(new \io\TempFile("arcl"));
-        $this->t->open(ARCHIVE_CREATE);
+        $this->t->open(Archive::CREATE);
       }
 
       public function delete() {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassFromArchiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassFromArchiveTest.class.php
@@ -36,7 +36,7 @@ class ClassFromArchiveTest extends ClassFromUriTest {
 
       public function create() {
         $this->t= new \lang\archive\Archive(new \io\TempFile("arcl"));
-        $this->t->open(Archive::CREATE);
+        $this->t->open(\lang\archive\Archive::CREATE);
       }
 
       public function delete() {


### PR DESCRIPTION
Like #79, this PR introduces Archive class constants and deprecates the global ARCHIVE_* constants.