### PR TITLE
Path::real()

### DIFF
--- a/src/main/php/io/Path.class.php
+++ b/src/main/php/io/Path.class.php
@@ -59,17 +59,17 @@ class Path extends \lang\Object {
    * Creates a new instance with a variable number of arguments
    *
    * @see    php://realpath
-   * @param  var $base Either a string, a Path, a File, Folder or IOElement
-   * @param  var... $args Further components to be concatenated, Paths or strings.
+   * @param  var $arg Either a string, a Path, a File, Folder or IOElement or an array thereof
+   * @param  var $wd Working directory A string, a Path, Folder or IOElement
    * @return self
    */
-  public static function real($base) {
-    if (is_array($base)) {
-      $path= self::pathFor($base);
+  public static function real($arg, $wd= null) {
+    if (is_array($arg)) {
+      $path= self::pathFor($arg);
     } else {
-      $path= self::pathFor(func_get_args());
+      $path= self::pathFor([$arg]);
     }
-    return new self(self::real0($path, getcwd()));
+    return new self(self::real0($path, $wd ?: getcwd()));
   }
 
   /**
@@ -142,7 +142,7 @@ class Path extends \lang\Object {
    *
    * @see    php://realpath
    * @param  string $path
-   * @param  string $wd
+   * @param  var $wd
    * @return string
    */
   private static function real0($path, $wd) {
@@ -155,7 +155,7 @@ class Path extends \lang\Object {
     } else if (null === $wd) {
       throw new IllegalStateException('Cannot resolve '.$path);
     } else {
-      return self::real0($wd.DIRECTORY_SEPARATOR.$path, null);
+      return self::real0(self::pathFor([$wd]).DIRECTORY_SEPARATOR.$path, null);
     }
 
     $check= true;
@@ -186,7 +186,7 @@ class Path extends \lang\Object {
    * used to resolve relative paths.
    *
    * @see    php://getcwd
-   * @param  string $wd Working directory
+   * @param  var $wd Working directory A string, a Path, Folder or IOElement
    * @return string
    */
   public function asURI($wd= null) {
@@ -199,7 +199,7 @@ class Path extends \lang\Object {
    * used to resolve relative paths.
    *
    * @see    php://getcwd
-   * @param  string $wd Working directory
+   * @param  var $wd Working directory A string, a Path, Folder or IOElement
    * @return self
    */
   public function asRealpath($wd= null) {

--- a/src/main/php/io/Path.class.php
+++ b/src/main/php/io/Path.class.php
@@ -59,7 +59,7 @@ class Path extends \lang\Object {
    * Creates a new instance with a variable number of arguments
    *
    * @see    php://realpath
-   * @param  var $arg Either a string, a Path, a File, Folder or IOElement or an array thereof
+   * @param  var $arg Either a string, a Path, a File, Folder or IOElement or an array
    * @param  var $wd Working directory A string, a Path, Folder or IOElement
    * @return self
    */

--- a/src/main/php/xp/xar/instruction/CreateInstruction.class.php
+++ b/src/main/php/xp/xar/instruction/CreateInstruction.class.php
@@ -44,10 +44,10 @@ class CreateInstruction extends AbstractInstruction {
   public function addAll($arguments, $cwd) {
     foreach ($arguments as $arg) {
       if (false !== ($p= strrpos($arg, '='))) {
-        $path= new Path(realpath(substr($arg, 0, $p)));
+        $path= Path::real(substr($arg, 0, $p));
         $named= new Path(substr($arg, $p+ 1));
       } else {
-        $path= new Path(realpath($arg));
+        $path= Path::real($arg);
         $named= null;
       }
 
@@ -74,7 +74,7 @@ class CreateInstruction extends AbstractInstruction {
    */
   public function perform() {
     $this->archive->open(Archive::CREATE);
-    $this->addAll($this->getArguments(), new Path(realpath(getcwd())));
+    $this->addAll($this->getArguments(), Path::real(getcwd())));
     $this->archive->create();
   }
 }

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -144,6 +144,15 @@ class PathTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function real() {
+    $folder= $this->existingFolder();
+    $this->assertEquals(
+      $folder->path,
+      Path::real($folder->path, '.', $folder->dirname, '..')->toString()
+    );
+  }
+
+  #[@test]
   public function folder_as_realpath() {
     $folder= $this->existingFolder();
     $this->assertEquals(

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -144,9 +144,15 @@ class PathTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function real() {
+  public function real_with_folder() {
     $folder= $this->existingFolder();
     $this->assertEquals(rtrim($folder->getURI(), DIRECTORY_SEPARATOR), Path::real($folder)->toString());
+  }
+
+  #[@test]
+  public function real_with_uri() {
+    $folder= $this->existingFolder();
+    $this->assertEquals(rtrim($folder->getURI(), DIRECTORY_SEPARATOR), Path::real($folder->getURI())->toString());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -146,10 +146,19 @@ class PathTest extends \unittest\TestCase {
   #[@test]
   public function real() {
     $folder= $this->existingFolder();
-    $this->assertEquals(
-      $folder->path,
-      Path::real($folder->path, '.', $folder->dirname, '..')->toString()
-    );
+    $this->assertEquals(rtrim($folder->getURI(), DIRECTORY_SEPARATOR), Path::real($folder)->toString());
+  }
+
+  #[@test]
+  public function real_with_working_directory() {
+    $folder= $this->existingFolder();
+    $this->assertEquals($folder->path, Path::real('..', $folder)->toString());
+  }
+
+  #[@test]
+  public function real_with_array() {
+    $folder= $this->existingFolder();
+    $this->assertEquals($folder->path, Path::real([$folder->path, '.', $folder->dirname, '..'])->toString());
   }
 
   #[@test]


### PR DESCRIPTION
This pull request adds a static method `real()` to the io.Path class. With it, one can create instances which are resolved according to [realpath](http://php.net/realpath) semantics.

```php
// Before
$real= new Path(realpath($in));          // Does not work if $in does not exist
$real= (new Path($in))->asRealpath();    // Kind of long

// After
$real= Path::real($in);
```

Easiest way to fully qualify current directory now:

```sh
$ xp -w '\io\Path::real(".")'
C:\cygwin\home\Timm\devel\xp\core
```