### PR TITLE
Remove deprecated raise() core functionality

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ XP Framework Core ChangeLog
 
 ### Heads up!
 
+* **Removed deprecated raise() core functionality**
+  (@thekid)
 * **Removed pre-namespace class loading**:
   - The deprecated `uses()` core functionality has been removed.
   - It is no longer possible to use package-qualified classes.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,8 @@ XP Framework Core ChangeLog
 
 ### Heads up!
 
-* **Removed deprecated raise() core functionality**
+* **Removed deprecated raise() core functionality**.
+  See xp-framework/core#89
   (@thekid)
 * **Removed pre-namespace class loading**:
   - The deprecated `uses()` core functionality has been removed.

--- a/src/main/php/io/EncapsedStream.class.php
+++ b/src/main/php/io/EncapsedStream.class.php
@@ -163,7 +163,7 @@ class EncapsedStream extends Stream {
    * @return  int number of bytes written
    */
   public function write($string) {
-    raise('lang.MethodNotImplementedException', 'Writing not supported');
+    throw new MethodNotImplementedException('Writing not supported');
   }    
 
   /**
@@ -173,7 +173,7 @@ class EncapsedStream extends Stream {
    * @return  int number of bytes written
    */
   public function writeLine($string= '') {
-    raise('lang.MethodNotImplementedException', 'Writing not supported');
+    throw new MethodNotImplementedException('Writing not supported');
   }
   
   /**

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -367,20 +367,6 @@ function __error($code, $msg, $file, $line) {
 }
 // }}}
 
-// {{{ proto deprecated void raise (string classname, var* args)
-//     throws an exception by a given class name
-function raise($classname) {
-  try {
-    $class= \lang\XPClass::forName($classname);
-  } catch (ClassNotFoundException $e) {
-    xp::error($e->getMessage());
-  }
-  
-  $a= func_get_args();
-  throw call_user_func_array([$class, 'newInstance'], array_slice($a, 1));
-}
-// }}}
-
 // {{{ proto void ensure ($t)
 //     Replacement for finally() which clashes with PHP 5.5.0's finally
 function ensure(&$t) {
@@ -392,7 +378,7 @@ function ensure(&$t) {
 //     Casts an arg NULL-safe
 function cast($arg, $type, $nullsafe= true) {
   if (null === $arg && $nullsafe) {
-    raise('lang.ClassCastException', 'Cannot cast NULL to '.$type);
+    throw new \lang\ClassCastException('Cannot cast NULL to '.$type);
   } else if ($type instanceof \lang\Type) {
     return $type->cast($arg);
   } else {

--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -314,7 +314,7 @@ class FunctionType extends Type {
    * @throws  lang.reflect.TargetInvocationException for any exception raised from the invoked function
    */
   public function invoke($func, $args= []) {
-    $closure= $this->verified($func, function($m) use($func) { raise('lang.IllegalArgumentException', sprintf(
+    $closure= $this->verified($func, function($m) use($func) { throw new IllegalArgumentException(sprintf(
       'Passed argument is not of a %s type (%s): %s',
       $this->getName(),
       \xp::typeOf($func),

--- a/src/main/php/util/PropertyExpansion.class.php
+++ b/src/main/php/util/PropertyExpansion.class.php
@@ -1,6 +1,7 @@
 <?php namespace util;
 
 use lang\ElementNotFoundException;
+use lang\FormatException;
 
 /**
  * Expands variables inside property files.
@@ -47,7 +48,7 @@ class PropertyExpansion extends \lang\Enum {
       '/\$\{([^.}]*)\.([^}|]*)(?:\|([^}]*))?\}/',
       function($match) {
         if (!isset($this->impl[$match[1]])) {
-          raise('lang.FormatException', 'Unknown expansion type in '.$match[0]);
+          throw new FormatException('Unknown expansion type in '.$match[0]);
         }
 
         $f= $this->impl[$match[1]];


### PR DESCRIPTION
Related to pre-namespace class loading, lazily loads exception and then throws it. No longer necessary now that we are using the PHP builtin class loading, which is lazy by default

Part of 6.4.0-RELEASE per xp-framework/rfc#298