### PR TITLE
Deprecate wrapper types in `lang.types`, primitive boxing and unboxing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@ XP Framework Core ChangeLog
 
 ## ?.?.? / ????-??-??
 
+### Heads up!
+
+* Deprecated wrapper types in `lang.types`, primitive boxing and unboxing.
+  See xp-framework/rfc#298
+  (@thekid)
+
 ### Features
 
 * Merged xp-framework/core#76: Implement type unions. Instead of using

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -725,8 +725,6 @@ spl_autoload_register(function($class) {
 foreach ([
   'lang.Generic', 'lang.Object', 'lang.Type', 'lang.XPClass', 'lang.ClassLoader',
   'lang.Throwable', 'lang.XPException', 'lang.Error',
-  'lang.types.String', 'lang.types.Bytes', 'lang.types.Integer', 'lang.types.Double', 'lang.types.Boolean',
-  'lang.types.ArrayList', 'lang.types.ArrayMap',
   'lang.reflect.Method', 'lang.reflect.Constructor', 'lang.reflect.Field'
 ] as $class) {
   $short= substr($class, strrpos($class, '.') + 1);

--- a/src/main/php/lang/Primitive.class.php
+++ b/src/main/php/lang/Primitive.class.php
@@ -1,12 +1,5 @@
 <?php namespace lang;
 
-use lang\types\String;
-use lang\types\Double;
-use lang\types\Integer;
-use lang\types\Boolean;
-use lang\types\Number;
-use lang\types\ArrayList;
-
 /**
  * Represents primitive types:
  * 
@@ -57,11 +50,11 @@ class Primitive extends Type {
    * @throws  lang.IllegalArgumentException in case in cannot be unboxed.
    */
   public static function unboxed($in) {
-    if ($in instanceof String) return $in->toString();
-    if ($in instanceof Double) return $in->doubleValue();
-    if ($in instanceof Integer) return $in->intValue();
-    if ($in instanceof Boolean) return $in->value;
-    if ($in instanceof ArrayList) return $in->values;   // deprecated
+    if ($in instanceof \lang\types\String) return $in->toString();
+    if ($in instanceof \lang\types\Double) return $in->doubleValue();
+    if ($in instanceof \lang\types\Integer) return $in->intValue();
+    if ($in instanceof \lang\types\Boolean) return $in->value;
+    if ($in instanceof \lang\types\ArrayList) return $in->values;   // deprecated
     if ($in instanceof Generic) {
       throw new IllegalArgumentException('Cannot unbox '.\xp::typeOf($in));
     }
@@ -79,11 +72,11 @@ class Primitive extends Type {
   public static function boxed($in) {
     if (null === $in || $in instanceof Generic) return $in;
     $t= gettype($in);
-    if ('string' === $t) return new String($in);
-    if ('integer' === $t) return new Integer($in);
-    if ('double' === $t) return new Double($in);
-    if ('boolean' === $t) return new Boolean($in);
-    if ('array' === $t) return ArrayList::newInstance($in);   // deprecated
+    if ('string' === $t) return new \lang\types\String($in);
+    if ('integer' === $t) return new \lang\types\Integer($in);
+    if ('double' === $t) return new \lang\types\Double($in);
+    if ('boolean' === $t) return new \lang\types\Boolean($in);
+    if ('array' === $t) return \lang\types\ArrayList::newInstance($in);   // deprecated
     throw new IllegalArgumentException('Cannot box '.\xp::typeOf($in));
   }
   

--- a/src/main/php/lang/Primitive.class.php
+++ b/src/main/php/lang/Primitive.class.php
@@ -130,31 +130,31 @@ class Primitive extends Type {
   protected function coerce($value, $default) {
     if (!is_array($value)) switch ($this) {
       case self::$STRING:
-        if ($value instanceof String) return $value->toString();
-        if ($value instanceof Number) return (string)$value->value;
-        if ($value instanceof Boolean) return (string)$value->value;
-        if ($value instanceof Generic) return $value->toString();
+        if ($value instanceof \lang\types\String) return $value->toString();
+        if ($value instanceof \lang\types\Number) return (string)$value->value;
+        if ($value instanceof \lang\types\Boolean) return (string)$value->value;
+        if ($value instanceof \lang\types\Generic) return $value->toString();
         return (string)$value;
 
       case self::$INT:
-        if ($value instanceof String) return (int)$value->toString();
-        if ($value instanceof Number) return $value->intValue();
-        if ($value instanceof Boolean) return (int)$value->value;
-        if ($value instanceof Generic) return (int)$value->toString();
+        if ($value instanceof \lang\types\String) return (int)$value->toString();
+        if ($value instanceof \lang\types\Number) return $value->intValue();
+        if ($value instanceof \lang\types\Boolean) return (int)$value->value;
+        if ($value instanceof \lang\types\Generic) return (int)$value->toString();
         return (int)$value;
 
       case self::$DOUBLE:
-        if ($value instanceof String) return (double)$value->toString();
-        if ($value instanceof Number) return $value->doubleValue();
-        if ($value instanceof Boolean) return (double)$value->value;
-        if ($value instanceof Generic) return (double)$value->toString();
+        if ($value instanceof \lang\types\String) return (double)$value->toString();
+        if ($value instanceof \lang\types\Number) return $value->doubleValue();
+        if ($value instanceof \lang\types\Boolean) return (double)$value->value;
+        if ($value instanceof \lang\types\Generic) return (double)$value->toString();
         return (double)$value;
 
       case self::$BOOL:
-        if ($value instanceof String) return (bool)$value->toString();
-        if ($value instanceof Number) return (bool)$value->value;
-        if ($value instanceof Boolean) return $value->value;
-        if ($value instanceof Generic) return (bool)$value->toString();
+        if ($value instanceof \lang\types\String) return (bool)$value->toString();
+        if ($value instanceof \lang\types\Number) return (bool)$value->value;
+        if ($value instanceof \lang\types\Boolean) return $value->value;
+        if ($value instanceof \lang\types\Generic) return (bool)$value->toString();
         return (bool)$value;
     }
 

--- a/src/main/php/lang/Primitive.class.php
+++ b/src/main/php/lang/Primitive.class.php
@@ -35,6 +35,7 @@ class Primitive extends Type {
   /**
    * Returns the wrapper class for this primitive
    *
+   * @deprecated Wrapper types will move to their own library
    * @see     http://en.wikipedia.org/wiki/Wrapper_class
    * @return  lang.XPClass
    */
@@ -50,6 +51,7 @@ class Primitive extends Type {
   /**
    * Boxes a type - that is, turns Generics into primitives
    *
+   * @deprecated Wrapper types will move to their own library
    * @param   var in
    * @return  var the primitive if not already primitive
    * @throws  lang.IllegalArgumentException in case in cannot be unboxed.
@@ -69,6 +71,7 @@ class Primitive extends Type {
   /**
    * Boxes a type - that is, turns primitives into Generics
    *
+   * @deprecated Wrapper types will move to their own library
    * @param   var in
    * @return  lang.Generic the Generic if not already generic
    * @throws  lang.IllegalArgumentException in case in cannot be boxed.

--- a/src/main/php/lang/types/ArrayList.class.php
+++ b/src/main/php/lang/types/ArrayList.class.php
@@ -7,6 +7,7 @@ use lang\IllegalArgumentException;
  * Represents a "numeric" array
  *
  * @test   xp://net.xp_framework.unittest.core.types.ArrayListTest
+ * @deprecated Wrapper types will move to their own library
  */
 class ArrayList extends \lang\Object implements \ArrayAccess, \IteratorAggregate {
   public

--- a/src/main/php/lang/types/ArrayMap.class.php
+++ b/src/main/php/lang/types/ArrayMap.class.php
@@ -6,6 +6,7 @@ use lang\IndexOutOfBoundsException;
  * Represents a mapped array
  *
  * @test   xp://net.xp_framework.unittest.core.types.ArrayMapTest
+ * @deprecated Wrapper types will move to their own library
  */
 class ArrayMap extends \lang\Object implements \ArrayAccess, \IteratorAggregate {
   public

--- a/src/main/php/lang/types/Boolean.class.php
+++ b/src/main/php/lang/types/Boolean.class.php
@@ -4,6 +4,7 @@
  * The boolean wrapper class
  *
  * @test    xp://net.xp_framework.unittest.core.types.BooleanTest
+ * @deprecated Wrapper types will move to their own library
  */
 class Boolean extends \lang\Object {
   public static $TRUE, $FALSE;

--- a/src/main/php/lang/types/Byte.class.php
+++ b/src/main/php/lang/types/Byte.class.php
@@ -4,6 +4,8 @@
  * The Byte class wraps a value of the type byte 
  * 
  * Range: -2^7 - (2^7)- 1
+ *
+ * @deprecated Wrapper types will move to their own library
  */
 class Byte extends Number {
 

--- a/src/main/php/lang/types/Bytes.class.php
+++ b/src/main/php/lang/types/Bytes.class.php
@@ -5,6 +5,7 @@ use lang\IndexOutOfBoundsException;
 /**
  * Represents a list of bytes
  *
+ * @deprecated Wrapper types will move to their own library
  * @test     xp://net.xp_framework.unittest.core.types.BytesTest
  */
 class Bytes extends \lang\Object implements \ArrayAccess, \IteratorAggregate {

--- a/src/main/php/lang/types/Character.class.php
+++ b/src/main/php/lang/types/Character.class.php
@@ -17,6 +17,7 @@
  *   $c= $s[1];                             // "b"
  * </code>
  *
+ * @deprecated Wrapper types will move to their own library
  * @ext   iconv
  * @test  xp://net.xp_framework.unittest.core.types.CharacterTest
  */

--- a/src/main/php/lang/types/Double.class.php
+++ b/src/main/php/lang/types/Double.class.php
@@ -2,6 +2,8 @@
 
 /**
  * The Double class wraps a value of the type double
+ *
+ * @deprecated Wrapper types will move to their own library
  */
 class Double extends Number {
 

--- a/src/main/php/lang/types/Float.class.php
+++ b/src/main/php/lang/types/Float.class.php
@@ -2,6 +2,8 @@
 
 /**
  * The Float class wraps a value of the type float
+ *
+ * @deprecated Wrapper types will move to their own library
  */
 class Float extends Number {
 

--- a/src/main/php/lang/types/Integer.class.php
+++ b/src/main/php/lang/types/Integer.class.php
@@ -4,6 +4,8 @@
  * The Integer class wraps a value of the type int 
  * 
  * Range: -2^31 - (2^31)- 1
+ *
+ * @deprecated Wrapper types will move to their own library
  */
 class Integer extends Number {
 

--- a/src/main/php/lang/types/Long.class.php
+++ b/src/main/php/lang/types/Long.class.php
@@ -4,6 +4,8 @@
  * The Long class wraps a value of the type long 
  * 
  * Range: -2^63 - (2^63)- 1
+ *
+ * @deprecated Wrapper types will move to their own library
  */
 class Long extends Number {
 

--- a/src/main/php/lang/types/Number.class.php
+++ b/src/main/php/lang/types/Number.class.php
@@ -7,6 +7,7 @@ use lang\MethodNotImplementedException;
  * numbers
  *
  * @test  xp://net.xp_framework.unittest.core.types.NumberTest
+ * @deprecated Wrapper types will move to their own library
  */
 abstract class Number extends \lang\Object {
   public $value = '';

--- a/src/main/php/lang/types/Short.class.php
+++ b/src/main/php/lang/types/Short.class.php
@@ -4,6 +4,8 @@
  * The Short class wraps a value of the type short 
  * 
  * Range: -2^15 - (2^15)- 1
+ *
+ * @deprecated Wrapper types will move to their own library
  */
 class Short extends Number {
 

--- a/src/main/php/lang/types/String.class.php
+++ b/src/main/php/lang/types/String.class.php
@@ -24,6 +24,7 @@ if (extension_loaded('mbstring')) {
 /**
  * Represents a string
  *
+ * @deprecated Wrapper types will move to their own library
  * @ext   iconv
  * @test  xp://net.xp_framework.unittest.core.types.StringTest
  */

--- a/src/main/php/lang/types/package-info.xp
+++ b/src/main/php/lang/types/package-info.xp
@@ -28,6 +28,7 @@
  * an array is "numeric" or not (PHP's array types can be either numeric,
  * hashes or a mix of both and aren't necessarily zero-indexed).
  *
+ * @deprecated Wrapper types will move to their own library
  * @see      http://news.xp-framework.net/article/52/2005/05/29/
  * @see      http://news.xp-framework.net/article/54/2005/06/12/
  * @see      http://developer.xp-framework.net/xml/rfc/view?0038

--- a/src/test/php/net/xp_framework/unittest/annotations/AnnotationParsingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/AnnotationParsingTest.class.php
@@ -387,16 +387,16 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   #[@test]
   public function class_instance_value() {
     $this->assertEquals(
-      array(0 => array('value' => new \lang\types\String('hello')), 1 => []),
-      $this->parse('#[@value(new String("hello"))]', array('String' => 'lang.types.String'))
+      array(0 => array('value' => new Name('hello')), 1 => []),
+      $this->parse('#[@value(new Name("hello"))]', array('Name' => 'net.xp_framework.unittest.annotations.Name'))
     );
   }
 
   #[@test]
   public function ns_class_instance_value() {
     $this->assertEquals(
-      array(0 => array('value' => new \lang\types\String('hello')), 1 => []),
-      $this->parse('#[@value(new \lang\types\String("hello"))]')
+      array(0 => array('value' => new Name('hello')), 1 => []),
+      $this->parse('#[@value(new Name("hello"))]')
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/annotations/ClassMemberParsingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/ClassMemberParsingTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace net\xp_framework\unittest\annotations;
 
 use net\xp_framework\unittest\annotations\fixture\Namespaced;
-use lang\types\String;
 use lang\XPClass;
 
 /**
@@ -18,9 +17,9 @@ class ClassMemberParsingTest extends \unittest\TestCase {
     $this->assertEquals('local', $value);
   }
 
-  #[@test, @values([new String(self::CONSTANT)])]
+  #[@test, @values([new Name(self::CONSTANT)])]
   public function class_constant_via_self_inside_new($value) {
-    $this->assertEquals(new String('local'), $value);
+    $this->assertEquals(new Name('local'), $value);
   }
 
   #[@test, @values([ClassMemberParsingTest::CONSTANT])]
@@ -48,9 +47,9 @@ class ClassMemberParsingTest extends \unittest\TestCase {
     $this->assertEquals('static', $value);
   }
 
-  #[@test, @values([new String(self::$value)])]
+  #[@test, @values([new Name(self::$value)])]
   public function static_member_via_self_inside_new($value) {
-    $this->assertEquals(new String('static'), $value);
+    $this->assertEquals(new Name('static'), $value);
   }
 
   #[@test, @values([ClassMemberParsingTest::$value])]

--- a/src/test/php/net/xp_framework/unittest/annotations/Name.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/Name.class.php
@@ -1,0 +1,39 @@
+<?php namespace net\xp_framework\unittest\annotations;
+
+class Name extends \lang\Object {
+  private $value;
+
+  /** @param string $value */
+  public function __construct($value) { $this->value= (string)$value; }
+
+  /** @return string */
+  public function value() { return $this->value; }
+
+  /**
+   * Returns a hashcode
+   *
+   * @return string
+   */
+  public function hashCode() {
+    return crc32($this->value);
+  }
+
+  /**
+   * Returns whether this name is equal to another
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && $this->value === $cmp->value;
+  }
+
+  /**
+   * Returns a string representation
+   *
+   * @return string
+   */
+  public function toString() {
+    return $this->value;
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/core/ArrayTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ArrayTypeTest.class.php
@@ -5,6 +5,7 @@ use lang\IllegalArgumentException;
 use lang\Primitive;
 use lang\Type;
 use lang\XPClass;
+use lang\types\String;
 
 /**
  * TestCase

--- a/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
@@ -2,7 +2,6 @@
 
 use lang\XPClass;
 use lang\Object;
-use lang\types\String;
 use util\collections\Vector;
 use util\collections\HashTable;
 
@@ -12,7 +11,7 @@ use util\collections\HashTable;
  * 1) Create generics
  *
  * ```php
- * $v= create('new util.collections.Vector<lang.types.String>');
+ * $v= create('new util.collections.Vector<lang.Object>');
  * ```
  *
  * 2) For BC with PHP 5.3 - PHP 5.4 has added constructor dereferencing! Returning
@@ -32,40 +31,41 @@ class CreateTest extends \unittest\TestCase {
     $this->assertEquals($fixture, create($fixture));
   }
 
-  #[@test, @ignore('No short aliases at the moment')]
+  #[@test]
   public function create_with_all_short_names_for_components() {
-    $h= create('new util.collections.HashTable<String, String>');
+    $h= create('new util.collections.HashTable<Object, Object>');
     $this->assertEquals(
-      [XPClass::forName('lang.types.String'), XPClass::forName('lang.types.String')], 
+      [XPClass::forName('lang.Object'), XPClass::forName('lang.Object')], 
       $h->getClass()->genericArguments()
     );
   }
 
   #[@test]
   public function create_with_all_qualified_names() {
-    $h= create('new util.collections.HashTable<lang.types.String, lang.types.String>');
+    $h= create('new util.collections.HashTable<lang.Object, lang.Object>');
     $this->assertEquals(
-      [XPClass::forName('lang.types.String'), XPClass::forName('lang.types.String')], 
+      [XPClass::forName('lang.Object'), XPClass::forName('lang.Object')], 
       $h->getClass()->genericArguments()
     );
   }
 
   #[@test]
   public function create_can_be_used_with_type_variables() {
-    $T= XPClass::forName('lang.types.String');
+    $T= XPClass::forName('lang.Object');
     $this->assertEquals([$T], create("new util.collections.Vector<$T>")->getClass()->genericArguments());
   }
 
   #[@test]
   public function create_invokes_constructor() {
+    $fixture= new Object();
     $this->assertEquals(
-      new String('Hello'),
-      create('new util.collections.Vector<lang.types.String>', [new String('Hello')])->get(0)
+      $fixture,
+      create('new util.collections.Vector<lang.Object>', [$fixture])->get(0)
     );
   }
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function create_raises_exception_when_non_generic_given() {
-    create('new lang.Object<lang.types.String>');
+    create('new lang.Object<lang.Object>');
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
@@ -6,8 +6,7 @@ use lang\MapType;
 use lang\Primitive;
 use lang\Type;
 use lang\XPClass;
-use lang\types\Integer;
-use lang\types\String;
+use lang\Object;
 
 /**
  * TestCase
@@ -83,7 +82,7 @@ class MapTypeTest extends \unittest\TestCase {
 
   #[@test]
   public function varMap() {
-    $this->assertTrue(MapType::forName('[:var]')->isInstance(['one' => 1, 'two' => 'Zwei', 'three' => new Integer(3)]));
+    $this->assertTrue(MapType::forName('[:var]')->isInstance(['one' => 1, 'two' => 'Zwei', 'three' => new Object()]));
   }
 
   #[@test]
@@ -146,7 +145,7 @@ class MapTypeTest extends \unittest\TestCase {
   }
 
   #[@test, @expect(IllegalArgumentException::class), @values([
-  #  0, -1, 0.5, '', 'Test', new String('a'), true, false,
+  #  0, -1, 0.5, '', 'Test', new Object(), true, false,
   #  [[0, 1, 2]]
   #])]
   public function newInstance_raises_exceptions_for_non_arrays($value) {
@@ -163,7 +162,7 @@ class MapTypeTest extends \unittest\TestCase {
   }
 
   #[@test, @expect('lang.ClassCastException'), @values([
-  #  0, -1, 0.5, '', 'Test', new String('a'), true, false,
+  #  0, -1, 0.5, '', 'Test', new Object(), true, false,
   #  [[0, 1, 2]]
   #])]
   public function cast_raises_exceptions_for_non_arrays($value) {

--- a/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
@@ -7,6 +7,7 @@ use lang\Primitive;
 use lang\Type;
 use lang\XPClass;
 use lang\types\Integer;
+use lang\types\String;
 
 /**
  * TestCase

--- a/src/test/php/net/xp_framework/unittest/core/generics/AbstractDefinitionReflectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/AbstractDefinitionReflectionTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
-use lang\types\String;
 use lang\XPClass;
+use lang\Primitive;
 
 /**
  * TestCase for definition reflection
@@ -49,17 +49,17 @@ abstract class AbstractDefinitionReflectionTest extends \unittest\TestCase {
 
   #[@test]
   public function newGenericTypeIsGeneric() {
-    $t= $this->fixture->newGenericType(array(
-      XPClass::forName('lang.types.String'), 
+    $t= $this->fixture->newGenericType([
+      Primitive::$STRING, 
       XPClass::forName('unittest.TestCase')
-    ));
+    ]);
     $this->assertTrue($t->isGeneric());
   }
 
   #[@test]
   public function newLookupWithStringAndTestCase() {
     $arguments= array(
-      XPClass::forName('lang.types.String'), 
+      Primitive::$STRING, 
       XPClass::forName('unittest.TestCase')
     );
     $this->assertEquals(
@@ -71,19 +71,7 @@ abstract class AbstractDefinitionReflectionTest extends \unittest\TestCase {
   #[@test]
   public function newLookupWithStringAndObject() {
     $arguments= array(
-      XPClass::forName('lang.types.String'), 
-      XPClass::forName('lang.Object')
-    );
-    $this->assertEquals(
-      $arguments, 
-      $this->fixture->newGenericType($arguments)->genericArguments()
-    );
-  }
-
-  #[@test]
-  public function newLookupWithPrimitiveStringAndObject() {
-    $arguments= array(
-      \lang\Primitive::$STRING,
+      Primitive::$STRING, 
       XPClass::forName('lang.Object')
     );
     $this->assertEquals(
@@ -97,7 +85,7 @@ abstract class AbstractDefinitionReflectionTest extends \unittest\TestCase {
     $this->assertEquals(
       $this->fixtureInstance()->getClass(),
       $this->fixture->newGenericType(array(
-        XPClass::forName('lang.types.String'), 
+        Primitive::$STRING, 
         XPClass::forName('unittest.TestCase')
       ))
     );
@@ -107,11 +95,11 @@ abstract class AbstractDefinitionReflectionTest extends \unittest\TestCase {
   public function classesCreatedWithDifferentTypesAreNotEqual() {
     $this->assertNotEquals(
       $this->fixture->newGenericType(array(
-        XPClass::forName('lang.types.String'), 
+        Primitive::$STRING, 
         XPClass::forName('lang.Object')
       )),
       $this->fixture->newGenericType(array(
-        XPClass::forName('lang.types.String'), 
+        Primitive::$STRING, 
         XPClass::forName('unittest.TestCase')
       ))
     );

--- a/src/test/php/net/xp_framework/unittest/core/generics/DefinitionReflectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/DefinitionReflectionTest.class.php
@@ -22,6 +22,6 @@ class DefinitionReflectionTest extends AbstractDefinitionReflectionTest {
    * @return  var
    */
   protected function fixtureInstance() {
-    return create('new net.xp_framework.unittest.core.generics.Lookup<String, unittest.TestCase>()');
+    return create('new net.xp_framework.unittest.core.generics.Lookup<string, unittest.TestCase>()');
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/generics/InstanceReflectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/InstanceReflectionTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
-use lang\types\String;
+use lang\Primitive;
+use lang\XPClass;
 
 /**
  * TestCase for instance reflection
@@ -8,6 +9,7 @@ use lang\types\String;
  * @see   xp://net.xp_framework.unittest.core.generics.Lookup
  */
 class InstanceReflectionTest extends \unittest\TestCase {
+  private $fixture;
   
   /**
    * Creates fixture, a Lookup with String and TestCase as component
@@ -15,13 +17,13 @@ class InstanceReflectionTest extends \unittest\TestCase {
    *
    */  
   public function setUp() {
-    $this->fixture= create('new net.xp_framework.unittest.core.generics.Lookup<String, unittest.TestCase>()');
+    $this->fixture= create('new net.xp_framework.unittest.core.generics.Lookup<string, unittest.TestCase>()');
   }
 
   #[@test]
   public function getClassNameMethod() {
     $this->assertEquals(
-      'net.xp_framework.unittest.core.generics.Lookup<lang.types.String,unittest.TestCase>', 
+      'net.xp_framework.unittest.core.generics.Lookup<string,unittest.TestCase>', 
       $this->fixture->getClassName()
     );
   }
@@ -29,7 +31,7 @@ class InstanceReflectionTest extends \unittest\TestCase {
   #[@test]
   public function nameOfClass() {
     $this->assertEquals(
-      'net.xp_framework.unittest.core.generics.Lookup<lang.types.String,unittest.TestCase>', 
+      'net.xp_framework.unittest.core.generics.Lookup<string,unittest.TestCase>', 
       $this->fixture->getClass()->getName()
     );
   }
@@ -37,7 +39,7 @@ class InstanceReflectionTest extends \unittest\TestCase {
   #[@test]
   public function simpleNameOfClass() {
     $this->assertEquals(
-      'Lookup<lang.types.String,unittest.TestCase>', 
+      'Lookup<string,unittest.TestCase>', 
       $this->fixture->getClass()->getSimpleName()
     );
   }
@@ -46,7 +48,7 @@ class InstanceReflectionTest extends \unittest\TestCase {
   public function reflectedNameOfClass() {
     $class= $this->fixture->getClass();
     $this->assertEquals(
-      'net\xp_framework\unittest\core\generics\Lookup··lang¦types¦String¸unittest¦TestCase', 
+      'net\xp_framework\unittest\core\generics\Lookup··þstring¸unittest¦TestCase', 
       literal($class->getName())
     );
   }
@@ -64,7 +66,7 @@ class InstanceReflectionTest extends \unittest\TestCase {
   #[@test]
   public function genericDefinition() {
     $this->assertEquals(
-      \lang\XPClass::forName('net.xp_framework.unittest.core.generics.Lookup'),
+      XPClass::forName('net.xp_framework.unittest.core.generics.Lookup'),
       $this->fixture->getClass()->genericDefinition()
     );
   }
@@ -72,7 +74,7 @@ class InstanceReflectionTest extends \unittest\TestCase {
   #[@test]
   public function genericArguments() {
     $this->assertEquals(
-      array(\lang\XPClass::forName('lang.types.String'), \lang\XPClass::forName('unittest.TestCase')),
+      [Primitive::$STRING, XPClass::forName('unittest.TestCase')],
       $this->fixture->getClass()->genericArguments()
     );
   }
@@ -89,8 +91,8 @@ class InstanceReflectionTest extends \unittest\TestCase {
   public function putParameters() {
     $params= $this->fixture->getClass()->getMethod('put')->getParameters();
     $this->assertEquals(2, sizeof($params));
-    $this->assertEquals(\lang\XPClass::forName('lang.types.String'), $params[0]->getType());
-    $this->assertEquals(\lang\XPClass::forName('unittest.TestCase'), $params[1]->getType());
+    $this->assertEquals(Primitive::$STRING, $params[0]->getType());
+    $this->assertEquals(XPClass::forName('unittest.TestCase'), $params[1]->getType());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/core/generics/PrimitivesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/PrimitivesTest.class.php
@@ -1,14 +1,14 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
-use unittest\TestCase;
-use lang\types\String;
+use lang\XPClass;
+use lang\Primitive;
 
 /**
  * TestCase for generic behaviour at runtime.
  *
  * @see   xp://net.xp_framework.unittest.core.generics.Lookup
  */
-class PrimitivesTest extends TestCase {
+class PrimitivesTest extends \unittest\TestCase {
 
   #[@test]
   public function primitiveStringKey() {
@@ -34,22 +34,22 @@ class PrimitivesTest extends TestCase {
   #[@test, @expect('lang.IllegalArgumentException')]
   public function instanceVerification() {
     $l= create('new net.xp_framework.unittest.core.generics.Lookup<string, unittest.TestCase>()');
-    $l->put(new String('Hello'), $this);
+    $l->put($this, $this);
   }
 
   #[@test]
   public function nameOfClass() {
-    $type= \lang\XPClass::forName('net.xp_framework.unittest.core.generics.Lookup')->newGenericType(array(
-      \lang\Primitive::$STRING,
-      \lang\XPClass::forName('unittest.TestCase')
-    ));
+    $type= XPClass::forName('net.xp_framework.unittest.core.generics.Lookup')->newGenericType([
+      Primitive::$STRING,
+      XPClass::forName('unittest.TestCase')
+    ]);
     $this->assertEquals('net.xp_framework.unittest.core.generics.Lookup<string,unittest.TestCase>', $type->getName());
   }
 
   #[@test]
   public function typeArguments() {
     $this->assertEquals(
-      array(\lang\Primitive::$STRING, \lang\XPClass::forName('unittest.TestCase')),
+      [Primitive::$STRING, XPClass::forName('unittest.TestCase')],
       create('new net.xp_framework.unittest.core.generics.Lookup<string, unittest.TestCase>()')->getClass()->genericArguments()
     );
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/RuntimeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/RuntimeTest.class.php
@@ -1,52 +1,58 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
-use unittest\TestCase;
-use lang\types\String;
-use lang\types\Integer;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase for generic behaviour at runtime.
  *
  * @see   xp://collections.Lookup
  */
-class RuntimeTest extends TestCase {
-  protected $fixture= null;
+class RuntimeTest extends \unittest\TestCase {
+  private $fixture;
   
   /**
-   * Creates fixture, a Lookup with String and TestCase as component
-   * types.
+   * Creates fixture, a Lookup with string and TestCase as component types.
+   *
+   * @return void
    */  
   public function setUp() {
-    $this->fixture= create('new net.xp_framework.unittest.core.generics.Lookup<String, unittest.TestCase>()');
+    $this->fixture= create('new net.xp_framework.unittest.core.generics.Lookup<string, unittest.TestCase>()');
   }
 
   #[@test]
   public function name() {
     $this->assertEquals(
-      'net\\xp_framework\\unittest\\core\\generics\\Lookup··lang¦types¦String¸unittest¦TestCase',
+      'net.xp_framework.unittest.core.generics.Lookup<string,unittest.TestCase>',
+      $this->fixture->getClass()->getName()
+    );
+  }
+
+  #[@test]
+  public function literal() {
+    $this->assertEquals(
+      'net\\xp_framework\\unittest\\core\\generics\\Lookup··þstring¸unittest¦TestCase',
       $this->fixture->getClass()->literal()
     );
   }
 
   #[@test]
   public function putStringAndThis() {
-    $this->fixture->put(new String($this->name), $this);
+    $this->fixture->put('Test', $this);
   }
 
   #[@test]
   public function putAndGetRoundTrip() {
-    $key= new String($this->name);
-    $this->fixture->put($key, $this);
-    $this->assertEquals($this, $this->fixture->get($key));
+    $this->fixture->put('Test', $this);
+    $this->assertEquals($this, $this->fixture->get('Test'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function keyTypeIncorrect() {
-    $this->fixture->put(new Integer(1), $this);
+    $this->fixture->put(1, $this);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function valueTypeIncorrect() {
-    $this->fixture->put(new String($this->name), new \lang\Object());
+    $this->fixture->put('Test', new \lang\Object());
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/types/ArrayListTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/ArrayListTest.class.php
@@ -7,6 +7,7 @@ use lang\IndexOutOfBoundsException;
 /**
  * Tests the ArrayList class
  *
+ * @deprecated Wrapper types will move to their own library
  * @see  xp://lang.types.ArrayList
  */
 class ArrayListTest extends TestCase {

--- a/src/test/php/net/xp_framework/unittest/core/types/ArrayMapTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/ArrayMapTest.class.php
@@ -7,6 +7,7 @@ use lang\IndexOutOfBoundsException;
 /**
  * Tests the ArrayMap class
  *
+ * @deprecated Wrapper types will move to their own library
  * @see  xp://lang.types.ArrayMap
  */
 class ArrayMapTest extends TestCase {

--- a/src/test/php/net/xp_framework/unittest/core/types/BooleanTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/BooleanTest.class.php
@@ -7,6 +7,7 @@ use lang\types\Boolean;
 /**
  * Tests the boolean wrapper type
  *
+ * @deprecated Wrapper types will move to their own library
  * @see      xp://lang.types.Boolean
  */
 class BooleanTest extends TestCase {

--- a/src/test/php/net/xp_framework/unittest/core/types/BytesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/BytesTest.class.php
@@ -8,6 +8,7 @@ use lang\types\Byte;
 /**
  * TestCase for Bytes class
  *
+ * @deprecated Wrapper types will move to their own library
  * @see      xp://lang.types.Bytes
  */
 class BytesTest extends \unittest\TestCase {

--- a/src/test/php/net/xp_framework/unittest/core/types/CharacterTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/CharacterTest.class.php
@@ -8,6 +8,7 @@ use lang\types\Bytes;
 /**
  * TestCase
  *
+ * @deprecated Wrapper types will move to their own library
  * @see  xp://lang.types.Character
  */
 class CharacterTest extends TestCase {

--- a/src/test/php/net/xp_framework/unittest/core/types/NumberTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/NumberTest.class.php
@@ -10,6 +10,7 @@ use lang\types\Double;
 /**
  * Tests the number wrapper typess
  *
+ * @deprecated Wrapper types will move to their own library
  * @see   xp://lang.types.Number
  * @see   xp://lang.types.Byte
  * @see   xp://lang.types.Short

--- a/src/test/php/net/xp_framework/unittest/core/types/StringTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/StringTest.class.php
@@ -5,6 +5,7 @@ use lang\types\String;
 /**
  * TestCase for String class
  *
+ * @deprecated Wrapper types will move to their own library
  * @see   xp://lang.types.String
  */
 class StringTest extends \unittest\TestCase {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassCastingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassCastingTest.class.php
@@ -3,7 +3,7 @@
 use unittest\TestCase;
 use lang\XPClass;
 use lang\Object;
-use lang\types\String;
+use lang\Type;
 
 /**
  * TestCase
@@ -34,7 +34,7 @@ class ClassCastingTest extends TestCase {
 
   #[@test, @expect('lang.ClassCastException')]
   public function thisClassCastingAnUnrelatedClass() {
-    $this->getClass()->cast(new String('Hello'));
+    $this->getClass()->cast(Type::$VOID);
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
@@ -49,43 +49,51 @@ class PrimitiveTest extends TestCase {
     Primitive::forName('lang.Object');
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function boxString() {
     $this->assertEquals(new String('Hello'), Primitive::boxed('Hello'));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function boxInteger() {
     $this->assertEquals(new Integer(1), Primitive::boxed(1));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function boxDouble() {
     $this->assertEquals(new Double(1.0), Primitive::boxed(1.0));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function boxBoolean() {
     $this->assertEquals(Boolean::$TRUE, Primitive::boxed(true), 'true');
     $this->assertEquals(Boolean::$FALSE, Primitive::boxed(false), 'false');
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function boxArray() {
     $this->assertEquals(new ArrayList(1, 2, 3), Primitive::boxed([1, 2, 3]));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function boxObject() {
     $o= new \lang\Object();
     $this->assertEquals($o, Primitive::boxed($o));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function boxNull() {
     $this->assertEquals(null, Primitive::boxed(null));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function boxResource() {
     $fd= Streams::readableFd(new MemoryInputStream('test'));
@@ -100,42 +108,50 @@ class PrimitiveTest extends TestCase {
     $this->fail('Expected exception not caught', null, 'lang.IllegalArgumentException');
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function unboxString() {
     $this->assertEquals('Hello', Primitive::unboxed(new String('Hello')));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function unboxInteger() {
     $this->assertEquals(1, Primitive::unboxed(new Integer(1)));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function unboxDouble() {
     $this->assertEquals(1.0, Primitive::unboxed(new Double(1.0)));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function unboxBoolean() {
     $this->assertEquals(true, Primitive::unboxed(Boolean::$TRUE), 'true');
     $this->assertEquals(false, Primitive::unboxed(Boolean::$FALSE), 'false');
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function unboxArray() {
     $this->assertEquals([1, 2, 3], Primitive::unboxed(new ArrayList(1, 2, 3)));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test, @expect('lang.IllegalArgumentException')]
   public function unboxObject() {
     Primitive::unboxed(new \lang\Object());
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function unboxNull() {
     $this->assertEquals(null, Primitive::unboxed(null));
   }
 
+  /** @deprecated Wrapper types will move to their own library */
   #[@test]
   public function unboxPrimitive() {
     $this->assertEquals(1, Primitive::unboxed(1));

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -123,12 +123,12 @@ class TypeTest extends TestCase {
 
   #[@test]
   public function genericObjectType() {
-    with ($t= Type::forName('util.collections.HashTable<String, Object>')); {
+    with ($t= Type::forName('util.collections.HashTable<string, Object>')); {
       $this->assertInstanceOf('lang.XPClass', $t);
       $this->assertTrue($t->isGeneric());
       $this->assertEquals(XPClass::forName('util.collections.HashTable'), $t->genericDefinition());
       $this->assertEquals(
-        [XPClass::forName('lang.types.String'), XPClass::forName('lang.Object')],
+        [Primitive::$STRING, XPClass::forName('lang.Object')],
         $t->genericArguments()
       );
     }

--- a/src/test/php/net/xp_framework/unittest/util/collections/ArrayAccessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/ArrayAccessTest.class.php
@@ -1,11 +1,8 @@
 <?php namespace net\xp_framework\unittest\util\collections;
 
-use unittest\TestCase;
-use lang\types\String;
 use util\collections\HashTable;
 use util\collections\HashSet;
 use util\collections\Vector;
-
 
 /**
  * TestCase
@@ -14,7 +11,7 @@ use util\collections\Vector;
  * @see   xp://util.collections.HashSet
  * @see   xp://util.collections.Vector
  */
-class ArrayAccessTest extends TestCase {
+class ArrayAccessTest extends \unittest\TestCase {
 
   /**
    * Tests array access operator is overloaded for reading
@@ -23,9 +20,9 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashTableReadElement() {
     $c= new HashTable();
-    $world= new String('world');
-    $c->put(new String('hello'), $world);
-    $this->assertEquals($world, $c[new String('hello')]);
+    $world= new Name('world');
+    $c->put(new Name('hello'), $world);
+    $this->assertEquals($world, $c[new Name('hello')]);
   }
 
   /**
@@ -35,7 +32,7 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashTableReadNonExistantElement() {
     $c= new HashTable();
-    $this->assertEquals(null, $c[new String('hello')]);
+    $this->assertEquals(null, $c[new Name('hello')]);
   }
 
   /**
@@ -55,9 +52,9 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashTableWriteElement() {
     $c= new HashTable();
-    $world= new String('world');
-    $c[new String('hello')]= $world;
-    $this->assertEquals($world, $c->get(new String('hello')));
+    $world= new Name('world');
+    $c[new Name('hello')]= $world;
+    $this->assertEquals($world, $c->get(new Name('hello')));
   }
 
   /**
@@ -67,7 +64,7 @@ class ArrayAccessTest extends TestCase {
   #[@test, @expect('lang.IllegalArgumentException')]
   public function hashTableWriteIllegalKey() {
     $c= create('new util.collections.HashTable<string, Object>()');
-    $c[STDIN]= new String('Hello');
+    $c[STDIN]= new Name('Hello');
   }
 
   /**
@@ -87,9 +84,9 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashTableTestElement() {
     $c= new HashTable();
-    $c->put(new String('hello'), new String('world'));
-    $this->assertTrue(isset($c[new String('hello')]));
-    $this->assertFalse(isset($c[new String('world')]));
+    $c->put(new Name('hello'), new Name('world'));
+    $this->assertTrue(isset($c[new Name('hello')]));
+    $this->assertFalse(isset($c[new Name('world')]));
   }
 
   /**
@@ -99,10 +96,10 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashTableRemoveElement() {
     $c= new HashTable();
-    $c->put(new String('hello'), new String('world'));
-    $this->assertTrue(isset($c[new String('hello')]));
-    unset($c[new String('hello')]);
-    $this->assertFalse(isset($c[new String('hello')]));
+    $c->put(new Name('hello'), new Name('world'));
+    $this->assertTrue(isset($c[new Name('hello')]));
+    unset($c[new Name('hello')]);
+    $this->assertFalse(isset($c[new Name('hello')]));
   }
 
   /**
@@ -112,7 +109,7 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function vectorReadElement() {
     $v= new Vector();
-    $world= new String('world');
+    $world= new Name('world');
     $v->add($world);
     $this->assertEquals($world, $v[0]);
   }
@@ -134,7 +131,7 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function vectorAddElement() {
     $v= new Vector();
-    $world= new String('world');
+    $world= new Name('world');
     $v[]= $world;
     $this->assertEquals($world, $v[0]);
   }
@@ -145,8 +142,8 @@ class ArrayAccessTest extends TestCase {
    */
   #[@test]
   public function vectorWriteElement() {
-    $v= new Vector(array(new String('hello')));
-    $world= new String('world');
+    $v= new Vector(array(new Name('hello')));
+    $world= new Name('world');
     $v[0]= $world;
     $this->assertEquals($world, $v[0]);
   }
@@ -158,7 +155,7 @@ class ArrayAccessTest extends TestCase {
   #[@test, @expect('lang.IndexOutOfBoundsException')]
   public function vectorWriteElementBeyondBoundsKey() {
     $v= new Vector();
-    $v[0]= new String('world');
+    $v[0]= new Name('world');
   }
 
   /**
@@ -168,7 +165,7 @@ class ArrayAccessTest extends TestCase {
   #[@test, @expect('lang.IndexOutOfBoundsException')]
   public function vectorWriteElementNegativeKey() {
     $v= new Vector();
-    $v[-1]= new String('world');
+    $v[-1]= new Name('world');
   }
 
   /**
@@ -178,7 +175,7 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function vectorTestElement() {
     $v= new Vector();
-    $v[]= new String('world');
+    $v[]= new Name('world');
     $this->assertTrue(isset($v[0]));
     $this->assertFalse(isset($v[1]));
     $this->assertFalse(isset($v[-1]));
@@ -191,7 +188,7 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function vectorRemoveElement() {
     $v= new Vector();
-    $v[]= new String('world');
+    $v[]= new Name('world');
     unset($v[0]);
     $this->assertFalse(isset($v[0]));
   }
@@ -202,141 +199,11 @@ class ArrayAccessTest extends TestCase {
    */
   #[@test]
   public function vectorIsUsableInForeach() {
-    $values= array(new String('hello'), new String('world'));
+    $values= array(new Name('hello'), new Name('world'));
     foreach (new Vector($values) as $i => $value) {
       $this->assertEquals($values[$i], $value);
     }
     $this->assertEquals(sizeof($values)- 1, $i);
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test]
-  public function stringReadChar() {
-    $s= new String('Hello');
-    $this->assertEquals(new \lang\types\Character('H'), $s[0]);
-    $this->assertEquals(new \lang\types\Character('e'), $s[1]);
-    $this->assertEquals(new \lang\types\Character('l'), $s[2]);
-    $this->assertEquals(new \lang\types\Character('l'), $s[3]);
-    $this->assertEquals(new \lang\types\Character('o'), $s[4]);
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
-  public function stringReadBeyondOffset() {
-    $s= new String('Hello');
-    $s[5];
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
-  public function stringReadNegativeOffset() {
-    $s= new String('Hello');
-    $s[-1];
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test]
-  public function stringReadUtfChar() {
-    $s= new String('Übercoder', 'iso-8859-1');
-    $this->assertEquals(new \lang\types\Character('Ü', 'iso-8859-1'), $s[0]);
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test]
-  public function stringWriteChar() {
-    $s= new String('Übercoder', 'iso-8859-1');
-    $s[0]= 'U';
-    $this->assertEquals(new String('Ubercoder'), $s);
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test]
-  public function stringWriteUtfChar() {
-    $s= new String('Ubercoder');
-    $s[0]= new \lang\types\Character('Ü', 'iso-8859-1');
-    $this->assertEquals(new String('Übercoder', 'iso-8859-1'), $s);
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
-  public function stringWriteMoreThanOneChar() {
-    $s= new String('Hallo');
-    $s[0]= 'Halli H';   // Hoping somehow this would become "Halli Hallo":)
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
-  public function stringWriteBeyondOffset() {
-    $s= new String('Hello');
-    $s[5]= 's';
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
-  public function stringWriteNegativeOffset() {
-    $s= new String('Hello');
-    $s[-1]= "\x00";
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
-  public function stringAppend() {
-    $s= new String('Hello');
-    $s[]= ' ';   // use concat() instead
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test]
-  public function stringTestChar() {
-    $s= new String('Übercoder', 'iso-8859-1');
-    $this->assertTrue(isset($s[0]));
-    $this->assertTrue(isset($s[$s->length()- 1]));
-    $this->assertFalse(isset($s[$s->length()]));
-    $this->assertFalse(isset($s[-1]));
-  }
-
-  /**
-   * Tests string class array access operator overloading
-   *
-   */
-  #[@test]
-  public function stringRemoveChar() {
-    $s= new String('Übercoder', 'iso-8859-1');
-    unset($s[0]);
-    $this->assertEquals(new String('bercoder'), $s);
   }
 
   /**
@@ -346,8 +213,8 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashSetAddElement() {
     $s= new HashSet();
-    $s[]= new String('X');
-    $this->assertTrue($s->contains(new String('X')));
+    $s[]= new Name('X');
+    $this->assertTrue($s->contains(new Name('X')));
   }
 
   /**
@@ -357,7 +224,7 @@ class ArrayAccessTest extends TestCase {
   #[@test, @expect('lang.IllegalArgumentException')]
   public function hashSetWriteElement() {
     $s= new HashSet();
-    $s[0]= new String('X');
+    $s[0]= new Name('X');
   }
 
   /**
@@ -367,7 +234,7 @@ class ArrayAccessTest extends TestCase {
   #[@test, @expect('lang.IllegalArgumentException')]
   public function hashSetReadElement() {
     $s= new HashSet();
-    $s[]= new String('X');
+    $s[]= new Name('X');
     $x= $s[0];
   }
 
@@ -378,9 +245,9 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashSetTestElement() {
     $s= new HashSet();
-    $this->assertFalse(isset($s[new String('X')]));
-    $s[]= new String('X');
-    $this->assertTrue(isset($s[new String('X')]));
+    $this->assertFalse(isset($s[new Name('X')]));
+    $s[]= new Name('X');
+    $this->assertTrue(isset($s[new Name('X')]));
   }
 
   /**
@@ -390,9 +257,9 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashSetRemoveElement() {
     $s= new HashSet();
-    $s[]= new String('X');
-    unset($s[new String('X')]);
-    $this->assertFalse(isset($s[new String('X')]));
+    $s[]= new Name('X');
+    unset($s[new Name('X')]);
+    $this->assertFalse(isset($s[new Name('X')]));
   }
 
   /**
@@ -402,9 +269,9 @@ class ArrayAccessTest extends TestCase {
   #[@test]
   public function hashSetUsableInForeach() {
     $s= new HashSet();
-    $s->addAll(array(new String('0'), new String('1'), new String('2')));
+    $s->addAll(array(new Name('0'), new Name('1'), new Name('2')));
     foreach ($s as $i => $element) {
-      $this->assertEquals(new String($i), $element);
+      $this->assertEquals(new Name($i), $element);
     }
   }
 }

--- a/src/test/php/net/xp_framework/unittest/util/collections/HashTableTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/HashTableTest.class.php
@@ -1,9 +1,7 @@
 <?php namespace net\xp_framework\unittest\util\collections;
  
-use unittest\TestCase;
 use util\collections\HashTable;
 use util\collections\Pair;
-use lang\types\String;
 use lang\types\Integer;
 use lang\types\Double;
 
@@ -12,7 +10,7 @@ use lang\types\Double;
  *
  * @see   xp://util.collections.HashTable
  */
-class HashTableTest extends TestCase {
+class HashTableTest extends \unittest\TestCase {
 
   /** @return var[] */
   protected function fixtures() {
@@ -22,12 +20,12 @@ class HashTableTest extends TestCase {
         new Pair('price', null)
       ]],
       [new HashTable(), [
-        new Pair(new String('color'), new String('green')),
-        new Pair(new String('price'), new Double(12.99))
+        new Pair(new Name('color'), new Name('green')),
+        new Pair(new Name('price'), new Double(12.99))
       ]],
-      [create('new util.collections.HashTable<string, lang.types.String>'), [
-        new Pair('hello', new String('World')),
-        new Pair('hallo', new String('Welt'))
+      [create('new util.collections.HashTable<string, net.xp_framework.unittest.util.collections.Name>'), [
+        new Pair('hello', new Name('World')),
+        new Pair('hallo', new Name('Welt'))
       ]],
       [create('new util.collections.HashTable<lang.types.Integer, string[]>'), [
         new Pair(new Integer(1), ['one', 'eins']),
@@ -115,17 +113,17 @@ class HashTableTest extends TestCase {
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function put_illegal_type_in_key() {
-    create('new util.collections.HashTable<string, lang.types.String>')->put(5, new String('hello'));
+    create('new util.collections.HashTable<string, net.xp_framework.unittest.util.collections.Name>')->put(5, new Name('hello'));
   }
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function put_illegal_type_in_value() {
-    create('new util.collections.HashTable<string, lang.types.String>')->put('hello', new Integer(1));
+    create('new util.collections.HashTable<string, net.xp_framework.unittest.util.collections.Name>')->put('hello', new Integer(1));
   }
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function put_raises_when_using_null_for_string_instance() {
-    create('new util.collections.HashTable<string, lang.types.String>')->put('test', null);
+    create('new util.collections.HashTable<string, net.xp_framework.unittest.util.collections.Name>')->put('test', null);
   }
 
   #[@test, @expect('lang.IllegalArgumentException')]
@@ -157,7 +155,7 @@ class HashTableTest extends TestCase {
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function get_illegal_type_in_argument() {
-    create('new util.collections.HashTable<lang.types.String, lang.types.String>')->get(new Integer(1));
+    create('new util.collections.HashTable<net.xp_framework.unittest.util.collections.Name, net.xp_framework.unittest.util.collections.Name>')->get(new Integer(1));
   }
 
   #[@test, @values('fixtures')]
@@ -184,7 +182,7 @@ class HashTableTest extends TestCase {
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function containsKey_illegal_type_in_argument() {
-    create('new util.collections.HashTable<lang.types.String, lang.types.String>')->containsKey(new Integer(1));
+    create('new util.collections.HashTable<net.xp_framework.unittest.util.collections.Name, net.xp_framework.unittest.util.collections.Name>')->containsKey(new Integer(1));
   }
 
   #[@test, @values('fixtures')]
@@ -200,7 +198,7 @@ class HashTableTest extends TestCase {
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function containsValue_illegal_type_in_argument() {
-    create('new util.collections.HashTable<lang.types.String, lang.types.String>')->containsValue(new Integer(1));
+    create('new util.collections.HashTable<net.xp_framework.unittest.util.collections.Name, net.xp_framework.unittest.util.collections.Name>')->containsValue(new Integer(1));
   }
 
   #[@test, @values('fixtures')]
@@ -237,7 +235,7 @@ class HashTableTest extends TestCase {
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function remove_illegal_type_in_argument() {
-    create('new util.collections.HashTable<lang.types.String, lang.types.String>')->remove(new Integer(1));
+    create('new util.collections.HashTable<net.xp_framework.unittest.util.collections.Name, net.xp_framework.unittest.util.collections.Name>')->remove(new Integer(1));
   }
 
   #[@test, @values('fixtures')]
@@ -370,8 +368,8 @@ class HashTableTest extends TestCase {
   #[@test]
   public function string_representation_of_generic_map() {
     $this->assertEquals(
-      'util.collections.HashTable<string,lang.types.String>[0] { }',
-      create('new util.collections.HashTable<string, lang.types.String>')->toString()
+      'util.collections.HashTable<string,net.xp_framework.unittest.util.collections.Name>[0] { }',
+      create('new util.collections.HashTable<string, net.xp_framework.unittest.util.collections.Name>')->toString()
     );
   }
 }

--- a/src/test/php/net/xp_framework/unittest/util/collections/LRUBufferTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/LRUBufferTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace net\xp_framework\unittest\util\collections;
 
 use util\collections\LRUBuffer;
-use lang\types\String;
 
 class LRUBufferTest extends \unittest\TestCase {
   const DEFAULT_SIZE = 3;
@@ -29,7 +28,7 @@ class LRUBufferTest extends \unittest\TestCase {
 
   #[@test]
   public function add() {
-    $this->buffer->add(new String('one'));
+    $this->buffer->add(new Name('one'));
     $this->assertEquals(1, $this->buffer->numElements());
   }
 
@@ -40,7 +39,7 @@ class LRUBufferTest extends \unittest\TestCase {
     // elements to the LRUBuffer. Nothing should be deleted from it
     // during this loop.
     for ($i= 0, $s= $this->buffer->getSize(); $i < $s; $i++) {
-      if (null === ($victim= $this->buffer->add(new String('item #'.$i)))) continue;
+      if (null === ($victim= $this->buffer->add(new Name('item #'.$i)))) continue;
       
       return $this->fail(
         'Victim '.\xp::stringOf($victim).' when inserting item #'.($i + 1).'/'.$s, 
@@ -52,8 +51,8 @@ class LRUBufferTest extends \unittest\TestCase {
     // The LRUBuffer is now "full". Next time we add something, the
     // element last recently used should be returned.
     $this->assertEquals(
-      new String('item #0'), 
-      $this->buffer->add(new String('last item'))
+      new Name('item #0'), 
+      $this->buffer->add(new Name('last item'))
     );
   }
   
@@ -64,7 +63,7 @@ class LRUBufferTest extends \unittest\TestCase {
    */
   protected function addElements($num) {
     for ($i= 0; $i < $num; $i++) {
-      $this->buffer->add(new String('item #'.$i));
+      $this->buffer->add(new Name('item #'.$i));
     }
   }
   
@@ -81,13 +80,13 @@ class LRUBufferTest extends \unittest\TestCase {
     $this->addElements($this->buffer->getSize());
     
     // Update the first item
-    $this->buffer->update(new String('item #0'));
+    $this->buffer->update(new Name('item #0'));
     
     // Now the second item should be chosen the victim when adding 
     // another element
     $this->assertEquals(
-      new String('item #1'), 
-      $this->buffer->add(new String('last item'))
+      new Name('item #1'), 
+      $this->buffer->add(new Name('last item'))
     );
   }
 
@@ -115,7 +114,7 @@ class LRUBufferTest extends \unittest\TestCase {
   #[@test]
   public function doesNotEqualWithSameElements() {
     $other= new LRUBuffer(self::DEFAULT_SIZE);
-    with ($string= new String('Hello')); {
+    with ($string= new Name('Hello')); {
       $other->add($string);
       $this->buffer->add($string);
     }

--- a/src/test/php/net/xp_framework/unittest/util/collections/Name.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/Name.class.php
@@ -1,0 +1,39 @@
+<?php namespace net\xp_framework\unittest\util\collections;
+
+class Name extends \lang\Object {
+  private $value;
+
+  /** @param string $value */
+  public function __construct($value) { $this->value= (string)$value; }
+
+  /** @return string */
+  public function value() { return $this->value; }
+
+  /**
+   * Returns a hashcode
+   *
+   * @return string
+   */
+  public function hashCode() {
+    return crc32($this->value);
+  }
+
+  /**
+   * Returns whether this name is equal to another
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && $this->value === $cmp->value;
+  }
+
+  /**
+   * Returns a string representation
+   *
+   * @return string
+   */
+  public function toString() {
+    return $this->value;
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/util/collections/PairTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/PairTest.class.php
@@ -1,117 +1,78 @@
 <?php namespace net\xp_framework\unittest\util\collections;
 
-use unittest\TestCase;
 use util\collections\Pair;
-use lang\types\String;
-
 
 /**
  * Test Pair class
  *
  * @see  xp://util.collections.Pair
  */
-class PairTest extends TestCase {
+class PairTest extends \unittest\TestCase {
 
-  /**
-   * Tests constructor
-   */
   #[@test]
   public function can_create() {
     new Pair(null, null);
   }
 
-  /**
-   * Tests key member
-   */
   #[@test]
   public function key() {
     $p= new Pair('key', null);
     $this->assertEquals('key', $p->key);
   }
 
-  /**
-   * Tests value member
-   */
   #[@test]
   public function value() {
     $p= new Pair(null, 'value');
     $this->assertEquals('value', $p->value);
   }
 
-  /**
-   * Tests equals() method
-   */
   #[@test]
   public function equals_same_instance() {
     $p= new Pair(null, null);
     $this->assertEquals($p, $p);
   }
 
-  /**
-   * Tests equals() method
-   */
   #[@test]
   public function equals_null_key_null_value() {
     $this->assertEquals(new Pair(null, null), new Pair(null, null));
   }
 
-  /**
-   * Tests equals() method
-   */
   #[@test]
   public function equals_primitive_key_null_value() {
     $this->assertEquals(new Pair('key', null), new Pair('key', null));
   }
 
-  /**
-   * Tests equals() method
-   */
   #[@test]
   public function equals_primitive_key_primitive_value() {
     $this->assertEquals(new Pair('key', 'value'), new Pair('key', 'value'));
   }
 
-  /**
-   * Tests equals() method
-   */
   #[@test]
   public function equals_key_instance_value_instance() {
     $this->assertEquals(
-      new Pair(new String('key'), new String('value')),
-      new Pair(new String('key'), new String('value'))
+      new Pair(new Name('key'), new Name('value')),
+      new Pair(new Name('key'), new Name('value'))
     );
   }
 
-  /**
-   * Tests equals() method
-   */
   #[@test]
   public function primitive_key_and_value_not_equal_to_null_key_and_value() {
     $this->assertNotEquals(new Pair('key', 'value'), new Pair(null, null));
   }
 
-  /**
-   * Tests equals() method
-   */
   #[@test]
   public function instance_key_and_value_not_equal_to_null_key_and_value() {
     $this->assertNotEquals(
-      new Pair(new String('key'), new String('value')),
+      new Pair(new Name('key'), new Name('value')),
       new Pair(null, null)
     );
   }
 
-  /**
-   * Tests equals() method
-   */
   #[@test]
   public function pair_not_equals_to_null() {
     $this->assertNotEquals(new Pair(null, null), null);
   }
 
-  /**
-   * Tests hashCode() method
-   */
   #[@test]
   public function hashcode_of_nulls_equal() {
     $this->assertEquals(
@@ -120,9 +81,6 @@ class PairTest extends TestCase {
     );
   }
 
-  /**
-   * Tests hashCode() method
-   */
   #[@test]
   public function hashcode_of_different_keys_not_equal() {
     $this->assertNotEquals(
@@ -131,9 +89,6 @@ class PairTest extends TestCase {
     );
   }
 
-  /**
-   * Tests hashCode() method
-   */
   #[@test]
   public function hashcode_of_different_values_not_equal() {
     $this->assertNotEquals(

--- a/src/test/php/net/xp_framework/unittest/util/collections/QueueTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/QueueTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace net\xp_framework\unittest\util\collections;
  
 use util\collections\Queue;
-use lang\types\String;
 
 class QueueTest extends \unittest\TestCase {
   private $queue;
@@ -22,20 +21,20 @@ class QueueTest extends \unittest\TestCase {
 
   #[@test]
   public function equalsClone() {
-    $this->queue->put(new String('green'));
+    $this->queue->put(new Name('green'));
     $this->assertTrue($this->queue->equals(clone($this->queue)));
   }
 
   #[@test]
   public function put() {
-    $this->queue->put(new String('green'));
+    $this->queue->put(new Name('green'));
     $this->assertFalse($this->queue->isEmpty());
     $this->assertEquals(1, $this->queue->size());
   }
 
   #[@test]
   public function get() {
-    $color= new String('red');
+    $color= new Name('red');
     $this->queue->put($color);
     $this->assertEquals($color, $this->queue->get());
     $this->assertTrue($this->queue->isEmpty());
@@ -48,7 +47,7 @@ class QueueTest extends \unittest\TestCase {
 
   #[@test]
   public function peek() {
-    $color= new String('blue');
+    $color= new Name('blue');
     $this->queue->put($color);
     $this->assertEquals($color, $this->queue->peek());
     $this->assertFalse($this->queue->isEmpty());
@@ -61,7 +60,7 @@ class QueueTest extends \unittest\TestCase {
 
   #[@test]
   public function remove() {
-    $color= new String('blue');
+    $color= new Name('blue');
     $this->queue->put($color);
     $this->queue->remove($color);
     $this->assertTrue($this->queue->isEmpty());
@@ -69,28 +68,28 @@ class QueueTest extends \unittest\TestCase {
 
   #[@test]
   public function removeReturnsWhetherDeleted() {
-    $color= new String('pink');
+    $color= new Name('pink');
     $this->queue->put($color);
     $this->assertTrue($this->queue->remove($color));
-    $this->assertFalse($this->queue->remove(new String('purple')));
+    $this->assertFalse($this->queue->remove(new Name('purple')));
     $this->assertTrue($this->queue->isEmpty());
     $this->assertFalse($this->queue->remove($color));
-    $this->assertFalse($this->queue->remove(new String('purple')));
+    $this->assertFalse($this->queue->remove(new Name('purple')));
   }
 
   #[@test]
   public function elementAt() {
-    $this->queue->put(new String('red'));
-    $this->queue->put(new String('green'));
-    $this->queue->put(new String('blue'));
-    $this->assertEquals(new String('red'), $this->queue->elementAt(0));
-    $this->assertEquals(new String('green'), $this->queue->elementAt(1));
-    $this->assertEquals(new String('blue'), $this->queue->elementAt(2));
+    $this->queue->put(new Name('red'));
+    $this->queue->put(new Name('green'));
+    $this->queue->put(new Name('blue'));
+    $this->assertEquals(new Name('red'), $this->queue->elementAt(0));
+    $this->assertEquals(new Name('green'), $this->queue->elementAt(1));
+    $this->assertEquals(new Name('blue'), $this->queue->elementAt(2));
   }
 
   #[@test]
   public function iterativeUse() {
-    $input= array(new String('red'), new String('green'), new String('blue'));
+    $input= array(new Name('red'), new Name('green'), new Name('blue'));
     
     // Add
     for ($i= 0, $s= sizeof($input); $i < sizeof($input); $i++) {
@@ -117,7 +116,7 @@ class QueueTest extends \unittest\TestCase {
 
   #[@test, @expect('lang.IndexOutOfBoundsException')]
   public function elementAtOffsetOutOfBounds() {
-    $this->queue->put(new String('one'));
+    $this->queue->put(new Name('one'));
     $this->queue->elementAt($this->queue->size() + 1);
   }
 

--- a/src/test/php/net/xp_framework/unittest/util/collections/StackTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/StackTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace net\xp_framework\unittest\util\collections;
  
 use util\collections\Stack;
-use lang\types\String;
 
 class StackTest extends \unittest\TestCase {
   private $stack;
@@ -22,20 +21,20 @@ class StackTest extends \unittest\TestCase {
 
   #[@test]
   public function equalsClone() {
-    $this->stack->push(new String('green'));
+    $this->stack->push(new Name('green'));
     $this->assertTrue($this->stack->equals(clone($this->stack)));
   }
 
   #[@test]
   public function push() {
-    $this->stack->push(new String('green'));
+    $this->stack->push(new Name('green'));
     $this->assertFalse($this->stack->isEmpty());
     $this->assertEquals(1, $this->stack->size());
   }
 
   #[@test]
   public function pop() {
-    $color= new String('green');
+    $color= new Name('green');
     $this->stack->push($color);
     $this->assertEquals($color, $this->stack->pop());
     $this->assertTrue($this->stack->isEmpty());
@@ -43,7 +42,7 @@ class StackTest extends \unittest\TestCase {
 
   #[@test]
   public function peek() {
-    $color= new String('green');
+    $color= new Name('green');
     $this->stack->push($color);
     $this->assertEquals($color, $this->stack->peek());
     $this->assertFalse($this->stack->isEmpty());
@@ -51,21 +50,21 @@ class StackTest extends \unittest\TestCase {
 
   #[@test]
   public function search() {
-    $color= new String('green');
+    $color= new Name('green');
     $this->stack->push($color);
     $this->assertEquals(0, $this->stack->search($color));
-    $this->assertEquals(-1, $this->stack->search(new String('non-existant')));
+    $this->assertEquals(-1, $this->stack->search(new Name('non-existant')));
   }
 
   #[@test]
   public function elementAt() {
-    $this->stack->push(new String('red'));
-    $this->stack->push(new String('green'));
-    $this->stack->push(new String('blue'));
+    $this->stack->push(new Name('red'));
+    $this->stack->push(new Name('green'));
+    $this->stack->push(new Name('blue'));
 
-    $this->assertEquals(new String('blue'), $this->stack->elementAt(0));
-    $this->assertEquals(new String('green'), $this->stack->elementAt(1));
-    $this->assertEquals(new String('red'), $this->stack->elementAt(2));
+    $this->assertEquals(new Name('blue'), $this->stack->elementAt(0));
+    $this->assertEquals(new Name('green'), $this->stack->elementAt(1));
+    $this->assertEquals(new Name('red'), $this->stack->elementAt(2));
   }
 
   #[@test, @expect('lang.IndexOutOfBoundsException')]

--- a/src/test/php/net/xp_framework/unittest/util/collections/VectorTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/VectorTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\util\collections;
 
-use unittest\TestCase;
-use lang\types\String;
+use lang\Object;
+use lang\IllegalArgumentException;
 use lang\types\ArrayList;
 use util\collections\Vector;
 
@@ -10,7 +10,7 @@ use util\collections\Vector;
  *
  * @see  xp://util.collections.Vector
  */
-class VectorTest extends TestCase {
+class VectorTest extends \unittest\TestCase {
 
   #[@test]
   public function initiallyEmpty() {
@@ -24,7 +24,7 @@ class VectorTest extends TestCase {
   
   #[@test]
   public function nonEmptyVector() {
-    $v= new Vector([new \lang\Object()]);
+    $v= new Vector([new Object()]);
     $this->assertEquals(1, $v->size());
     $this->assertFalse($v->isEmpty());
   }
@@ -32,14 +32,14 @@ class VectorTest extends TestCase {
   #[@test]
   public function adding() {
     $v= new Vector();
-    $v->add(new \lang\Object());
+    $v->add(new Object());
     $this->assertEquals(1, $v->size());
   }
 
   #[@test]
   public function addAllArray() {
     $v= new Vector();
-    $this->assertTrue($v->addAll([new \lang\Object(), new \lang\Object()]));
+    $this->assertTrue($v->addAll([new Object(), new Object()]));
     $this->assertEquals(2, $v->size());
   }
 
@@ -47,8 +47,8 @@ class VectorTest extends TestCase {
   public function addAllVector() {
     $v1= new Vector();
     $v2= new Vector();
-    $v2->add(new \lang\Object());
-    $v2->add(new \lang\Object());
+    $v2->add(new Object());
+    $v2->add(new Object());
     $this->assertTrue($v1->addAll($v2));
     $this->assertEquals(2, $v1->size());
   }
@@ -56,7 +56,7 @@ class VectorTest extends TestCase {
   #[@test]
   public function addAllArrayList() {
     $v= new Vector();
-    $this->assertTrue($v->addAll(new ArrayList(new \lang\Object(), new \lang\Object())));
+    $this->assertTrue($v->addAll(new ArrayList(new Object(), new Object())));
     $this->assertEquals(2, $v->size());
   }
 
@@ -79,9 +79,9 @@ class VectorTest extends TestCase {
   public function unchangedAfterNullInAddAll() {
     $v= create('new util.collections.Vector<Object>()');
     try {
-      $v->addAll([new \lang\Object(), null]);
+      $v->addAll([new Object(), null]);
       $this->fail('addAll() did not throw an exception', null, 'lang.IllegalArgumentException');
-    } catch (\lang\IllegalArgumentException $expected) {
+    } catch (IllegalArgumentException $expected) {
     }
     $this->assertTrue($v->isEmpty());
   }
@@ -92,7 +92,7 @@ class VectorTest extends TestCase {
     try {
       $v->addAll(['hello', 5]);
       $this->fail('addAll() did not throw an exception', null, 'lang.IllegalArgumentException');
-    } catch (\lang\IllegalArgumentException $expected) {
+    } catch (IllegalArgumentException $expected) {
     }
     $this->assertTrue($v->isEmpty());
   }
@@ -105,32 +105,32 @@ class VectorTest extends TestCase {
   #[@test]
   public function replacing() {
     $v= new Vector();
-    $o= new String('one');
+    $o= new Name('one');
     $v->add($o);
-    $r= $v->set(0, new String('two'));
+    $r= $v->set(0, new Name('two'));
     $this->assertEquals(1, $v->size());
     $this->assertEquals($o, $r);
   }
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function replacingWithNull() {
-    create('new util.collections.Vector<Object>', [new \lang\Object()])->set(0, null);
+    create('new util.collections.Vector<Object>', [new Object()])->set(0, null);
   }
 
   #[@test, @expect('lang.IndexOutOfBoundsException')]
   public function settingPastEnd() {
-    (new Vector())->set(0, new \lang\Object());
+    (new Vector())->set(0, new Object());
   }
 
   #[@test, @expect('lang.IndexOutOfBoundsException')]
   public function settingNegative() {
-    (new Vector())->set(-1, new \lang\Object());
+    (new Vector())->set(-1, new Object());
   }
 
   #[@test]
   public function reading() {
     $v= new Vector();
-    $o= new String('one');
+    $o= new Name('one');
     $v->add($o);
     $r= $v->get(0);
     $this->assertEquals($o, $r);
@@ -149,7 +149,7 @@ class VectorTest extends TestCase {
   #[@test]
   public function removing() {
     $v= new Vector();
-    $o= new String('one');
+    $o= new Name('one');
     $v->add($o);
     $r= $v->remove(0);
     $this->assertEquals(0, $v->size());
@@ -168,7 +168,7 @@ class VectorTest extends TestCase {
 
   #[@test]
   public function clearing() {
-    $v= new Vector([new String('Goodbye cruel world')]);
+    $v= new Vector([new Name('Goodbye cruel world')]);
     $this->assertFalse($v->isEmpty());
     $v->clear();
     $this->assertTrue($v->isEmpty());
@@ -181,55 +181,55 @@ class VectorTest extends TestCase {
 
   #[@test]
   public function elementsOf() {
-    $el= [new String('a'), new \lang\Object()];
+    $el= [new Name('a'), new Object()];
     $this->assertEquals($el, (new Vector($el))->elements());
   }
 
   #[@test]
-  public function addedStringIsContained() {
+  public function addedNameIsContained() {
     $v= new Vector();
-    $o= new String('one');
+    $o= new Name('one');
     $v->add($o);
     $this->assertTrue($v->contains($o));
   }
 
   #[@test]
-  public function emptyVectorDoesNotContainString() {
-    $this->assertFalse((new Vector())->contains(new \lang\Object()));
+  public function emptyVectorDoesNotContainName() {
+    $this->assertFalse((new Vector())->contains(new Object()));
   }
 
   #[@test]
   public function indexOfOnEmptyVector() {
-    $this->assertFalse((new Vector())->indexOf(new \lang\Object()));
+    $this->assertFalse((new Vector())->indexOf(new Object()));
   }
 
   #[@test]
   public function indexOf() {
-    $a= new String('A');
+    $a= new Name('A');
     $this->assertEquals(0, (new Vector([$a]))->indexOf($a));
   }
 
   #[@test]
   public function indexOfElementContainedTwice() {
-    $a= new String('A');
-    $this->assertEquals(0, (new Vector([$a, new \lang\Object(), $a]))->indexOf($a));
+    $a= new Name('A');
+    $this->assertEquals(0, (new Vector([$a, new Object(), $a]))->indexOf($a));
   }
 
   #[@test]
   public function lastIndexOfOnEmptyVector() {
-    $this->assertFalse((new Vector())->lastIndexOf(new \lang\Object()));
+    $this->assertFalse((new Vector())->lastIndexOf(new Object()));
   }
 
   #[@test]
   public function lastIndexOf() {
-    $a= new String('A');
+    $a= new Name('A');
     $this->assertEquals(0, (new Vector([$a]))->lastIndexOf($a));
   }
 
   #[@test]
   public function lastIndexOfElementContainedTwice() {
-    $a= new String('A');
-    $this->assertEquals(2, (new Vector([$a, new \lang\Object(), $a]))->lastIndexOf($a));
+    $a= new Name('A');
+    $this->assertEquals(2, (new Vector([$a, new Object(), $a]))->lastIndexOf($a));
   }
 
   #[@test]
@@ -244,7 +244,7 @@ class VectorTest extends TestCase {
   public function stringOf() {
     $this->assertEquals(
       "util.collections.Vector[2]@{\n  0: One\n  1: Two\n}",
-      (new Vector([new String('One'), new String('Two')]))->toString()
+      (new Vector([new Name('One'), new Name('Two')]))->toString()
     );
   }
 
@@ -252,13 +252,13 @@ class VectorTest extends TestCase {
   public function iteration() {
     $v= new Vector();
     for ($i= 0; $i < 5; $i++) {
-      $v->add(new String('#'.$i));
+      $v->add(new Name('#'.$i));
     }
     
     $i= 0;
     foreach ($v as $offset => $string) {
       $this->assertEquals($offset, $i);
-      $this->assertEquals(new String('#'.$i), $string);
+      $this->assertEquals(new Name('#'.$i), $string);
       $i++;
     }
   }
@@ -270,14 +270,14 @@ class VectorTest extends TestCase {
 
   #[@test]
   public function sameVectorsAreEqual() {
-    $a= new Vector([new String('One'), new String('Two')]);
+    $a= new Vector([new Name('One'), new Name('Two')]);
     $this->assertTrue($a->equals($a));
   }
 
   #[@test]
   public function vectorsWithSameContentsAreEqual() {
-    $a= new Vector([new String('One'), new String('Two')]);
-    $b= new Vector([new String('One'), new String('Two')]);
+    $a= new Vector([new Name('One'), new Name('Two')]);
+    $b= new Vector([new Name('One'), new Name('Two')]);
     $this->assertTrue($a->equals($b));
   }
 
@@ -288,13 +288,13 @@ class VectorTest extends TestCase {
 
   #[@test]
   public function twoVectorsOfDifferentSizeAreNotEqual() {
-    $this->assertFalse((new Vector([new \lang\Object()]))->equals(new Vector()));
+    $this->assertFalse((new Vector([new Object()]))->equals(new Vector()));
   }
 
   #[@test]
   public function orderMattersForEquality() {
-    $a= [new String('a'), new String('b')];
-    $b= [new String('b'), new String('a')];
+    $a= [new Name('a'), new Name('b')];
+    $b= [new Name('b'), new Name('a')];
     $this->assertFalse((new Vector($a))->equals(new Vector($b)));
   }
 }


### PR DESCRIPTION
This pull request implements the part of xp-framework/rfc#298 suggesting to deprecate `lang.types`, primitive boxing and unboxing

* [x] Add `@deprecated` markers to lang.types
* [x] Add `@deprecated` markers to boxed(), unboxed() and wrapperClass() methods in `lang.Primitive`
* [x] Remove lang.types.* from classes auto-loaded at startup
* [x] Adjust test suite to no longer use lang.types if not necessary

*Historic note: Wrapper types were introduced in 2005 - https://github.com/xp-framework/rfc/issues/38*