### PR TITLE
Value interface

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -164,7 +164,7 @@ final class xp {
       return '<null>';
     } else if (is_int($arg) || is_float($arg)) {
       return (string)$arg;
-    } else if ($arg instanceof \lang\Generic && !isset($protect[(string)$arg->hashCode()])) {
+    } else if (($arg instanceof \lang\Generic || $arg instanceof \lang\Value) && !isset($protect[(string)$arg->hashCode()])) {
       $protect[(string)$arg->hashCode()]= true;
       $s= $arg->toString();
       unset($protect[(string)$arg->hashCode()]);

--- a/src/main/php/lang/Value.class.php
+++ b/src/main/php/lang/Value.class.php
@@ -1,0 +1,34 @@
+<?php namespace lang;
+
+/**
+ * Implementing the value interface marks a value object, which may be compared,
+ * hashed, and represented as a string.
+ */
+interface Value {
+
+  /**
+   * Compares this value to a given other value. Returns 0 if the values are
+   * equal, a negative integer if `$this < $cmp`, and a positive integer if 
+   * `$this > $cmp`.
+   *
+   * @see    https://wiki.php.net/rfc/comparable
+   * @param  var $cmp
+   * @return int
+   */
+  public function compareTo($cmp);
+
+  /**
+   * Calculates a hashcode and makes this value useable in e.g. collections.
+   *
+   * @see    php://spl_object_hash
+   * @return string
+   */
+  public function hashCode();
+
+  /**
+   * Creates a string representation of this value.
+   *
+   * @return string
+   */
+  public function toString();
+}

--- a/src/main/php/lang/types/ArrayList.class.php
+++ b/src/main/php/lang/types/ArrayList.class.php
@@ -2,6 +2,8 @@
 
 use lang\IndexOutOfBoundsException;
 use lang\IllegalArgumentException;
+use lang\Generic;
+use lang\Value;
 
 /**
  * Represents a "numeric" array
@@ -131,10 +133,18 @@ class ArrayList extends \lang\Object implements \ArrayAccess, \IteratorAggregate
    * @return  bool
    */
   public function contains($value) {
-    if (!$value instanceof \lang\Generic) {
+    if ($value instanceof Generic) {
+      foreach ($this->values as $v) {
+        if ($value->equals($v)) return true;
+      }
+      return false;
+    } else if ($value instanceof Value) {
+      foreach ($this->values as $v) {
+        if (0 === $value->compareTo($v)) return true;
+      }
+      return false;
+    } else {
       return in_array($value, $this->values, true);
-    } else foreach ($this->values as $v) {
-      if ($value->equals($v)) return true;
     }
     return false;
   }

--- a/src/main/php/lang/types/ArrayMap.class.php
+++ b/src/main/php/lang/types/ArrayMap.class.php
@@ -1,6 +1,9 @@
 <?php namespace lang\types;
 
 use lang\IndexOutOfBoundsException;
+use lang\IllegalArgumentException;
+use lang\Generic;
+use lang\Value;
 
 /**
  * Represents a mapped array
@@ -65,7 +68,7 @@ class ArrayMap extends \lang\Object implements \ArrayAccess, \IteratorAggregate 
    */
   public function offsetSet($key, $value) {
     if (!is_string($key)) {
-      throw new \lang\IllegalArgumentException('Incorrect type '.gettype($key).' for index');
+      throw new IllegalArgumentException('Incorrect type '.gettype($key).' for index');
     }
     $this->values[$key]= $value;
   }
@@ -107,12 +110,19 @@ class ArrayMap extends \lang\Object implements \ArrayAccess, \IteratorAggregate 
    * @return  bool
    */
   public function contains($value) {
-    if (!$value instanceof \lang\Generic) {
+    if ($value instanceof Generic) {
+      foreach ($this->values as $v) {
+        if ($value->equals($v)) return true;
+      }
+      return false;
+    } else if ($value instanceof Value) {
+      foreach ($this->values as $v) {
+        if (0 === $value->compareTo($v)) return true;
+      }
+      return false;
+    } else {
       return in_array($value, $this->values, true);
-    } else foreach ($this->values as $v) {
-      if ($value->equals($v)) return true;
     }
-    return false;
   }
   
   /**

--- a/src/main/php/unittest/ComparisonFailedMessage.class.php
+++ b/src/main/php/unittest/ComparisonFailedMessage.class.php
@@ -1,6 +1,7 @@
 <?php namespace unittest;
 
 use lang\Generic;
+use lang\Value;
 
 /**
  * The message for an assertion failure
@@ -78,6 +79,9 @@ class ComparisonFailedMessage extends \lang\Object implements AssertionFailedMes
     } else if ($this->expect instanceof Generic && $this->actual instanceof Generic) {
       $expect= $this->stringOf($this->expect, null);
       $actual= $this->stringOf($this->actual, null);
+    } else if ($this->expect instanceof Value && $this->actual instanceof Value) {
+      $expect= $this->expect->toString();
+      $actual= $this->actual->toString();
     } else {
       $te= \xp::typeOf($this->expect);
       $ta= \xp::typeOf($this->actual);

--- a/src/main/php/util/Objects.class.php
+++ b/src/main/php/util/Objects.class.php
@@ -1,6 +1,7 @@
 <?php namespace util;
 
 use lang\Generic;
+use lang\Value;
 
 /**
  * Objects utility methods
@@ -17,7 +18,9 @@ abstract class Objects extends \lang\Object {
    * @return  bool
    */
   public static function equal($a, $b) {
-    if ($a instanceof Generic) {
+    if ($a instanceof Value) {
+      return 0 === $a->compareTo($b);
+    } else if ($a instanceof Generic) {
       return $a->equals($b);
     } else if (is_array($a)) {
       if (!is_array($b) || sizeof($a) !== sizeof($b)) return false;

--- a/src/main/php/util/Objects.class.php
+++ b/src/main/php/util/Objects.class.php
@@ -43,7 +43,7 @@ abstract class Objects extends \lang\Object {
   public static function stringOf($val, $default= '') {
     if (null === $val) {
       return $default;
-    } else if ($val instanceof Generic) {
+    } else if ($val instanceof Generic || $val instanceof Value) {
       return $val->toString();
     } else {
       return \xp::stringOf($val);
@@ -59,7 +59,7 @@ abstract class Objects extends \lang\Object {
   public static function hashOf($val) {
     if (null === $val) {
       return 'N;';
-    } else if ($val instanceof Generic) {
+    } else if ($val instanceof Generic || $val instanceof Value) {
       return $val->hashCode();
     } else if ($val instanceof \Closure) {
       return spl_object_hash($val);

--- a/src/main/php/util/collections/Arrays.class.php
+++ b/src/main/php/util/collections/Arrays.class.php
@@ -2,6 +2,8 @@
 
 use lang\types\ArrayList;
 use util\Comparator;
+use lang\Generic;
+use lang\Value;
 
 /**
  * Various methods for working with arrays.
@@ -70,9 +72,13 @@ abstract class Arrays extends \lang\Object {
    * @return  bool
    */
   public static function contains(ArrayList $array, $search) {
-    if ($search instanceof \lang\Generic) {
+    if ($search instanceof eneric) {
       foreach ($array->values as $value) {
         if ($search->equals($value)) return true;
+      }
+    } else if ($search instanceof Value) {
+      foreach ($array->values as $value) {
+        if (0 === $search->compareTo($value)) return true;
       }
     } else {
       foreach ($array->values as $value) {

--- a/src/main/php/util/collections/Arrays.class.php
+++ b/src/main/php/util/collections/Arrays.class.php
@@ -72,7 +72,7 @@ abstract class Arrays extends \lang\Object {
    * @return  bool
    */
   public static function contains(ArrayList $array, $search) {
-    if ($search instanceof eneric) {
+    if ($search instanceof Generic) {
       foreach ($array->values as $value) {
         if ($search->equals($value)) return true;
       }

--- a/src/main/php/util/collections/HashSet.class.php
+++ b/src/main/php/util/collections/HashSet.class.php
@@ -1,5 +1,8 @@
 <?php namespace util\collections;
 
+use lang\Generic;
+use lang\Value;
+
 /**
  * A set of objects
  *
@@ -93,7 +96,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function add($element) { 
-    $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+    $h= $element instanceof Generic || $element instanceof Value ? $element->hashCode() : serialize($element);
     if (isset($this->_elements[$h])) return false;
     
     $this->_hash+= HashProvider::hashOf($h);
@@ -109,7 +112,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function remove($element) { 
-    $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+    $h= $element instanceof Generic || $element instanceof Value ? $element->hashCode() : serialize($element);
     if (!isset($this->_elements[$h])) return false;
 
     $this->_hash-= HashProvider::hashOf($h);
@@ -125,7 +128,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function contains($element) { 
-    $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+    $h= $element instanceof Generic || $element instanceof Value ? $element->hashCode() : serialize($element);
     return isset($this->_elements[$h]);
   }
 
@@ -166,7 +169,7 @@ class HashSet extends \lang\Object implements Set {
   public function addAll($elements) { 
     $changed= false;
     foreach ($elements as $element) {
-      $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+      $h= $element instanceof Generic || $element instanceof Value ? $element->hashCode() : serialize($element);
       if (isset($this->_elements[$h])) continue;
 
       $this->_hash+= HashProvider::hashOf($h);

--- a/src/main/php/util/collections/HashSet.class.php
+++ b/src/main/php/util/collections/HashSet.class.php
@@ -96,7 +96,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function add($element) { 
-    $h= $element instanceof Generic || $element instanceof Value ? $element->hashCode() : serialize($element);
+    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
     if (isset($this->_elements[$h])) return false;
     
     $this->_hash+= HashProvider::hashOf($h);
@@ -112,7 +112,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function remove($element) { 
-    $h= $element instanceof Generic || $element instanceof Value ? $element->hashCode() : serialize($element);
+    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
     if (!isset($this->_elements[$h])) return false;
 
     $this->_hash-= HashProvider::hashOf($h);
@@ -128,7 +128,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function contains($element) { 
-    $h= $element instanceof Generic || $element instanceof Value ? $element->hashCode() : serialize($element);
+    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
     return isset($this->_elements[$h]);
   }
 
@@ -169,7 +169,7 @@ class HashSet extends \lang\Object implements Set {
   public function addAll($elements) { 
     $changed= false;
     foreach ($elements as $element) {
-      $h= $element instanceof Generic || $element instanceof Value ? $element->hashCode() : serialize($element);
+      $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
       if (isset($this->_elements[$h])) continue;
 
       $this->_hash+= HashProvider::hashOf($h);

--- a/src/main/php/util/collections/HashTable.class.php
+++ b/src/main/php/util/collections/HashTable.class.php
@@ -101,7 +101,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K, V', return= 'V')]
   public function put($key, $value) {
-    $h= $key instanceof Generic || $key instanceof Value ? $key->hashCode() : serialize($key);
+    $h= ($key instanceof Generic || $key instanceof Value) ? $key->hashCode() : serialize($key);
     if (!isset($this->_buckets[$h])) {
       $previous= null;
     } else {
@@ -109,7 +109,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
     }
 
     $this->_buckets[$h]= array($key, $value);
-    $this->_hash+= HashProvider::hashOf($h.($value instanceof Generic || $value instanceof Value ? $value->hashCode() : serialize($value)));
+    $this->_hash+= HashProvider::hashOf($h.(($value instanceof Generic || $value instanceof Value) ? $value->hashCode() : serialize($value)));
     return $previous;
   }
 
@@ -122,7 +122,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K', return= 'V')]
   public function get($key) {
-    $h= $key instanceof Generic || $key instanceof Value ? $key->hashCode() : serialize($key);
+    $h= ($key instanceof Generic || $key instanceof Value) ? $key->hashCode() : serialize($key);
     return isset($this->_buckets[$h]) ? $this->_buckets[$h][1] : null; 
   }
   
@@ -136,12 +136,12 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K', return= 'V')]
   public function remove($key) {
-    $h= $key instanceof Generic || $key instanceof Value ? $key->hashCode() : serialize($key);
+    $h= ($key instanceof Generic || $key instanceof Value) ? $key->hashCode() : serialize($key);
     if (!isset($this->_buckets[$h])) {
       $prev= null;
     } else {
       $prev= $this->_buckets[$h][1];
-      $this->_hash-= HashProvider::hashOf($h.($prev instanceof Generic || $prev instanceof Value ? $prev->hashCode() : serialize($prev)));
+      $this->_hash-= HashProvider::hashOf($h.(($prev instanceof Generic || $prev instanceof Value) ? $prev->hashCode() : serialize($prev)));
       unset($this->_buckets[$h]);
     }
 
@@ -183,7 +183,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K')]
   public function containsKey($key) {
-    $h= $key instanceof Generic || $key instanceof Value ? $key->hashCode() : serialize($key);
+    $h= ($key instanceof Generic || $key instanceof Value) ? $key->hashCode() : serialize($key);
     return isset($this->_buckets[$h]);
   }
 
@@ -195,9 +195,13 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'V')]
   public function containsValue($value) {
-    if ($value instanceof Generic || $value instanceof Value) {
+    if ($value instanceof Generic) {
       foreach (array_keys($this->_buckets) as $key) {
         if ($value->equals($this->_buckets[$key][1])) return true;
+      }
+    } else if ($value instanceof Value) {
+      foreach (array_keys($this->_buckets) as $key) {
+        if (0 === $value->compareTo($this->_buckets[$key][1])) return true;
       }
     } else {
       foreach (array_keys($this->_buckets) as $key) {

--- a/src/main/php/util/collections/HashTable.class.php
+++ b/src/main/php/util/collections/HashTable.class.php
@@ -2,6 +2,7 @@
 
 use lang\Primitive;
 use lang\Generic;
+use lang\Value;
 
 /**
  * Hash table consisting of non-null objects as keys and values
@@ -100,7 +101,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K, V', return= 'V')]
   public function put($key, $value) {
-    $h= $key instanceof Generic ? $key->hashCode() : serialize($key);
+    $h= $key instanceof Generic || $key instanceof Value ? $key->hashCode() : serialize($key);
     if (!isset($this->_buckets[$h])) {
       $previous= null;
     } else {
@@ -108,7 +109,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
     }
 
     $this->_buckets[$h]= array($key, $value);
-    $this->_hash+= HashProvider::hashOf($h.($value instanceof Generic ? $value->hashCode() : serialize($value)));
+    $this->_hash+= HashProvider::hashOf($h.($value instanceof Generic || $value instanceof Value ? $value->hashCode() : serialize($value)));
     return $previous;
   }
 
@@ -121,7 +122,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K', return= 'V')]
   public function get($key) {
-    $h= $key instanceof Generic ? $key->hashCode() : serialize($key);
+    $h= $key instanceof Generic || $key instanceof Value ? $key->hashCode() : serialize($key);
     return isset($this->_buckets[$h]) ? $this->_buckets[$h][1] : null; 
   }
   
@@ -135,12 +136,12 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K', return= 'V')]
   public function remove($key) {
-    $h= $key instanceof Generic ? $key->hashCode() : serialize($key);
+    $h= $key instanceof Generic || $key instanceof Value ? $key->hashCode() : serialize($key);
     if (!isset($this->_buckets[$h])) {
       $prev= null;
     } else {
       $prev= $this->_buckets[$h][1];
-      $this->_hash-= HashProvider::hashOf($h.($prev instanceof Generic ? $prev->hashCode() : serialize($prev)));
+      $this->_hash-= HashProvider::hashOf($h.($prev instanceof Generic || $prev instanceof Value ? $prev->hashCode() : serialize($prev)));
       unset($this->_buckets[$h]);
     }
 
@@ -182,7 +183,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K')]
   public function containsKey($key) {
-    $h= $key instanceof Generic ? $key->hashCode() : serialize($key);
+    $h= $key instanceof Generic || $key instanceof Value ? $key->hashCode() : serialize($key);
     return isset($this->_buckets[$h]);
   }
 
@@ -194,7 +195,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'V')]
   public function containsValue($value) {
-    if ($value instanceof Generic) {
+    if ($value instanceof Generic || $value instanceof Value) {
       foreach (array_keys($this->_buckets) as $key) {
         if ($value->equals($this->_buckets[$key][1])) return true;
       }

--- a/src/main/php/util/collections/LRUBuffer.class.php
+++ b/src/main/php/util/collections/LRUBuffer.class.php
@@ -44,7 +44,7 @@ class LRUBuffer extends \lang\Object {
    */
   #[@generic(params= 'T', return= 'T')]
   public function add($element) {
-    $h= $this->prefix.($element instanceof \lang\Generic ? $element->hashCode() : serialize($element));
+    $h= $this->prefix.(($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element));
     $this->_elements[$h]= $element;
 
     // Check if this buffer's size has been exceeded
@@ -65,7 +65,7 @@ class LRUBuffer extends \lang\Object {
    */
   #[@generic(params= 'T')]
   public function update($element) {
-    $h= $this->prefix.($element instanceof \lang\Generic ? $element->hashCode() : serialize($element));
+    $h= $this->prefix.(($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element));
     unset($this->_elements[$h]);
     $this->_elements= $this->_elements + array($h => $element);
   }

--- a/src/main/php/util/collections/Pair.class.php
+++ b/src/main/php/util/collections/Pair.class.php
@@ -1,5 +1,7 @@
 <?php namespace util\collections;
 
+use util\Objects;
+
 /**
  * Provides key and value for iteration
  *
@@ -32,11 +34,7 @@ class Pair extends \lang\Object {
    * @return bool
    */
   public function equals($cmp) {
-    return (
-      $cmp instanceof self &&
-      ($cmp->key instanceof \lang\Generic ? $cmp->key->equals($this->key) : $cmp->key === $this->key) &&
-      ($cmp->value instanceof \lang\Generic ? $cmp->value->equals($this->value) : $cmp->value === $this->value)
-    );
+    return $cmp instanceof self && Objects::equal($cmp->key, $this->key);
   }
 
   /**
@@ -46,8 +44,8 @@ class Pair extends \lang\Object {
    */
   public function hashCode() {
     return (
-      HashProvider::hashOf($this->key instanceof \lang\Generic ? $this->key->hashCode() : serialize($this->key)) +
-      HashProvider::hashOf($this->value instanceof \lang\Generic ? $this->value->hashCode() : serialize($this->value))
+      HashProvider::hashOf(Objects::hashOf($this->key)) +
+      HashProvider::hashOf(Objects::hashOf($this->value))
     );
   }
 
@@ -57,6 +55,6 @@ class Pair extends \lang\Object {
    * @return  string
    */
   public function toString() {
-    return nameof($this).'<key= '.\xp::stringOf($this->key).', value= '.\xp::stringOf($this->value).'>';
+    return nameof($this).'<key= '.Objects::stringOf($this->key).', value= '.Objects::stringOf($this->value).'>';
   }
 }

--- a/src/main/php/util/collections/Queue.class.php
+++ b/src/main/php/util/collections/Queue.class.php
@@ -2,6 +2,8 @@
 
 use lang\IndexOutOfBoundsException;
 use util\NoSuchElementException;
+use lang\Generic;
+use lang\Value;
 
 /**
  * A First-In-First-Out (FIFO) queue of objects.
@@ -43,7 +45,7 @@ class Queue extends \lang\Object {
    */
   #[@generic(params= 'T', return= 'T')]
   public function put($element) {
-    $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
     $this->_elements[]= $element;
     $this->_hash+= HashProvider::hashOf($h);
     return $element;
@@ -62,7 +64,7 @@ class Queue extends \lang\Object {
     }
 
     $element= $this->_elements[0];
-    $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+    $h= ($element instanceof Generic || $element instanceof Value)? $element->hashCode() : serialize($element);
     $this->_hash-= HashProvider::hashOf($h);
     $this->_elements= array_slice($this->_elements, 1);
     return $element;
@@ -124,7 +126,7 @@ class Queue extends \lang\Object {
     if (-1 == ($pos= $this->search($element))) return false;
     
     $element= $this->_elements[$pos];
-    $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+    $h= ($element instanceof Generic || $element instanceof Value)? $element->hashCode() : serialize($element);
     $this->_hash-= HashProvider::hashOf($h);
     unset($this->_elements[$pos]);
     $this->_elements= array_values($this->_elements);   // Re-index

--- a/src/main/php/util/collections/Stack.class.php
+++ b/src/main/php/util/collections/Stack.class.php
@@ -2,6 +2,8 @@
 
 use lang\IndexOutOfBoundsException;
 use util\NoSuchElementException;
+use lang\Generic;
+use lang\Value;
 
 /**
  * A Last-In-First-Out (LIFO) stack of objects.
@@ -45,7 +47,7 @@ class Stack extends \lang\Object {
    */
   #[@generic(params= 'T', return= 'T')]
   public function push($element) {
-    $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
     array_unshift($this->_elements, $element);
     $this->_hash+= HashProvider::hashOf($h);
     return $element;
@@ -63,7 +65,7 @@ class Stack extends \lang\Object {
       throw new NoSuchElementException('Stack is empty');
     }
     $element= array_shift($this->_elements);
-    $h= $element instanceof \lang\Generic ? $element->hashCode() : serialize($element);
+    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
     $this->_hash+= HashProvider::hashOf($h);
     return $element;
   }

--- a/src/main/php/util/collections/Vector.class.php
+++ b/src/main/php/util/collections/Vector.class.php
@@ -239,6 +239,10 @@ class Vector extends \lang\Object implements IList {
       foreach ($this->elements as $i => $compare) {
         if ($element->equals($compare)) return true;
       }
+    } else if ($element instanceof Value) {
+      foreach ($this->elements as $i => $compare) {
+        if (0 === $element->compareTo($compare)) return true;
+      }
     } else {
       foreach ($this->elements as $i => $compare) {
         if ($element === $compare) return true;
@@ -259,6 +263,10 @@ class Vector extends \lang\Object implements IList {
       foreach ($this->elements as $i => $compare) {
         if ($element->equals($compare)) return $i;
       }
+    } else if ($element instanceof Value) {
+      foreach ($this->elements as $i => $compare) {
+        if (0 === $element->compareTo($compare)) return $i;
+      }
     } else {
       foreach ($this->elements as $i => $compare) {
         if ($element === $compare) return $i;
@@ -278,6 +286,10 @@ class Vector extends \lang\Object implements IList {
     if ($element instanceof Generic) {
       for ($i= $this->size- 1; $i > -1; $i--) {
         if ($element->equals($this->elements[$i])) return $i;
+      }
+    } else if ($element instanceof Value) {
+      for ($i= $this->size- 1; $i > -1; $i--) {
+        if (0 === $element->compareTo($this->elements[$i])) return $i;
       }
     } else {
       for ($i= $this->size- 1; $i > -1; $i--) {
@@ -312,6 +324,7 @@ class Vector extends \lang\Object implements IList {
     // Compare element by element
     foreach ($this->elements as $i => $element) {
       if ($element instanceof Generic && !$element->equals($cmp->elements[$i])) return false;
+      if ($element instanceof Value && 0 !== $element->compareTo($cmp->elements[$i])) return false;
       if ($element !== $this->elements[$i]) return false;
     }
     return true;

--- a/src/test/php/net/xp_framework/unittest/Name.class.php
+++ b/src/test/php/net/xp_framework/unittest/Name.class.php
@@ -1,6 +1,6 @@
-<?php namespace net\xp_framework\unittest\tests;
+<?php namespace net\xp_framework\unittest;
 
-class Name extends \lang\Object implements \lang\Value {
+class Name implements \lang\Value {
   private $value;
 
   /** @param string $value */

--- a/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
@@ -15,9 +15,22 @@ class StringOfTest extends \unittest\TestCase {
    * @return lang.Object
    */
   protected function testStringInstance() {
-    return newinstance('lang.Object', [], array(
+    return newinstance('lang.Object', [], [
       'toString' => function() { return 'TestString(6) { String }'; }
-    ));
+    ]);
+  }
+
+  /**
+   * Returns a value also returning the string `TestValue(6) { String }`.
+   *
+   * @return lang.Value
+   */
+  protected function valueInstance() {
+    return newinstance('lang.Value', [], [
+      'compareTo' => function($cmp) { /* Not implemented */ },
+      'hashCode'  => function() { /* Not implemented */ },
+      'toString'  => function() { return 'TestValue(6) { String }'; }
+    ]);
   }
 
   #[@test, @values([
@@ -40,6 +53,11 @@ class StringOfTest extends \unittest\TestCase {
   #[@test]
   public function testString_representation() {
     $this->assertEquals('TestString(6) { String }', \xp::stringOf($this->testStringInstance()));
+  }
+
+  #[@test]
+  public function value_representation() {
+    $this->assertEquals('TestValue(6) { String }', \xp::stringOf($this->valueInstance()));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
+use net\xp_framework\unittest\Name;
+
 /**
  * Tests the xp::stringOf() core utility
  *
@@ -26,11 +28,8 @@ class StringOfTest extends \unittest\TestCase {
    * @return lang.Value
    */
   protected function valueInstance() {
-    return newinstance('lang.Value', [], [
-      'compareTo' => function($cmp) { /* Not implemented */ },
-      'hashCode'  => function() { /* Not implemented */ },
-      'toString'  => function() { return 'TestValue(6) { String }'; }
-    ]);
+    return new Name($this->name);
+
   }
 
   #[@test, @values([
@@ -57,7 +56,7 @@ class StringOfTest extends \unittest\TestCase {
 
   #[@test]
   public function value_representation() {
-    $this->assertEquals('TestValue(6) { String }', \xp::stringOf($this->valueInstance()));
+    $this->assertEquals('value_representation', \xp::stringOf($this->valueInstance()));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
@@ -22,16 +22,6 @@ class StringOfTest extends \unittest\TestCase {
     ]);
   }
 
-  /**
-   * Returns a value also returning the string `TestValue(6) { String }`.
-   *
-   * @return lang.Value
-   */
-  protected function valueInstance() {
-    return new Name($this->name);
-
-  }
-
   #[@test, @values([
   #  ['""', ''], ['"Hello"', 'Hello'],
   #  ['true', true], ['false', false],
@@ -56,7 +46,7 @@ class StringOfTest extends \unittest\TestCase {
 
   #[@test]
   public function value_representation() {
-    $this->assertEquals('value_representation', \xp::stringOf($this->valueInstance()));
+    $this->assertEquals('value_representation', \xp::stringOf(new Name($this->name)));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/core/types/ArrayListTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/ArrayListTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\core\types;
 
-use unittest\TestCase;
 use lang\types\ArrayList;
 use lang\IndexOutOfBoundsException;
+use net\xp_framework\unittest\Name;
 
 /**
  * Tests the ArrayList class
@@ -10,7 +10,7 @@ use lang\IndexOutOfBoundsException;
  * @deprecated Wrapper types will move to their own library
  * @see  xp://lang.types.ArrayList
  */
-class ArrayListTest extends TestCase {
+class ArrayListTest extends \unittest\TestCase {
 
   #[@test]
   public function a_newly_created_arraylist_has_zero_length() {
@@ -192,6 +192,12 @@ class ArrayListTest extends TestCase {
   #[@test]
   public function a_list_of_an_object_contains_the_given_object() {
     $o= new \lang\Object();
+    $this->assertTrue((new ArrayList($o))->contains($o));
+  }
+
+  #[@test]
+  public function a_list_of_an_value_contains_the_given_value() {
+    $o= new Name('Test');
     $this->assertTrue((new ArrayList($o))->contains($o));
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/types/ArrayMapTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/ArrayMapTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\core\types;
 
-use unittest\TestCase;
 use lang\types\ArrayMap;
 use lang\IndexOutOfBoundsException;
+use net\xp_framework\unittest\Name;
 
 /**
  * Tests the ArrayMap class
@@ -10,7 +10,7 @@ use lang\IndexOutOfBoundsException;
  * @deprecated Wrapper types will move to their own library
  * @see  xp://lang.types.ArrayMap
  */
-class ArrayMapTest extends TestCase {
+class ArrayMapTest extends \unittest\TestCase {
 
   /** @return  var[][] */
   protected function fixtures() {
@@ -134,6 +134,12 @@ class ArrayMapTest extends TestCase {
   #[@test]
   public function a_map_of_an_object_contains_the_given_object() {
     $o= new \lang\Object();
+    $this->assertTrue((new ArrayMap(['key' => $o]))->contains($o));
+  }
+
+  #[@test]
+  public function a_map_of_an_object_contains_the_given_value() {
+    $o= new Name('Test');
     $this->assertTrue((new ArrayMap(['key' => $o]))->contains($o));
   }
 

--- a/src/test/php/net/xp_framework/unittest/tests/AssertionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/tests/AssertionsTest.class.php
@@ -103,9 +103,14 @@ class AssertionsTest extends \unittest\TestCase {
     $this->assertEquals($hash, array_reverse($hash, true), \xp::stringOf($hash));
   }    
 
-  #[@test, @values([new String(''), new String('Hello'), new String('äöüß')])]
+  #[@test, @values(['', 'Hello','äöüß'])]
   public function stringObjectsAreEqual($str) {
-    $this->assertEquals($str, $str);
+    $this->assertEquals(new String($str), new String($str));
+  }
+
+  #[@test, @values(['', 'Hello','äöüß'])]
+  public function valuesAreEqual($str) {
+    $this->assertEquals(new Name($str), new Name($str));
   }
 
   #[@test, @expect('unittest.AssertionFailedError')]

--- a/src/test/php/net/xp_framework/unittest/tests/AssertionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/tests/AssertionsTest.class.php
@@ -2,6 +2,7 @@
  
 use lang\types\String;
 use lang\types\ArrayList;
+use net\xp_framework\unittest\Name;
 
 /**
  * Test assertion methods

--- a/src/test/php/net/xp_framework/unittest/tests/Name.class.php
+++ b/src/test/php/net/xp_framework/unittest/tests/Name.class.php
@@ -1,0 +1,39 @@
+<?php namespace net\xp_framework\unittest\tests;
+
+class Name extends \lang\Object implements \lang\Value {
+  private $value;
+
+  /** @param string $value */
+  public function __construct($value) { $this->value= (string)$value; }
+
+  /** @return string */
+  public function value() { return $this->value; }
+
+  /**
+   * Compares this name
+   *
+   * @param  var $cmp
+   * @return int
+   */
+  public function compareTo($cmp) {
+    return $cmp instanceof self ? strcmp($this->value, $cmp->value) : -1;
+  }
+
+  /**
+   * Returns a hashcode
+   *
+   * @return string
+   */
+  public function hashCode() {
+    return crc32($this->value);
+  }
+
+  /**
+   * Returns a string representation
+   *
+   * @return string
+   */
+  public function toString() {
+    return $this->value;
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\util;
 
 use util\Objects;
-use lang\Value;
+use net\xp_framework\unittest\Name;
 
 /**
  * TestCase for Objects class
@@ -44,11 +44,7 @@ class ObjectsTest extends \unittest\TestCase {
       [new \lang\Object()],
       [new \lang\types\String('')],
       [new \lang\types\String('Test')],
-      [newinstance('lang.Value', [], [
-        'compareTo' => function($cmp) { return $cmp instanceof Value ? 0 : -1; },
-        'hashCode'  => function() { /* Not implemented */ },
-        'toString'  => function() { return 'value'; }
-      ])]
+      [new Name('')]
     ];
   }
 

--- a/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
@@ -1,14 +1,14 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\Objects;
+use lang\Value;
 
 /**
  * TestCase for Objects class
  *
  * @see  xp://util.Objects
  */
-class ObjectsTest extends TestCase {
+class ObjectsTest extends \unittest\TestCase {
 
   /** @return  var[][] */
   public function primitives() {
@@ -43,7 +43,12 @@ class ObjectsTest extends TestCase {
       [$this],
       [new \lang\Object()],
       [new \lang\types\String('')],
-      [new \lang\types\String('Test')]
+      [new \lang\types\String('Test')],
+      [newinstance('lang.Value', [], [
+        'compareTo' => function($cmp) { return $cmp instanceof Value ? 0 : -1; },
+        'hashCode'  => function() { /* Not implemented */ },
+        'toString'  => function() { return 'value'; }
+      ])]
     ];
   }
 


### PR DESCRIPTION
This PR implements xp-framework/rfc#297 and adds a `lang.Value` interface. This serves as a forward compatibility measure for the time when we no longer have a single `lang.Generic` root interface.

Classes which aren't value objects won't inherit the `lang.Object` class anymore in the future:

```php
use util\cmd\Console;

class Program {

  public static function main($args) {
    Console::writeLine('Hello World');
  }
}
```

Classes which should be comparable or usable as hash keys can choose to implement `lang.Value`:

```php
class Name implements \lang\Value {
  private $value;

  public function __construct($value) {
    $this->value= (string)$value;
  }

  public function value() {
    return $this->value;
  }

  public function compareTo($cmp) {
    return $cmp instanceof self ? strcmp($this->value, $cmp->value) : -1;
  }

  public function hashCode() {
    return crc32($this->value);
  }

  public function toString() {
    return $this->value;
  }
}
```