### PR TITLE
Path::asFile() and asFolder() accept arguments

### DIFF
--- a/src/main/php/io/Path.class.php
+++ b/src/main/php/io/Path.class.php
@@ -5,6 +5,7 @@ use lang\IllegalArgumentException;
 use io\collections\IOElement;
 
 class Path extends \lang\Object {
+  const EXISTING = true;
   protected $path;
 
   /**
@@ -182,23 +183,39 @@ class Path extends \lang\Object {
   /**
    * Returns a file instance for this path
    *
+   * @param  bool $existing Whether only to return existing files
    * @return io.File
    * @throws lang.IllegalStateException if the path is not a file
    */
-  public function asFile() {
-    if (is_file($this->path)) return new File($this->path);
-    throw new IllegalStateException($this->path.' is not a file');
+  public function asFile($existing= false) {
+    if (is_file($this->path)) {
+      return new File($this->path);
+    } else if (file_exists($this->path)) {
+      throw new IllegalStateException($this->path.' exists but is not a file');
+    } else if ($existing) {
+      throw new IllegalStateException($this->path.' does not exist');
+    } else {
+      return new File($this->path);
+    }
   }
 
   /**
    * Returns a folder instance for this path
    *
+   * @param  bool $existing Whether only to return existing folder
    * @return io.File
    * @throws lang.IllegalStateException if the path is not a folder
    */
-  public function asFolder() {
-    if (is_dir($this->path)) return new Folder($this->path);
-    throw new IllegalStateException($this->path.' is not a folder');
+  public function asFolder($existing= false) {
+    if (is_dir($this->path)) {
+      return new Folder($this->path);
+    } else if (file_exists($this->path)) {
+      throw new IllegalStateException($this->path.' exists but is not a folder');
+    } else if ($existing) {
+      throw new IllegalStateException($this->path.' does not exist');
+    } else {
+      return new Folder($this->path);
+    }
   }
 
   /**

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -193,6 +193,16 @@ class PathTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function as_file_works_with_nonexistant_paths() {
+    $this->assertEquals(new File('test.txt'), (new Path('test.txt'))->asFile());
+  }
+
+  #[@test, @expect(class= 'lang.IllegalStateException', withMessage= '/.+ does not exist/')]
+  public function as_file_throws_exception_when_existing_flag_defined_an_nonexistant_path_given() {
+    (new Path('test.txt'))->asFile(Path::EXISTING);
+  }
+
+  #[@test]
   public function as_folder() {
     $folder= $this->existingFolder();
     $this->assertEquals($folder, (new Path($folder))->asFolder());
@@ -201,6 +211,16 @@ class PathTest extends \unittest\TestCase {
   #[@test, @expect(class= 'lang.IllegalStateException', withMessage= '/.+ is not a folder/')]
   public function as_folder_throws_exception_when_invoked_on_a_folder() {
     (new Path($this->existingFile()))->asFolder();
+  }
+
+  #[@test]
+  public function as_folder_works_with_nonexistant_paths() {
+    $this->assertEquals(new Folder('test'), (new Path('test'))->asFolder());
+  }
+
+  #[@test, @expect(class= 'lang.IllegalStateException', withMessage= '/.+ does not exist/')]
+  public function as_folder_throws_exception_when_existing_flag_defined_an_nonexistant_path_given() {
+    (new Path('test'))->asFolder(Path::EXISTING);
   }
 
   #[@test, @values(['.', '..', 'test', '/root/parent/child', 'C:/Windows'])]

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -6,6 +6,8 @@ use io\Folder;
 use lang\Runtime;
 use lang\System;
 use unittest\actions\IsPlatform;
+use lang\IllegalStateException;
+use lang\IllegalArgumentException;
 
 class PathTest extends \unittest\TestCase {
 
@@ -188,7 +190,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals($file, (new Path($file))->asFile());
   }
 
-  #[@test, @expect(class= 'lang.IllegalStateException', withMessage= '/.+ is not a file/')]
+  #[@test, @expect(class= IllegalStateException::class, withMessage= '/.+ is not a file/')]
   public function as_file_throws_exception_when_invoked_on_a_folder() {
     (new Path($this->existingFolder()))->asFile();
   }
@@ -198,7 +200,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals(new File('test.txt'), (new Path('test.txt'))->asFile());
   }
 
-  #[@test, @expect(class= 'lang.IllegalStateException', withMessage= '/.+ does not exist/')]
+  #[@test, @expect(class= IllegalStateException::class, withMessage= '/.+ does not exist/')]
   public function as_file_throws_exception_when_existing_flag_defined_an_nonexistant_path_given() {
     (new Path('test.txt'))->asFile(Path::EXISTING);
   }
@@ -209,7 +211,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals($folder, (new Path($folder))->asFolder());
   }
 
-  #[@test, @expect(class= 'lang.IllegalStateException', withMessage= '/.+ is not a folder/')]
+  #[@test, @expect(class= IllegalStateException::class, withMessage= '/.+ is not a folder/')]
   public function as_folder_throws_exception_when_invoked_on_a_folder() {
     (new Path($this->existingFile()))->asFolder();
   }
@@ -219,7 +221,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals(new Folder('test'), (new Path('test'))->asFolder());
   }
 
-  #[@test, @expect(class= 'lang.IllegalStateException', withMessage= '/.+ does not exist/')]
+  #[@test, @expect(class= IllegalStateException::class, withMessage= '/.+ does not exist/')]
   public function as_folder_throws_exception_when_existing_flag_defined_an_nonexistant_path_given() {
     (new Path('test'))->asFolder(Path::EXISTING);
   }
@@ -301,7 +303,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals($result, (new Path($a))->resolve($b)->toString('/'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values([
+  #[@test, @expect(IllegalArgumentException::class), @values([
   #  ['relative', '/dev'],
   #  ['relative', 'C:/Windows']
   #])]
@@ -325,7 +327,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals($result, (new Path($a))->relativeTo($b)->toString('/'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values([
+  #[@test, @expect(IllegalArgumentException::class), @values([
   #  ['/dev', 'relative'], ['relative', '/dev'],
   #  ['C:/Windows', 'relative'], ['relative', 'C:/Windows']
   #])]

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -4,6 +4,7 @@ use io\Path;
 use io\File;
 use io\Folder;
 use lang\Runtime;
+use lang\System;
 use unittest\actions\IsPlatform;
 
 class PathTest extends \unittest\TestCase {
@@ -169,7 +170,7 @@ class PathTest extends \unittest\TestCase {
 
   #[@test]
   public function links_resolved_in_realpath() {
-    $temp= \lang\System::tempDir();
+    $temp= System::tempDir();
     $link= new Path($temp, 'link-to-temp');
     if (false === symlink($temp, $link)) {
       $this->skip('Cannot create '.$link.' -> '.$temp);


### PR DESCRIPTION
This pull request removes the necessity of using conditionals in the following two usecases:

### Old
```php
$path= new Path('test.txt');

// Usecase 1: Also work for non-existant paths, e.g. because we want to write to the file
if ($path->exists()) {
  $file= $path->asFile();
} else {
  $file= new File($path);
}
$file->open(File::WRITE);

// Usecase 2: Ensure file exists, e.g. because we want to read from it
if ($path->exists()) {
  $file= $path->asFile()->open(File::READ);
} else {
  throw new IllegalStateException('File '.$path.' does not exist');
}
```

### New
```php
$path= new Path('test.txt');

$file= $path->asFile()->open(File::WRITE);                // Usecase #1
$file= $path->asFile(Path::EXISTING)->open(File::READ);   // Usecase #2
```

*Note: The fluent API for File::open was introduced in xp-framework/core@bfc86f28f8764fcb3ef8ee08bda58a6775cf7552*