### PR TITLE
Feature: Folder entries

### DIFF
--- a/src/main/php/io/Folder.class.php
+++ b/src/main/php/io/Folder.class.php
@@ -22,8 +22,7 @@ class Folder extends \lang\Object {
     $dirname  = '',
     $path     = '';
   
-  public
-    $_hdir= false;
+  private $_hdir = false;
     
   /**
    * Constructor
@@ -46,7 +45,6 @@ class Folder extends \lang\Object {
   
   /**
    * Destructor
-   *
    */
   public function __destruct() {
     $this->close();
@@ -205,10 +203,14 @@ class Folder extends \lang\Object {
   public function exists() {
     return is_dir($this->uri);
   }
-  
+
+  /** @return io.FolderEntries */
+  public function entries() { return new FolderEntries($this); }
+
   /**
    * Read through the contents of the directory, ommitting the entries "." and ".."
    *
+   * @deprecated Use entries() instead
    * @return  string entry directory entry (w/o path!), FALSE, if no more entries are left
    * @throws  io.IOException in case an error occurs
    */
@@ -231,6 +233,7 @@ class Folder extends \lang\Object {
   /**
    * Rewinds the directory to the beginning.
    *
+   * @deprecated Use entries() instead
    * @throws  io.IOException in case an error occurs
    */
   public function rewind() {
@@ -322,6 +325,7 @@ class Folder extends \lang\Object {
   /**
    * Return if the folder was already opened
    *
+   * @deprecated Use entries() instead
    * @return  bool
    */
   public function isOpen() {

--- a/src/main/php/io/FolderEntries.class.php
+++ b/src/main/php/io/FolderEntries.class.php
@@ -9,7 +9,6 @@ use lang\IllegalArgumentException;
  * @see   xp://io.Folder#entries
  */
 class FolderEntries extends \lang\Object implements \Iterator {
-  const EOF = -1;
   private $base, $entry;
   private $handle= null;
 

--- a/src/main/php/io/FolderEntries.class.php
+++ b/src/main/php/io/FolderEntries.class.php
@@ -1,0 +1,78 @@
+<?php namespace io;
+
+use lang\IllegalArgumentException;
+
+/**
+ * Folder entries provi
+ *
+ * @test  xp://net.xp_framework.unittest.io.FolderEntriesTest
+ * @see   xp://io.Folder#entries
+ */
+class FolderEntries extends \lang\Object implements \Iterator {
+  const EOF = -1;
+  private $base, $entry;
+  private $handle= null;
+
+  /**
+   * Creates a new Folder entries object
+   *
+   * @param  var... $args Either an io.Folder, an io.Path or a string
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct() {
+    $this->base= Path::compose(func_get_args());
+    if ($this->base->isEmpty()) {
+      throw new IllegalArgumentException('Cannot create from empty name');
+    }
+  }
+
+  /**
+   * Returns a path by a given name inside this folder
+   *
+   * @param  string $name
+   * @return io.Path
+   */
+  public function named($name) {
+    return new Path($this->base, $name);
+  }
+
+  /** @return string */
+  public function current() { return new Path($this->base, $this->entry); }
+
+  /** @return string */
+  public function key() { return $this->entry; }
+
+  /** @return bool */
+  public function valid() { return false !== $this->entry; }
+
+  /** @return void */
+  public function next() {
+    do {
+      $entry= readdir($this->handle);
+    } while ('.' === $entry || '..' === $entry);
+    $this->entry= $entry;
+  }
+
+  /** @return void */
+  public function rewind() {
+    if (null === $this->handle) {
+      if (!is_resource($handle= opendir($this->base->asFolder()->getURI()))) {
+        $e= new IOException('Cannot open folder '.$this->base);
+        \xp::gc(__FILE__);
+        throw $e;
+      }
+      $this->handle= $handle;
+    } else {
+      rewinddir($this->handle);
+    }
+    $this->next();
+  }
+
+  /** @return void */
+  public function __destruct() {
+    if (null !== $this->handle) {
+      closedir($this->handle);
+      $this->handle= null;
+    }
+  }
+}

--- a/src/main/php/io/FolderEntries.class.php
+++ b/src/main/php/io/FolderEntries.class.php
@@ -3,7 +3,7 @@
 use lang\IllegalArgumentException;
 
 /**
- * Folder entries provi
+ * Folder entries provides an iterable view of the files inside a given folder
  *
  * @test  xp://net.xp_framework.unittest.io.FolderEntriesTest
  * @see   xp://io.Folder#entries

--- a/src/main/php/io/Path.class.php
+++ b/src/main/php/io/Path.class.php
@@ -111,6 +111,15 @@ class Path extends \lang\Object {
   }
 
   /**
+   * Tests whether this path references an empty string
+   *
+   * @return bool
+   */
+  public function isEmpty() {
+    return '' === $this->path;
+  }
+
+  /**
    * Realpath
    *
    * @see    php://realpath

--- a/src/main/php/io/package-info.xp
+++ b/src/main/php/io/package-info.xp
@@ -11,10 +11,9 @@
  * omitting the "." and ".." entries:
  * <code>
  *   $usr= new Folder('/usr');
- *   foreach ($usr->getEntry() as $name) {
+ *   foreach ($usr->entries() as $name => $path) {
  *     Console::writeLine('- ', $name);
  *   }
- *   $usr->close();
  * </code>
  *
  * An io.File object represents a file. To sequentially read a file,

--- a/src/test/config/unittest/io.ini
+++ b/src/test/config/unittest/io.ini
@@ -83,3 +83,6 @@ class="net.xp_framework.unittest.io.streams.StringWriterTest"
 
 [lines]
 class="net.xp_framework.unittest.io.streams.LinesInTest"
+
+[folder-entries]
+class="net.xp_framework.unittest.io.FolderEntriesTest"

--- a/src/test/php/net/xp_framework/unittest/io/FolderEntriesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/FolderEntriesTest.class.php
@@ -1,0 +1,106 @@
+<?php namespace net\xp_framework\unittest\io;
+
+use io\Folder;
+use io\Path;
+use io\File;
+use io\FolderEntries;
+use lang\System;
+use lang\IllegalArgumentException;
+
+class FolderEntriesTest extends \unittest\TestCase {
+  private $folder;
+
+  /**
+   * Sets up test case - initializes temp directory in %TEMP%
+   *
+   * @return void
+   */
+  public function setUp() {
+    $this->folder= new Folder(System::tempDir(), md5(uniqid()).'.xp');
+    $this->folder->exists() && $this->folder->unlink();
+    $this->folder->create();
+  }
+
+  /**
+   * Deletes directory in %TEMP% (including any files inside) if existant
+   *
+   * @return void
+   */
+  public function tearDown() {
+    $this->folder->exists() && $this->folder->unlink();
+  }
+
+  #[@test]
+  public function can_create_with_folder() {
+    new FolderEntries($this->folder);
+  }
+
+  #[@test]
+  public function can_create_with_uri() {
+    new FolderEntries($this->folder->getURI());
+  }
+
+  #[@test]
+  public function can_create_with_reference_to_current_directory() {
+    new FolderEntries('.');
+  }
+
+  #[@test]
+  public function can_create_with_reference_to_parent_directory() {
+    new FolderEntries('..');
+  }
+
+  #[@test]
+  public function can_create_with_path() {
+    new FolderEntries(new Path($this->folder));
+  }
+
+  #[@test, @expect(IllegalArgumentException::class), @values([null, ''])]
+  public function cannot_create_from_empty_name($value) {
+    new FolderEntries($value);
+  }
+
+  #[@test]
+  public function entries_iteration_for_empty_folder() {
+    $this->assertEquals([], iterator_to_array(new FolderEntries($this->folder)));
+  }
+
+  #[@test]
+  public function entries_iteration_with_one_file() {
+    (new File($this->folder, 'one'))->touch();
+
+    $this->assertEquals(
+      ['one' => new Path($this->folder, 'one')],
+      iterator_to_array(new FolderEntries($this->folder))
+    );
+  }
+
+  #[@test]
+  public function entries_iteration_with_files_and_directories() {
+    (new File($this->folder, 'one'))->touch();
+    (new Folder($this->folder, 'two'))->create();
+
+    $this->assertEquals(
+      ['one' => new Path($this->folder, 'one'), 'two' => new Path($this->folder, 'two')],
+      iterator_to_array(new FolderEntries($this->folder))
+    );
+  }
+
+  #[@test]
+  public function entries_reiteration() {
+    (new File($this->folder, 'one'))->touch();
+    (new File($this->folder, 'two'))->touch();
+
+    $expected= ['one' => new Path($this->folder, 'one'), 'two' => new Path($this->folder, 'two')];
+    $entries= new FolderEntries($this->folder);
+    $this->assertEquals(
+      [$expected, $expected],
+      [iterator_to_array($entries), iterator_to_array($entries)]
+    );
+  }
+
+  #[@test]
+  public function named() {
+    $this->assertEquals(new Path($this->folder, 'test'), (new FolderEntries($this->folder))->named('test'));
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/io/FolderEntriesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/FolderEntriesTest.class.php
@@ -103,4 +103,9 @@ class FolderEntriesTest extends \unittest\TestCase {
   public function named() {
     $this->assertEquals(new Path($this->folder, 'test'), (new FolderEntries($this->folder))->named('test'));
   }
+
+  #[@test]
+  public function named_dot() {
+    $this->assertEquals(new Path($this->folder), (new FolderEntries($this->folder))->named('.'));
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/io/FolderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/FolderTest.class.php
@@ -1,16 +1,17 @@
 <?php namespace net\xp_framework\unittest\io;
 
-use unittest\TestCase;
 use io\Folder;
 use io\Path;
 use lang\System;
+use lang\IllegalStateException;
+use unittest\PrerequisitesNotMetError;
 
 /**
  * TestCase
  *
  * @see      xp://io.Folder
  */
-class FolderTest extends TestCase {
+class FolderTest extends \unittest\TestCase {
   protected $temp= '';
   
   /**
@@ -25,17 +26,21 @@ class FolderTest extends TestCase {
   }
 
   /**
-   * Sets up test case - initializes directory in %TEMP
+   * Sets up test case - initializes directory in %TEMP%
+   *
+   * @return void
    */
   public function setUp() {
     $this->temp= $this->normalize(realpath(System::tempDir())).md5(uniqid()).'.xp'.DIRECTORY_SEPARATOR;
     if (is_dir($this->temp) && !rmdir($this->temp)) {
-      throw new \unittest\PrerequisitesNotMetError('Fixture directory exists, but cannot remove', null, $this->temp);
+      throw new PrerequisitesNotMetError('Fixture directory exists, but cannot remove', null, $this->temp);
     }
   }
   
   /**
-   * Deletes directory in %TEMP if existant
+   * Deletes directory in %TEMP% (including any files inside) if existant
+   *
+   * @return void
    */
   public function tearDown() {
     is_dir($this->temp) && rmdir($this->temp);
@@ -176,5 +181,15 @@ class FolderTest extends TestCase {
   public function pathClassCanBeUsedAsArg() {
     $f= new Folder(new Path($this->temp));
     $this->assertEquals($this->temp, $f->getURI());
+  }
+
+  #[@test]
+  public function entries() {
+    $this->assertInstanceOf('io.FolderEntries', (new Folder($this->temp))->entries());
+  }
+
+  #[@test, @expect(IllegalStateException::class)]
+  public function entries_iteration_raises_exception_if_path_does_not_exist() {
+    iterator_to_array((new Folder($this->temp))->entries());
   }
 }


### PR DESCRIPTION
This PR adds a new method `entries()` to the io.Folder class and deprecates the iteration via `getEntry()`.

### Old

```php
$folder= new Folder('.');
while (false !== ($entry= $folder->getEntry())) {
  $path= new Path($folder, $entry);
  // ...
}

$path= new Path($folder, 'test.txt');
```


### New

```php
$folder= new Folder('.');
foreach ($folder->entries() as $path) {
  // ...
}

$path= $folder->entries()->named('test.txt');
```