### PR TITLE
Remove variant of create() which returns object given

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - php: nightly
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.3.1/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.4.0/setup' -O - | php
   - echo "use=." > xp.ini
   - echo "[runtime]" >> xp.ini
   - echo "date.timezone=Europe/Berlin" >> xp.ini

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@ XP Framework Core ChangeLog
 
 ### Heads up!
 
+* **Remove variant of create() which returns object given**.
+  See xp-framework/core#90
+  (@thekid)
 * **Removed deprecated raise() core functionality**.
   See xp-framework/core#89
   (@thekid)

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -554,12 +554,10 @@ function newinstance($spec, $args, $def= null) {
 }
 // }}}
 
-// {{{ proto lang.Generic create(string spec)
+// {{{ proto lang.Generic create(var spec)
 //     Creates a generic object
 function create($spec) {
-  if (!is_string($spec)) {
-    throw new \lang\IllegalArgumentException('Create expects its first argument to be a string');
-  }
+  if ($spec instanceof \lang\Generic) return $spec;
 
   // Parse type specification: "new " TYPE "()"?
   // TYPE:= B "<" ARGS ">"

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -554,10 +554,12 @@ function newinstance($spec, $args, $def= null) {
 }
 // }}}
 
-// {{{ proto lang.Generic create(var spec)
+// {{{ proto lang.Generic create(string spec)
 //     Creates a generic object
 function create($spec) {
-  if ($spec instanceof \lang\Generic) return $spec;
+  if (!is_string($spec)) {
+    throw new \lang\IllegalArgumentException('Create expects its first argument to be a string');
+  }
 
   // Parse type specification: "new " TYPE "()"?
   // TYPE:= B "<" ARGS ">"

--- a/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
@@ -1,35 +1,20 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\XPClass;
-use lang\Object;
 use util\collections\Vector;
 use util\collections\HashTable;
 
 /**
- * TestCase for create() core functionality. It has the following two purposes:
- *
- * 1) Create generics
+ * TestCase for create() core functionality, which is used to create
+ * generic instances.
  *
  * ```php
  * $v= create('new util.collections.Vector<lang.Object>');
  * ```
- *
- * 2) For BC with PHP 5.3 - PHP 5.4 has added constructor dereferencing! Returning
- * an object passed in, for use in fluent interfaces, e.g.
- *
- * ```php
- * $c= create(new Criteria())->add('bz_id', 20000, EQUAL);
- * ````
  * 
  * @see   http://news.xp-framework.net/article/184/2007/05/06/
  */
 class CreateTest extends \unittest\TestCase {
-
-  #[@test]
-  public function create_returns_given_object_for_BC_reasons() {
-    $fixture= new Object();
-    $this->assertEquals($fixture, create($fixture));
-  }
 
   #[@test]
   public function create_with_all_qualified_names() {
@@ -48,10 +33,9 @@ class CreateTest extends \unittest\TestCase {
 
   #[@test]
   public function create_invokes_constructor() {
-    $fixture= new Object();
     $this->assertEquals(
-      $fixture,
-      create('new util.collections.Vector<lang.Object>', [$fixture])->get(0)
+      $this,
+      create('new util.collections.Vector<lang.Object>', [$this])->get(0)
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
@@ -1,20 +1,35 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\XPClass;
+use lang\Object;
 use util\collections\Vector;
 use util\collections\HashTable;
 
 /**
- * TestCase for create() core functionality, which is used to create
- * generic instances.
+ * TestCase for create() core functionality. It has the following two purposes:
+ *
+ * 1) Create generics
  *
  * ```php
  * $v= create('new util.collections.Vector<lang.Object>');
  * ```
+ *
+ * 2) For BC with PHP 5.3 - PHP 5.4 has added constructor dereferencing! Returning
+ * an object passed in, for use in fluent interfaces, e.g.
+ *
+ * ```php
+ * $c= create(new Criteria())->add('bz_id', 20000, EQUAL);
+ * ````
  * 
  * @see   http://news.xp-framework.net/article/184/2007/05/06/
  */
 class CreateTest extends \unittest\TestCase {
+
+  #[@test]
+  public function create_returns_given_object_for_BC_reasons() {
+    $fixture= new Object();
+    $this->assertEquals($fixture, create($fixture));
+  }
 
   #[@test]
   public function create_with_all_qualified_names() {
@@ -33,9 +48,10 @@ class CreateTest extends \unittest\TestCase {
 
   #[@test]
   public function create_invokes_constructor() {
+    $fixture= new Object();
     $this->assertEquals(
-      $this,
-      create('new util.collections.Vector<lang.Object>', [$this])->get(0)
+      $fixture,
+      create('new util.collections.Vector<lang.Object>', [$fixture])->get(0)
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
@@ -108,7 +108,7 @@ class ExceptionsTest extends TestCase {
   public function printStackTrace() {
     $out= new MemoryOutputStream();
     $e= new Throwable('Test');
-    create($e)->printStackTrace(Streams::writeableFd($out));
+    $e->printStackTrace(Streams::writeableFd($out));
     $this->assertEquals($e->toString(), $out->getBytes());
   }
   

--- a/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
@@ -108,7 +108,7 @@ class ExceptionsTest extends TestCase {
   public function printStackTrace() {
     $out= new MemoryOutputStream();
     $e= new Throwable('Test');
-    $e->printStackTrace(Streams::writeableFd($out));
+    create($e)->printStackTrace(Streams::writeableFd($out));
     $this->assertEquals($e->toString(), $out->getBytes());
   }
   

--- a/src/test/php/net/xp_framework/unittest/peer/URLTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/URLTest.class.php
@@ -15,203 +15,203 @@ class URLTest extends TestCase {
 
   #[@test]
   public function scheme() {
-    $this->assertEquals('http', create(new URL('http://localhost'))->getScheme());
+    $this->assertEquals('http', (new URL('http://localhost'))->getScheme());
   }
 
   #[@test]
   public function schemeWithPlus() {
-    $this->assertEquals('svn+ssl', create(new URL('svn+ssl://localhost'))->getScheme());
+    $this->assertEquals('svn+ssl', (new URL('svn+ssl://localhost'))->getScheme());
   }
 
   #[@test]
   public function schemeMutability() {
     $this->assertEquals(
       'ftp://localhost', 
-      create(new URL('http://localhost'))->setScheme('ftp')->getURL()
+      (new URL('http://localhost'))->setScheme('ftp')->getURL()
     );
   }
 
   #[@test]
   public function host() {
-    $this->assertEquals('localhost', create(new URL('http://localhost'))->getHost());
+    $this->assertEquals('localhost', (new URL('http://localhost'))->getHost());
   }
 
   #[@test]
   public function uppercaseHost() {
-    $this->assertEquals('TEST', create(new URL('http://TEST'))->getHost());
+    $this->assertEquals('TEST', (new URL('http://TEST'))->getHost());
   }
 
   #[@test]
   public function hostMutability() {
     $this->assertEquals(
       'http://127.0.0.1', 
-      create(new URL('http://localhost'))->setHost('127.0.0.1')->getURL()
+      (new URL('http://localhost'))->setHost('127.0.0.1')->getURL()
     );
   }
 
   #[@test]
   public function path() {
-    $this->assertEquals('/news/index.html', create(new URL('http://localhost/news/index.html'))->getPath());
+    $this->assertEquals('/news/index.html', (new URL('http://localhost/news/index.html'))->getPath());
   }
 
   #[@test]
   public function emptyPath() {
-    $this->assertEquals(null, create(new URL('http://localhost'))->getPath());
+    $this->assertEquals(null, (new URL('http://localhost'))->getPath());
   }
 
   #[@test]
   public function slashPath() {
-    $this->assertEquals('/', create(new URL('http://localhost/'))->getPath());
+    $this->assertEquals('/', (new URL('http://localhost/'))->getPath());
   }
 
   #[@test]
   public function pathDefault() {
-    $this->assertEquals('/', create(new URL('http://localhost'))->getPath('/'));
+    $this->assertEquals('/', (new URL('http://localhost'))->getPath('/'));
   }
 
   #[@test]
   public function pathMutability() {
     $this->assertEquals(
       'http://localhost/index.html', 
-      create(new URL('http://localhost'))->setPath('/index.html')->getURL()
+      (new URL('http://localhost'))->setPath('/index.html')->getURL()
     );
   }
 
   #[@test]
   public function user() {
-    $this->assertEquals('user', create(new URL('http://user@localhost'))->getUser());
+    $this->assertEquals('user', (new URL('http://user@localhost'))->getUser());
   }
 
   #[@test]
   public function emptyUser() {
-    $this->assertEquals(null, create(new URL('http://localhost'))->getUser());
+    $this->assertEquals(null, (new URL('http://localhost'))->getUser());
   }
 
   #[@test]
   public function userDefault() {
-    $this->assertEquals('nobody', create(new URL('http://localhost'))->getUser('nobody'));
+    $this->assertEquals('nobody', (new URL('http://localhost'))->getUser('nobody'));
   }
 
   #[@test]
   public function urlEncodedUser() {
-    $this->assertEquals('user?', create(new URL('http://user%3F@localhost'))->getUser());
+    $this->assertEquals('user?', (new URL('http://user%3F@localhost'))->getUser());
   }
 
   #[@test]
   public function setUrlEncodedUser() {
-    $this->assertEquals('http://user%3F@localhost', create(new URL('http://localhost'))->setUser('user?')->getURL());
+    $this->assertEquals('http://user%3F@localhost', (new URL('http://localhost'))->setUser('user?')->getURL());
   }
 
   #[@test]
   public function userMutability() {
     $this->assertEquals(
       'http://thekid@localhost', 
-      create(new URL('http://localhost'))->setUser('thekid')->getURL()
+      (new URL('http://localhost'))->setUser('thekid')->getURL()
     );
   }
 
   #[@test]
   public function password() {
-    $this->assertEquals('password', create(new URL('http://user:password@localhost'))->getPassword());
+    $this->assertEquals('password', (new URL('http://user:password@localhost'))->getPassword());
   }
 
   #[@test]
   public function urlEncodedPassword() {
-    $this->assertEquals('pass?word', create(new URL('http://user:pass%3Fword@localhost'))->getPassword());
+    $this->assertEquals('pass?word', (new URL('http://user:pass%3Fword@localhost'))->getPassword());
   }
 
   #[@test]
   public function setUrlEncodedPassword() {
-    $this->assertEquals('http://user:pass%3Fword@localhost', create(new URL('http://user@localhost'))->setPassword('pass?word')->getURL());
+    $this->assertEquals('http://user:pass%3Fword@localhost', (new URL('http://user@localhost'))->setPassword('pass?word')->getURL());
   }
 
   #[@test]
   public function emptyPassword() {
-    $this->assertEquals(null, create(new URL('http://localhost'))->getPassword());
+    $this->assertEquals(null, (new URL('http://localhost'))->getPassword());
   }
 
   #[@test]
   public function passwordDefault() {
-    $this->assertEquals('secret', create(new URL('http://user@localhost'))->getPassword('secret'));
+    $this->assertEquals('secret', (new URL('http://user@localhost'))->getPassword('secret'));
   }
 
   #[@test]
   public function passwordMutability() {
     $this->assertEquals(
       'http://anon:anon@localhost', 
-      create(new URL('http://anon@localhost'))->setPassword('anon')->getURL()
+      (new URL('http://anon@localhost'))->setPassword('anon')->getURL()
     );
   }
 
   #[@test]
   public function query() {
-    $this->assertEquals('a=b', create(new URL('http://localhost?a=b'))->getQuery());
+    $this->assertEquals('a=b', (new URL('http://localhost?a=b'))->getQuery());
   }
 
   #[@test]
   public function queryModifiedByParams() {
     $this->assertEquals(
       'a=b&c=d', 
-      create(new URL('http://localhost?a=b'))->addParam('c', 'd')->getQuery()
+      (new URL('http://localhost?a=b'))->addParam('c', 'd')->getQuery()
     );
   }
 
   #[@test]
   public function emptyQuery() {
-    $this->assertEquals(null, create(new URL('http://localhost'))->getQuery());
+    $this->assertEquals(null, (new URL('http://localhost'))->getQuery());
   }
 
   #[@test]
   public function parameterLessQuery() {
-    $this->assertEquals('1549', create(new URL('http://localhost/?1549'))->getQuery());
+    $this->assertEquals('1549', (new URL('http://localhost/?1549'))->getQuery());
   }
 
   #[@test]
   public function addToParameterLessQuery() {
-    $this->assertEquals('1549&a=b', create(new URL('http://localhost/?1549'))->addParam('a', 'b')->getQuery());
+    $this->assertEquals('1549&a=b', (new URL('http://localhost/?1549'))->addParam('a', 'b')->getQuery());
   }
 
   #[@test]
-  public function createParameterLessQueryWithAdd() {
-    $this->assertEquals('1549', create(new URL('http://localhost/'))->addParam('1549')->getQuery());
+  public function ParameterLessQueryWithAdd() {
+    $this->assertEquals('1549', (new URL('http://localhost/'))->addParam('1549')->getQuery());
   }
 
   #[@test]
-  public function createParameterLessQueryWithSet() {
-    $this->assertEquals('1549', create(new URL('http://localhost/'))->setParam('1549')->getQuery());
+  public function ParameterLessQueryWithSet() {
+    $this->assertEquals('1549', (new URL('http://localhost/'))->setParam('1549')->getQuery());
   }
 
   #[@test]
   public function questionMarkOnly() {
-    $this->assertEquals(null, create(new URL('http://localhost?'))->getQuery());
+    $this->assertEquals(null, (new URL('http://localhost?'))->getQuery());
   }
 
   #[@test]
   public function questionMarkAndFragmentOnly() {
-    $this->assertEquals(null, create(new URL('http://localhost?#'))->getQuery());
+    $this->assertEquals(null, (new URL('http://localhost?#'))->getQuery());
   }
 
   #[@test]
   public function queryDefault() {
-    $this->assertEquals('1,2,3', create(new URL('http://localhost'))->getQuery('1,2,3'));
+    $this->assertEquals('1,2,3', (new URL('http://localhost'))->getQuery('1,2,3'));
   }
 
   #[@test]
   public function queryMutability() {
     $this->assertEquals(
       'http://localhost?a=b', 
-      create(new URL('http://localhost'))->setQuery('a=b')->getURL()
+      (new URL('http://localhost'))->setQuery('a=b')->getURL()
     );
   }
 
   #[@test]
   public function getParameterLessQuery() {
-    $this->assertEquals('', create(new URL('http://localhost/?1549'))->getParam('1549'));
+    $this->assertEquals('', (new URL('http://localhost/?1549'))->getParam('1549'));
   }
 
   #[@test]
   public function hasParameterLessQuery() {
-    $this->assertTrue(create(new URL('http://localhost/?1549'))->hasParam('1549'));
+    $this->assertTrue((new URL('http://localhost/?1549'))->hasParam('1549'));
   }
 
   /**
@@ -220,7 +220,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragment() {
-    $this->assertEquals('top', create(new URL('http://localhost#top'))->getFragment());
+    $this->assertEquals('top', (new URL('http://localhost#top'))->getFragment());
   }
 
   /**
@@ -229,7 +229,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragmentWithSlash() {
-    $this->assertEquals('top', create(new URL('http://localhost/#top'))->getFragment());
+    $this->assertEquals('top', (new URL('http://localhost/#top'))->getFragment());
   }
 
   /**
@@ -238,7 +238,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragmentWithSlashAndQuestionMark() {
-    $this->assertEquals('top', create(new URL('http://localhost/?#top'))->getFragment());
+    $this->assertEquals('top', (new URL('http://localhost/?#top'))->getFragment());
   }
 
   /**
@@ -247,7 +247,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragmentWithQuery() {
-    $this->assertEquals('top', create(new URL('http://localhost/?query#top'))->getFragment());
+    $this->assertEquals('top', (new URL('http://localhost/?query#top'))->getFragment());
   }
 
   /**
@@ -256,7 +256,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function emptyFragment() {
-    $this->assertEquals(null, create(new URL('http://localhost'))->getFragment());
+    $this->assertEquals(null, (new URL('http://localhost'))->getFragment());
   }
 
   /**
@@ -265,7 +265,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function hashOnly() {
-    $this->assertEquals(null, create(new URL('http://localhost#'))->getFragment());
+    $this->assertEquals(null, (new URL('http://localhost#'))->getFragment());
   }
 
   /**
@@ -274,7 +274,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function hashAtEnd() {
-    $this->assertEquals(null, create(new URL('http://localhost?#'))->getFragment());
+    $this->assertEquals(null, (new URL('http://localhost?#'))->getFragment());
   }
 
   /**
@@ -283,7 +283,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function hashAtEndWithQuery() {
-    $this->assertEquals(null, create(new URL('http://localhost?query#'))->getFragment());
+    $this->assertEquals(null, (new URL('http://localhost?query#'))->getFragment());
   }
 
   /**
@@ -292,7 +292,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragmentDefault() {
-    $this->assertEquals('top', create(new URL('http://localhost'))->getFragment('top'));
+    $this->assertEquals('top', (new URL('http://localhost'))->getFragment('top'));
   }
 
   /**
@@ -303,7 +303,7 @@ class URLTest extends TestCase {
   public function fragmentMutability() {
     $this->assertEquals(
       'http://localhost#list', 
-      create(new URL('http://localhost'))->setFragment('list')->getURL()
+      (new URL('http://localhost'))->setFragment('list')->getURL()
     );
   }
 
@@ -313,7 +313,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function port() {
-    $this->assertEquals(8080, create(new URL('http://localhost:8080'))->getPort());
+    $this->assertEquals(8080, (new URL('http://localhost:8080'))->getPort());
   }
 
   /**
@@ -322,7 +322,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function emptyPort() {
-    $this->assertEquals(null, create(new URL('http://localhost'))->getPort());
+    $this->assertEquals(null, (new URL('http://localhost'))->getPort());
   }
 
   /**
@@ -331,7 +331,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function portDefault() {
-    $this->assertEquals(80, create(new URL('http://localhost'))->getPort(80));
+    $this->assertEquals(80, (new URL('http://localhost'))->getPort(80));
   }
 
   /**
@@ -342,13 +342,13 @@ class URLTest extends TestCase {
   public function portMutability() {
     $this->assertEquals(
       'http://localhost:8081', 
-      create(new URL('http://localhost'))->setPort(8081)->getURL()
+      (new URL('http://localhost'))->setPort(8081)->getURL()
     );
   }
 
   #[@test]
   public function param() {
-    $this->assertEquals('b', create(new URL('http://localhost?a=b'))->getParam('a'));
+    $this->assertEquals('b', (new URL('http://localhost?a=b'))->getParam('a'));
   }
 
   /**
@@ -357,7 +357,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function getArrayParameter() {
-    $this->assertEquals(array('b'), create(new URL('http://localhost?a[]=b'))->getParam('a'));
+    $this->assertEquals(array('b'), (new URL('http://localhost?a[]=b'))->getParam('a'));
   }
 
   /**
@@ -366,7 +366,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function getEncodedArrayParameter() {
-    $this->assertEquals(array('='), create(new URL('http://localhost?a[]=%3D'))->getParam('a'));
+    $this->assertEquals(array('='), (new URL('http://localhost?a[]=%3D'))->getParam('a'));
   }
 
   /**
@@ -375,7 +375,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function getArrayParameters() {
-    $this->assertEquals(array('b', 'c'), create(new URL('http://localhost?a[]=b&a[]=c'))->getParam('a'));
+    $this->assertEquals(array('b', 'c'), (new URL('http://localhost?a[]=b&a[]=c'))->getParam('a'));
   }
 
   /**
@@ -386,7 +386,7 @@ class URLTest extends TestCase {
   public function getArrayParametersAsHash() {
     $this->assertEquals(
       array('name' => 'b', 'color' => 'c'), 
-      create(new URL('http://localhost?a[name]=b&a[color]=c'))->getParam('a')
+      (new URL('http://localhost?a[name]=b&a[color]=c'))->getParam('a')
     );
   }
 
@@ -398,7 +398,7 @@ class URLTest extends TestCase {
   public function getArrayParametersAsHashWithEncodedNames() {
     $this->assertEquals(
       array('=name=' => 'b', '=color=' => 'c'), 
-      create(new URL('http://localhost?a[%3Dname%3D]=b&a[%3Dcolor%3D]=c'))->getParam('a')
+      (new URL('http://localhost?a[%3Dname%3D]=b&a[%3Dcolor%3D]=c'))->getParam('a')
     );
   }
 
@@ -410,7 +410,7 @@ class URLTest extends TestCase {
   public function arrayOffsetsInDifferentArrays() {
     $this->assertEquals(
       array('a' => array('c'), 'b' => array('d')), 
-      create(new URL('http://localhost/?a[]=c&b[]=d'))->getParams()
+      (new URL('http://localhost/?a[]=c&b[]=d'))->getParams()
     );
   }
 
@@ -422,7 +422,7 @@ class URLTest extends TestCase {
   public function duplicateOffsetsOverwriteEachother() {
     $this->assertEquals(
       array('c'), 
-      create(new URL('http://localhost/?a[0]=b&a[0]=c'))->getParam('a')
+      (new URL('http://localhost/?a[0]=b&a[0]=c'))->getParam('a')
     );
   }
 
@@ -434,7 +434,7 @@ class URLTest extends TestCase {
   public function duplicateNamesOverwriteEachother() {
     $this->assertEquals(
       array('name' => 'c'), 
-      create(new URL('http://localhost/?a[name]=b&a[name]=c'))->getParam('a')
+      (new URL('http://localhost/?a[name]=b&a[name]=c'))->getParam('a')
     );
   }
 
@@ -446,7 +446,7 @@ class URLTest extends TestCase {
   public function twoDimensionalArray() {
     $this->assertEquals(
       array(array('b')), 
-      create(new URL('http://localhost/?a[][]=b'))->getParam('a')
+      (new URL('http://localhost/?a[][]=b'))->getParam('a')
     );
   }
 
@@ -458,7 +458,7 @@ class URLTest extends TestCase {
   public function threeDimensionalArray() {
     $this->assertEquals(
       array(array(array('b'))), 
-      create(new URL('http://localhost/?a[][][]=b'))->getParam('a')
+      (new URL('http://localhost/?a[][][]=b'))->getParam('a')
     );
   }
 
@@ -470,7 +470,7 @@ class URLTest extends TestCase {
   public function arrayOfHash() {
     $this->assertEquals(
       array(array(array('name' => 'b'))), 
-      create(new URL('http://localhost/?a[][][name]=b'))->getParam('a')
+      (new URL('http://localhost/?a[][][name]=b'))->getParam('a')
     );
   }
 
@@ -482,7 +482,7 @@ class URLTest extends TestCase {
   public function hashOfArray() {
     $this->assertEquals(
       array('name' => array(array('b'))), 
-      create(new URL('http://localhost/?a[name][][]=b'))->getParam('a')
+      (new URL('http://localhost/?a[name][][]=b'))->getParam('a')
     );
   }
 
@@ -494,7 +494,7 @@ class URLTest extends TestCase {
   public function hashOfArrayOfHash() {
     $this->assertEquals(
       array('name' => array(array('key' => 'b'))), 
-      create(new URL('http://localhost/?a[name][][key]=b'))->getParam('a')
+      (new URL('http://localhost/?a[name][][key]=b'))->getParam('a')
     );
   }
 
@@ -506,7 +506,7 @@ class URLTest extends TestCase {
   public function hashNotationWithoutValues() {
     $this->assertEquals(
       array('name' => '', 'color' => ''), 
-      create(new URL('http://localhost/?a[name]&a[color]'))->getParam('a')
+      (new URL('http://localhost/?a[name]&a[color]'))->getParam('a')
     );
   }
 
@@ -518,7 +518,7 @@ class URLTest extends TestCase {
   public function arrayNotationWithoutValues() {
     $this->assertEquals(
       array('', ''), 
-      create(new URL('http://localhost/?a[]&a[]'))->getParam('a')
+      (new URL('http://localhost/?a[]&a[]'))->getParam('a')
     );
   }
 
@@ -530,7 +530,7 @@ class URLTest extends TestCase {
   public function getArrayParams() {
     $this->assertEquals(
       array('a' => array('b', 'c')), 
-      create(new URL('http://localhost?a[]=b&a[]=c'))->getParams()
+      (new URL('http://localhost?a[]=b&a[]=c'))->getParams()
     );
   }
 
@@ -542,7 +542,7 @@ class URLTest extends TestCase {
   public function mixedOffsetsAndKeys() {
     $this->assertEquals(
       array(0 => 'b', 'name' => 'c', 1 => 'd'), 
-      create(new URL('http://localhost/?a[]=b&a[name]=c&a[]=d'))->getParam('a')
+      (new URL('http://localhost/?a[]=b&a[name]=c&a[]=d'))->getParam('a')
     );
   }
 
@@ -554,7 +554,7 @@ class URLTest extends TestCase {
   public function nestedBraces() {
     $this->assertEquals(
       array('a' => array('nested[]' => 'b')), 
-      create(new URL('http://localhost/?a[nested[]]=b'))->getParams()
+      (new URL('http://localhost/?a[nested[]]=b'))->getParams()
     );
   }
  
@@ -566,7 +566,7 @@ class URLTest extends TestCase {
   public function nestedBracesTwice() {
     $this->assertEquals(
       array('a' => array('nested[a]' => 'b', 'nested[b]' => 'c')), 
-      create(new URL('http://localhost/?a[nested[a]]=b&a[nested[b]]=c'))->getParams()
+      (new URL('http://localhost/?a[nested[a]]=b&a[nested[b]]=c'))->getParams()
     );
   }
 
@@ -578,7 +578,7 @@ class URLTest extends TestCase {
   public function nestedBracesChained() {
     $this->assertEquals(
       array('a' => array('nested[a]' => array('c'))), 
-      create(new URL('http://localhost/?a[nested[a]][]=c'))->getParams()
+      (new URL('http://localhost/?a[nested[a]][]=c'))->getParams()
     );
   }
 
@@ -587,21 +587,21 @@ class URLTest extends TestCase {
    *
    */
   #[@test]
-  public function unnamedArrayParameterDoesNotCreateArray() {
+  public function unnamedArrayParameterDoesNotArray() {
     $this->assertEquals(
       array('[]' => 'c'), 
-      create(new URL('http://localhost/?[]=c'))->getParams()
+      (new URL('http://localhost/?[]=c'))->getParams()
     );
   }
 
   #[@test]
   public function nonExistantParam() {
-    $this->assertEquals(null, create(new URL('http://localhost?a=b'))->getParam('b'));
+    $this->assertEquals(null, (new URL('http://localhost?a=b'))->getParam('b'));
   }
 
   #[@test]
   public function emptyParam() {
-    $this->assertEquals('', create(new URL('http://localhost?x='))->getParam('x'));
+    $this->assertEquals('', (new URL('http://localhost?x='))->getParam('x'));
   }
 
   /**
@@ -610,7 +610,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function paramDefault() {
-    $this->assertEquals('x', create(new URL('http://localhost?a=b'))->getParam('c', 'x'));
+    $this->assertEquals('x', (new URL('http://localhost?a=b'))->getParam('c', 'x'));
   }
  
   /**
@@ -621,7 +621,7 @@ class URLTest extends TestCase {
   public function addNewParam() {
     $this->assertEquals(
       'http://localhost?a=b', 
-      create(new URL('http://localhost'))->addParam('a', 'b')->getURL()
+      (new URL('http://localhost'))->addParam('a', 'b')->getURL()
     );
   }
 
@@ -633,7 +633,7 @@ class URLTest extends TestCase {
   public function setNewParam() {
     $this->assertEquals(
       'http://localhost?a=b', 
-      create(new URL('http://localhost'))->setParam('a', 'b')->getURL()
+      (new URL('http://localhost'))->setParam('a', 'b')->getURL()
     );
   }
 
@@ -645,7 +645,7 @@ class URLTest extends TestCase {
   public function addAdditionalParam() {
     $this->assertEquals(
       'http://localhost?a=b&c=d', 
-      create(new URL('http://localhost?a=b'))->addParam('c', 'd')->getURL()
+      (new URL('http://localhost?a=b'))->addParam('c', 'd')->getURL()
     );
   }
 
@@ -657,7 +657,7 @@ class URLTest extends TestCase {
   public function setAdditionalParam() {
     $this->assertEquals(
       'http://localhost?a=b&c=d', 
-      create(new URL('http://localhost?a=b'))->setParam('c', 'd')->getURL()
+      (new URL('http://localhost?a=b'))->setParam('c', 'd')->getURL()
     );
   }
 
@@ -669,7 +669,7 @@ class URLTest extends TestCase {
   public function addAdditionalParamChained() {
     $this->assertEquals(
       'http://localhost?a=b&c=d&e=f', 
-      create(new URL('http://localhost?a=b'))->addParam('c', 'd')->addParam('e', 'f')->getURL()
+      (new URL('http://localhost?a=b'))->addParam('c', 'd')->addParam('e', 'f')->getURL()
     );
   }
 
@@ -681,7 +681,7 @@ class URLTest extends TestCase {
   public function setAdditionalParamChained() {
     $this->assertEquals(
       'http://localhost?a=b&c=d&e=f', 
-      create(new URL('http://localhost?a=b'))->setParam('c', 'd')->setParam('e', 'f')->getURL()
+      (new URL('http://localhost?a=b'))->setParam('c', 'd')->setParam('e', 'f')->getURL()
     );
   }
 
@@ -691,7 +691,7 @@ class URLTest extends TestCase {
    */
   #[@test, @expect('lang.IllegalArgumentException')]
   public function addExistingParam() {
-    create(new URL('http://localhost?a=b'))->addParam('a', 'b');
+    (new URL('http://localhost?a=b'))->addParam('a', 'b');
   }
 
   /**
@@ -702,7 +702,7 @@ class URLTest extends TestCase {
   public function setExistingParam() {
     $this->assertEquals(
       'http://localhost?a=c', 
-      create(new URL('http://localhost?a=b'))->setParam('a', 'c')->getURL()
+      (new URL('http://localhost?a=b'))->setParam('a', 'c')->getURL()
     );
   }
 
@@ -712,7 +712,7 @@ class URLTest extends TestCase {
    */
   #[@test, @expect('lang.IllegalArgumentException')]
   public function addExistingParams() {
-    create(new URL('http://localhost?a=b'))->addParams(array('a' => 'b'));
+    (new URL('http://localhost?a=b'))->addParams(array('a' => 'b'));
   }
 
   /**
@@ -738,7 +738,7 @@ class URLTest extends TestCase {
   public function setExistingParams() {
     $this->assertEquals(
       'http://localhost?a=c', 
-      create(new URL('http://localhost?a=b'))->setParams(array('a' => 'c'))->getURL()
+      (new URL('http://localhost?a=b'))->setParams(array('a' => 'c'))->getURL()
     );
   }
 
@@ -750,7 +750,7 @@ class URLTest extends TestCase {
   public function addNewParams() {
     $this->assertEquals(
       'http://localhost?a=b&c=d', 
-      create(new URL('http://localhost'))->addParams(array('a' => 'b', 'c' => 'd'))->getURL()
+      (new URL('http://localhost'))->addParams(array('a' => 'b', 'c' => 'd'))->getURL()
     );
   }
 
@@ -762,7 +762,7 @@ class URLTest extends TestCase {
   public function setNewParams() {
     $this->assertEquals(
       'http://localhost?a=b&c=d', 
-      create(new URL('http://localhost'))->setParams(array('a' => 'b', 'c' => 'd'))->getURL()
+      (new URL('http://localhost'))->setParams(array('a' => 'b', 'c' => 'd'))->getURL()
     );
   }
 
@@ -774,7 +774,7 @@ class URLTest extends TestCase {
   public function addAdditionalParams() {
     $this->assertEquals(
       'http://localhost?z=x&a=b&c=d', 
-      create(new URL('http://localhost?z=x'))->addParams(array('a' => 'b', 'c' => 'd'))->getURL()
+      (new URL('http://localhost?z=x'))->addParams(array('a' => 'b', 'c' => 'd'))->getURL()
     );
   }
 
@@ -786,7 +786,7 @@ class URLTest extends TestCase {
   public function setAdditionalParams() {
     $this->assertEquals(
       'http://localhost?z=x&a=b&c=d', 
-      create(new URL('http://localhost?z=x'))->setParams(array('a' => 'b', 'c' => 'd'))->getURL()
+      (new URL('http://localhost?z=x'))->setParams(array('a' => 'b', 'c' => 'd'))->getURL()
     );
   }
 
@@ -818,77 +818,77 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function params() {
-    $this->assertEquals(array('a' => 'b', 'c' => 'd'), create(new URL('http://localhost?a=b&c=d'))->getParams());
+    $this->assertEquals(array('a' => 'b', 'c' => 'd'), (new URL('http://localhost?a=b&c=d'))->getParams());
   }
 
   #[@test]
   public function withParams() {
-    $this->assertTrue(create(new URL('http://localhost?a=b&c=d'))->hasParams());
+    $this->assertTrue((new URL('http://localhost?a=b&c=d'))->hasParams());
   }
 
   #[@test]
   public function withArrayParams() {
-    $this->assertTrue(create(new URL('http://localhost?a[]=b&a[]=d'))->hasParams());
+    $this->assertTrue((new URL('http://localhost?a[]=b&a[]=d'))->hasParams());
   }
 
   #[@test]
   public function noParams() {
-    $this->assertFalse(create(new URL('http://localhost'))->hasParams());
+    $this->assertFalse((new URL('http://localhost'))->hasParams());
   }
 
   #[@test]
   public function withParam() {
-    $this->assertTrue(create(new URL('http://localhost?a=b&c=d'))->hasParam('a'));
+    $this->assertTrue((new URL('http://localhost?a=b&c=d'))->hasParam('a'));
   }
 
   #[@test]
   public function withArrayParam() {
-    $this->assertTrue(create(new URL('http://localhost?a[]=b&a[]=d'))->hasParam('a'));
+    $this->assertTrue((new URL('http://localhost?a[]=b&a[]=d'))->hasParam('a'));
   }
 
   #[@test]
   public function withNonExistantParam() {
-    $this->assertFalse(create(new URL('http://localhost?a=b&c=d'))->hasParam('d'));
+    $this->assertFalse((new URL('http://localhost?a=b&c=d'))->hasParam('d'));
   }
 
   #[@test]
   public function noParam() {
-    $this->assertFalse(create(new URL('http://localhost'))->hasParam('a'));
+    $this->assertFalse((new URL('http://localhost'))->hasParam('a'));
   }
 
   #[@test]
   public function hasDotParam() {
-    $this->assertTrue(create(new URL('http://localhost/?a.b=c'))->hasParam('a.b'));
+    $this->assertTrue((new URL('http://localhost/?a.b=c'))->hasParam('a.b'));
   }
 
   #[@test]
   public function getDotParam() {
-    $this->assertEquals('c', create(new URL('http://localhost/?a.b=c'))->getParam('a.b'));
+    $this->assertEquals('c', (new URL('http://localhost/?a.b=c'))->getParam('a.b'));
   }
 
   #[@test]
   public function getDotParams() {
-    $this->assertEquals(array('a.b' => 'c'), create(new URL('http://localhost/?a.b=c'))->getParams());
+    $this->assertEquals(array('a.b' => 'c'), (new URL('http://localhost/?a.b=c'))->getParams());
   }
 
   #[@test]
   public function addDotParam() {
-    $this->assertEquals('a.b=c', create(new URL('http://localhost/'))->addParam('a.b', 'c')->getQuery());
+    $this->assertEquals('a.b=c', (new URL('http://localhost/'))->addParam('a.b', 'c')->getQuery());
   }
 
   #[@test]
   public function removeExistingParam() {
-    $this->assertEquals(new URL('http://localhost'), create(new URL('http://localhost?a=b'))->removeParam('a'));
+    $this->assertEquals(new URL('http://localhost'), (new URL('http://localhost?a=b'))->removeParam('a'));
   }
 
   #[@test]
   public function removeNonExistantParam() {
-    $this->assertEquals(new URL('http://localhost'), create(new URL('http://localhost'))->removeParam('a'));
+    $this->assertEquals(new URL('http://localhost'), (new URL('http://localhost'))->removeParam('a'));
   }
 
   #[@test]
   public function removeExistingArrayParam() {
-    $this->assertEquals(new URL('http://localhost'), create(new URL('http://localhost?a[]=b&a[]=c'))->removeParam('a'));
+    $this->assertEquals(new URL('http://localhost'), (new URL('http://localhost?a[]=b&a[]=c'))->removeParam('a'));
   }
 
   #[@test]
@@ -904,16 +904,16 @@ class URLTest extends TestCase {
   #[@test]
   public function hashCodesForSameUrls() {
     $this->assertEquals(
-      create(new URL('http://localhost'))->hashCode(), 
-      create(new URL('http://localhost'))->hashCode()
+      (new URL('http://localhost'))->hashCode(), 
+      (new URL('http://localhost'))->hashCode()
     );
   }
 
   #[@test]
   public function hashCodesForDifferentUrls() {
     $this->assertNotEquals(
-      create(new URL('http://localhost'))->hashCode(), 
-      create(new URL('ftp://localhost'))->hashCode()
+      (new URL('http://localhost'))->hashCode(), 
+      (new URL('ftp://localhost'))->hashCode()
     );
   }
 
@@ -923,7 +923,7 @@ class URLTest extends TestCase {
     $u->addParam('a', 'b');
     
     $this->assertNotEquals(
-      create(new URL('http://localhost'))->hashCode(), 
+      (new URL('http://localhost'))->hashCode(), 
       $u->hashCode()
     );
   }
@@ -965,12 +965,12 @@ class URLTest extends TestCase {
 
   #[@test]
   public function numericAsPartOfSchemeAllowed() {
-    $this->assertEquals('foo+v2', create(new URL('foo+v2://host'))->getScheme());
+    $this->assertEquals('foo+v2', (new URL('foo+v2://host'))->getScheme());
   }
 
   #[@test]
   public function oneLetterScheme() {
-    $this->assertEquals('f', create(new URL('f://host'))->getScheme());
+    $this->assertEquals('f', (new URL('f://host'))->getScheme());
   }
 
   #[@test, @expect('lang.FormatException')]
@@ -1237,27 +1237,27 @@ class URLTest extends TestCase {
 
   #[@test]
   public function getURLWithEmptyParameter() {
-    $this->assertEquals('http://example.com/test?a=v1&b&c=v2', create(new URL('http://example.com/test?a=v1&b=&c=v2'))->getURL());
+    $this->assertEquals('http://example.com/test?a=v1&b&c=v2', (new URL('http://example.com/test?a=v1&b=&c=v2'))->getURL());
   }
 
   #[@test]
   public function getURLWithParameterWithoutValue() {
-    $this->assertEquals('http://example.com/test?a=v1&b&c=v2', create(new URL('http://example.com/test?a=v1&b&c=v2'))->getURL());
+    $this->assertEquals('http://example.com/test?a=v1&b&c=v2', (new URL('http://example.com/test?a=v1&b&c=v2'))->getURL());
   }
 
   #[@test]
   public function getURLAfterSettingEmptyQueryString() {
-    $this->assertEquals('http://example.com/test', create(new URL('http://example.com/test'))->setQuery('')->getURL());
+    $this->assertEquals('http://example.com/test', (new URL('http://example.com/test'))->setQuery('')->getURL());
   }
 
   #[@test]
   public function getURLAfterSettingNullQueryString() {
-    $this->assertEquals('http://example.com/test', create(new URL('http://example.com/test'))->setQuery(null)->getURL());
+    $this->assertEquals('http://example.com/test', (new URL('http://example.com/test'))->setQuery(null)->getURL());
   }
 
   #[@test]
   public function getURLWithEmptyQueryStringConstructor() {
-    $this->assertEquals('http://example.com/test', create(new URL('http://example.com/test?'))->getURL());
+    $this->assertEquals('http://example.com/test', (new URL('http://example.com/test?'))->getURL());
   }
 
   #[@test]
@@ -1269,12 +1269,12 @@ class URLTest extends TestCase {
  
   #[@test]
   public function ipv4Address() {
-    $this->assertEquals('64.246.30.37', create(new URL('http://64.246.30.37'))->getHost());
+    $this->assertEquals('64.246.30.37', (new URL('http://64.246.30.37'))->getHost());
   }
 
   #[@test]
   public function ipv6Address() {
-    $this->assertEquals('[::1]', create(new URL('http://[::1]'))->getHost());
+    $this->assertEquals('[::1]', (new URL('http://[::1]'))->getHost());
   }
 
   #[@test]
@@ -1342,79 +1342,79 @@ class URLTest extends TestCase {
 
   #[@test]
   public function parseIpv6LocalhostURL() {
-    $this->assertEquals('http://[::1]:80/authenticate/', create(new URL('http://[::1]:80/authenticate/'))->getURL());
+    $this->assertEquals('http://[::1]:80/authenticate/', (new URL('http://[::1]:80/authenticate/'))->getURL());
   }
 
   #[@test]
   public function parseIpv6URL() {
-    $this->assertEquals('http://[2001:8d8f:1fe:5:abba:dbff:fefe:7755]:80/authenticate/', create(new URL('http://[2001:8d8f:1fe:5:abba:dbff:fefe:7755]:80/authenticate/'))->getURL());
+    $this->assertEquals('http://[2001:8d8f:1fe:5:abba:dbff:fefe:7755]:80/authenticate/', (new URL('http://[2001:8d8f:1fe:5:abba:dbff:fefe:7755]:80/authenticate/'))->getURL());
   }
 
   #[@test]
   public function canonicalURLScheme() {
-   $this->assertEquals('https://localhost/', create(new URL('https+v3://localhost'))->getCanonicalUrl());
+   $this->assertEquals('https://localhost/', (new URL('https+v3://localhost'))->getCanonicalUrl());
   }
 
   #[@test]
   public function canonicalURLLowerCaseHost() {
-    $this->assertEquals('http://localhost/', create(new URL('http://LOCALHOST'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/', (new URL('http://LOCALHOST'))->getCanonicalUrl());
   }
   
   #[@test]
   public function failCanonicalURLLowerCaseHost() {
-    $this->assertNotEquals('http://LOCALHOST/', create(new URL('http://LOCALHOST'))->getCanonicalUrl());
+    $this->assertNotEquals('http://LOCALHOST/', (new URL('http://LOCALHOST'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLRemoveDefaultPort() {
-    $this->assertEquals('http://localhost/', create(new URL('http://localhost:80'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/', (new URL('http://localhost:80'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLPort() {
-    $this->assertEquals('http://localhost:81/', create(new URL('http://localhost:81'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost:81/', (new URL('http://localhost:81'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLCapitalizeLettersInEscapeSequenceForPath() {
-    $this->assertEquals('http://localhost/a%C2%B1b', create(new URL('http://localhost/a%c2%b1b'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/a%C2%B1b', (new URL('http://localhost/a%c2%b1b'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLdecodePercentEncodedOctetsForPath() {
-    $this->assertEquals('http://localhost/-._~', create(new URL('http://localhost/%2D%2E%5F%7E'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/-._~', (new URL('http://localhost/%2D%2E%5F%7E'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLremoveDotSegmentsForPath() {
-    $this->assertEquals('http://localhost/a/g', create(new URL('http://localhost/a/b/c/./../../g'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/a/g', (new URL('http://localhost/a/b/c/./../../g'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURL() {
     $srcURL='https+v3://LOCALHOST:443/%c2/%7E?q1=%2D&q2=%b1#/a/b/c/./../../g';
     $destURL='https://localhost/%C2/~?q1=-&q2=%B1#/a/g';
-    $this->assertEquals($destURL, create(new URL($srcURL))->getCanonicalUrl());
+    $this->assertEquals($destURL, (new URL($srcURL))->getCanonicalUrl());
   }
 
   #[@test]
   public function atInParams() {
-    $this->assertEquals('@', create(new URL('http://localhost/?q=@'))->getParam('q'));
+    $this->assertEquals('@', (new URL('http://localhost/?q=@'))->getParam('q'));
   }
 
   #[@test]
   public function atInQuerystring() {
-    $this->assertEquals('%40', create(new URL('http://localhost/?@'))->getQuery());
+    $this->assertEquals('%40', (new URL('http://localhost/?@'))->getQuery());
   }
 
   #[@test]
   public function atInFragment() {
-    $this->assertEquals('@', create(new URL('http://localhost/#@'))->getFragment());
+    $this->assertEquals('@', (new URL('http://localhost/#@'))->getFragment());
   }
 
   #[@test]
   public function atInPath() {
-    $this->assertEquals('/@', create(new URL('http://localhost/@'))->getPath());
+    $this->assertEquals('/@', (new URL('http://localhost/@'))->getPath());
   }
 
   #[@test]
@@ -1433,7 +1433,7 @@ class URLTest extends TestCase {
   #  'http://user@localhost/path?query#fragment'
   #])]
   public function string_representation($input) {
-    $this->assertEquals($input, create(new URL($input))->toString());
+    $this->assertEquals($input, (new URL($input))->toString());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/peer/URLTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/URLTest.class.php
@@ -15,203 +15,203 @@ class URLTest extends TestCase {
 
   #[@test]
   public function scheme() {
-    $this->assertEquals('http', (new URL('http://localhost'))->getScheme());
+    $this->assertEquals('http', create(new URL('http://localhost'))->getScheme());
   }
 
   #[@test]
   public function schemeWithPlus() {
-    $this->assertEquals('svn+ssl', (new URL('svn+ssl://localhost'))->getScheme());
+    $this->assertEquals('svn+ssl', create(new URL('svn+ssl://localhost'))->getScheme());
   }
 
   #[@test]
   public function schemeMutability() {
     $this->assertEquals(
       'ftp://localhost', 
-      (new URL('http://localhost'))->setScheme('ftp')->getURL()
+      create(new URL('http://localhost'))->setScheme('ftp')->getURL()
     );
   }
 
   #[@test]
   public function host() {
-    $this->assertEquals('localhost', (new URL('http://localhost'))->getHost());
+    $this->assertEquals('localhost', create(new URL('http://localhost'))->getHost());
   }
 
   #[@test]
   public function uppercaseHost() {
-    $this->assertEquals('TEST', (new URL('http://TEST'))->getHost());
+    $this->assertEquals('TEST', create(new URL('http://TEST'))->getHost());
   }
 
   #[@test]
   public function hostMutability() {
     $this->assertEquals(
       'http://127.0.0.1', 
-      (new URL('http://localhost'))->setHost('127.0.0.1')->getURL()
+      create(new URL('http://localhost'))->setHost('127.0.0.1')->getURL()
     );
   }
 
   #[@test]
   public function path() {
-    $this->assertEquals('/news/index.html', (new URL('http://localhost/news/index.html'))->getPath());
+    $this->assertEquals('/news/index.html', create(new URL('http://localhost/news/index.html'))->getPath());
   }
 
   #[@test]
   public function emptyPath() {
-    $this->assertEquals(null, (new URL('http://localhost'))->getPath());
+    $this->assertEquals(null, create(new URL('http://localhost'))->getPath());
   }
 
   #[@test]
   public function slashPath() {
-    $this->assertEquals('/', (new URL('http://localhost/'))->getPath());
+    $this->assertEquals('/', create(new URL('http://localhost/'))->getPath());
   }
 
   #[@test]
   public function pathDefault() {
-    $this->assertEquals('/', (new URL('http://localhost'))->getPath('/'));
+    $this->assertEquals('/', create(new URL('http://localhost'))->getPath('/'));
   }
 
   #[@test]
   public function pathMutability() {
     $this->assertEquals(
       'http://localhost/index.html', 
-      (new URL('http://localhost'))->setPath('/index.html')->getURL()
+      create(new URL('http://localhost'))->setPath('/index.html')->getURL()
     );
   }
 
   #[@test]
   public function user() {
-    $this->assertEquals('user', (new URL('http://user@localhost'))->getUser());
+    $this->assertEquals('user', create(new URL('http://user@localhost'))->getUser());
   }
 
   #[@test]
   public function emptyUser() {
-    $this->assertEquals(null, (new URL('http://localhost'))->getUser());
+    $this->assertEquals(null, create(new URL('http://localhost'))->getUser());
   }
 
   #[@test]
   public function userDefault() {
-    $this->assertEquals('nobody', (new URL('http://localhost'))->getUser('nobody'));
+    $this->assertEquals('nobody', create(new URL('http://localhost'))->getUser('nobody'));
   }
 
   #[@test]
   public function urlEncodedUser() {
-    $this->assertEquals('user?', (new URL('http://user%3F@localhost'))->getUser());
+    $this->assertEquals('user?', create(new URL('http://user%3F@localhost'))->getUser());
   }
 
   #[@test]
   public function setUrlEncodedUser() {
-    $this->assertEquals('http://user%3F@localhost', (new URL('http://localhost'))->setUser('user?')->getURL());
+    $this->assertEquals('http://user%3F@localhost', create(new URL('http://localhost'))->setUser('user?')->getURL());
   }
 
   #[@test]
   public function userMutability() {
     $this->assertEquals(
       'http://thekid@localhost', 
-      (new URL('http://localhost'))->setUser('thekid')->getURL()
+      create(new URL('http://localhost'))->setUser('thekid')->getURL()
     );
   }
 
   #[@test]
   public function password() {
-    $this->assertEquals('password', (new URL('http://user:password@localhost'))->getPassword());
+    $this->assertEquals('password', create(new URL('http://user:password@localhost'))->getPassword());
   }
 
   #[@test]
   public function urlEncodedPassword() {
-    $this->assertEquals('pass?word', (new URL('http://user:pass%3Fword@localhost'))->getPassword());
+    $this->assertEquals('pass?word', create(new URL('http://user:pass%3Fword@localhost'))->getPassword());
   }
 
   #[@test]
   public function setUrlEncodedPassword() {
-    $this->assertEquals('http://user:pass%3Fword@localhost', (new URL('http://user@localhost'))->setPassword('pass?word')->getURL());
+    $this->assertEquals('http://user:pass%3Fword@localhost', create(new URL('http://user@localhost'))->setPassword('pass?word')->getURL());
   }
 
   #[@test]
   public function emptyPassword() {
-    $this->assertEquals(null, (new URL('http://localhost'))->getPassword());
+    $this->assertEquals(null, create(new URL('http://localhost'))->getPassword());
   }
 
   #[@test]
   public function passwordDefault() {
-    $this->assertEquals('secret', (new URL('http://user@localhost'))->getPassword('secret'));
+    $this->assertEquals('secret', create(new URL('http://user@localhost'))->getPassword('secret'));
   }
 
   #[@test]
   public function passwordMutability() {
     $this->assertEquals(
       'http://anon:anon@localhost', 
-      (new URL('http://anon@localhost'))->setPassword('anon')->getURL()
+      create(new URL('http://anon@localhost'))->setPassword('anon')->getURL()
     );
   }
 
   #[@test]
   public function query() {
-    $this->assertEquals('a=b', (new URL('http://localhost?a=b'))->getQuery());
+    $this->assertEquals('a=b', create(new URL('http://localhost?a=b'))->getQuery());
   }
 
   #[@test]
   public function queryModifiedByParams() {
     $this->assertEquals(
       'a=b&c=d', 
-      (new URL('http://localhost?a=b'))->addParam('c', 'd')->getQuery()
+      create(new URL('http://localhost?a=b'))->addParam('c', 'd')->getQuery()
     );
   }
 
   #[@test]
   public function emptyQuery() {
-    $this->assertEquals(null, (new URL('http://localhost'))->getQuery());
+    $this->assertEquals(null, create(new URL('http://localhost'))->getQuery());
   }
 
   #[@test]
   public function parameterLessQuery() {
-    $this->assertEquals('1549', (new URL('http://localhost/?1549'))->getQuery());
+    $this->assertEquals('1549', create(new URL('http://localhost/?1549'))->getQuery());
   }
 
   #[@test]
   public function addToParameterLessQuery() {
-    $this->assertEquals('1549&a=b', (new URL('http://localhost/?1549'))->addParam('a', 'b')->getQuery());
+    $this->assertEquals('1549&a=b', create(new URL('http://localhost/?1549'))->addParam('a', 'b')->getQuery());
   }
 
   #[@test]
-  public function ParameterLessQueryWithAdd() {
-    $this->assertEquals('1549', (new URL('http://localhost/'))->addParam('1549')->getQuery());
+  public function createParameterLessQueryWithAdd() {
+    $this->assertEquals('1549', create(new URL('http://localhost/'))->addParam('1549')->getQuery());
   }
 
   #[@test]
-  public function ParameterLessQueryWithSet() {
-    $this->assertEquals('1549', (new URL('http://localhost/'))->setParam('1549')->getQuery());
+  public function createParameterLessQueryWithSet() {
+    $this->assertEquals('1549', create(new URL('http://localhost/'))->setParam('1549')->getQuery());
   }
 
   #[@test]
   public function questionMarkOnly() {
-    $this->assertEquals(null, (new URL('http://localhost?'))->getQuery());
+    $this->assertEquals(null, create(new URL('http://localhost?'))->getQuery());
   }
 
   #[@test]
   public function questionMarkAndFragmentOnly() {
-    $this->assertEquals(null, (new URL('http://localhost?#'))->getQuery());
+    $this->assertEquals(null, create(new URL('http://localhost?#'))->getQuery());
   }
 
   #[@test]
   public function queryDefault() {
-    $this->assertEquals('1,2,3', (new URL('http://localhost'))->getQuery('1,2,3'));
+    $this->assertEquals('1,2,3', create(new URL('http://localhost'))->getQuery('1,2,3'));
   }
 
   #[@test]
   public function queryMutability() {
     $this->assertEquals(
       'http://localhost?a=b', 
-      (new URL('http://localhost'))->setQuery('a=b')->getURL()
+      create(new URL('http://localhost'))->setQuery('a=b')->getURL()
     );
   }
 
   #[@test]
   public function getParameterLessQuery() {
-    $this->assertEquals('', (new URL('http://localhost/?1549'))->getParam('1549'));
+    $this->assertEquals('', create(new URL('http://localhost/?1549'))->getParam('1549'));
   }
 
   #[@test]
   public function hasParameterLessQuery() {
-    $this->assertTrue((new URL('http://localhost/?1549'))->hasParam('1549'));
+    $this->assertTrue(create(new URL('http://localhost/?1549'))->hasParam('1549'));
   }
 
   /**
@@ -220,7 +220,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragment() {
-    $this->assertEquals('top', (new URL('http://localhost#top'))->getFragment());
+    $this->assertEquals('top', create(new URL('http://localhost#top'))->getFragment());
   }
 
   /**
@@ -229,7 +229,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragmentWithSlash() {
-    $this->assertEquals('top', (new URL('http://localhost/#top'))->getFragment());
+    $this->assertEquals('top', create(new URL('http://localhost/#top'))->getFragment());
   }
 
   /**
@@ -238,7 +238,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragmentWithSlashAndQuestionMark() {
-    $this->assertEquals('top', (new URL('http://localhost/?#top'))->getFragment());
+    $this->assertEquals('top', create(new URL('http://localhost/?#top'))->getFragment());
   }
 
   /**
@@ -247,7 +247,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragmentWithQuery() {
-    $this->assertEquals('top', (new URL('http://localhost/?query#top'))->getFragment());
+    $this->assertEquals('top', create(new URL('http://localhost/?query#top'))->getFragment());
   }
 
   /**
@@ -256,7 +256,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function emptyFragment() {
-    $this->assertEquals(null, (new URL('http://localhost'))->getFragment());
+    $this->assertEquals(null, create(new URL('http://localhost'))->getFragment());
   }
 
   /**
@@ -265,7 +265,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function hashOnly() {
-    $this->assertEquals(null, (new URL('http://localhost#'))->getFragment());
+    $this->assertEquals(null, create(new URL('http://localhost#'))->getFragment());
   }
 
   /**
@@ -274,7 +274,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function hashAtEnd() {
-    $this->assertEquals(null, (new URL('http://localhost?#'))->getFragment());
+    $this->assertEquals(null, create(new URL('http://localhost?#'))->getFragment());
   }
 
   /**
@@ -283,7 +283,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function hashAtEndWithQuery() {
-    $this->assertEquals(null, (new URL('http://localhost?query#'))->getFragment());
+    $this->assertEquals(null, create(new URL('http://localhost?query#'))->getFragment());
   }
 
   /**
@@ -292,7 +292,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function fragmentDefault() {
-    $this->assertEquals('top', (new URL('http://localhost'))->getFragment('top'));
+    $this->assertEquals('top', create(new URL('http://localhost'))->getFragment('top'));
   }
 
   /**
@@ -303,7 +303,7 @@ class URLTest extends TestCase {
   public function fragmentMutability() {
     $this->assertEquals(
       'http://localhost#list', 
-      (new URL('http://localhost'))->setFragment('list')->getURL()
+      create(new URL('http://localhost'))->setFragment('list')->getURL()
     );
   }
 
@@ -313,7 +313,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function port() {
-    $this->assertEquals(8080, (new URL('http://localhost:8080'))->getPort());
+    $this->assertEquals(8080, create(new URL('http://localhost:8080'))->getPort());
   }
 
   /**
@@ -322,7 +322,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function emptyPort() {
-    $this->assertEquals(null, (new URL('http://localhost'))->getPort());
+    $this->assertEquals(null, create(new URL('http://localhost'))->getPort());
   }
 
   /**
@@ -331,7 +331,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function portDefault() {
-    $this->assertEquals(80, (new URL('http://localhost'))->getPort(80));
+    $this->assertEquals(80, create(new URL('http://localhost'))->getPort(80));
   }
 
   /**
@@ -342,13 +342,13 @@ class URLTest extends TestCase {
   public function portMutability() {
     $this->assertEquals(
       'http://localhost:8081', 
-      (new URL('http://localhost'))->setPort(8081)->getURL()
+      create(new URL('http://localhost'))->setPort(8081)->getURL()
     );
   }
 
   #[@test]
   public function param() {
-    $this->assertEquals('b', (new URL('http://localhost?a=b'))->getParam('a'));
+    $this->assertEquals('b', create(new URL('http://localhost?a=b'))->getParam('a'));
   }
 
   /**
@@ -357,7 +357,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function getArrayParameter() {
-    $this->assertEquals(array('b'), (new URL('http://localhost?a[]=b'))->getParam('a'));
+    $this->assertEquals(array('b'), create(new URL('http://localhost?a[]=b'))->getParam('a'));
   }
 
   /**
@@ -366,7 +366,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function getEncodedArrayParameter() {
-    $this->assertEquals(array('='), (new URL('http://localhost?a[]=%3D'))->getParam('a'));
+    $this->assertEquals(array('='), create(new URL('http://localhost?a[]=%3D'))->getParam('a'));
   }
 
   /**
@@ -375,7 +375,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function getArrayParameters() {
-    $this->assertEquals(array('b', 'c'), (new URL('http://localhost?a[]=b&a[]=c'))->getParam('a'));
+    $this->assertEquals(array('b', 'c'), create(new URL('http://localhost?a[]=b&a[]=c'))->getParam('a'));
   }
 
   /**
@@ -386,7 +386,7 @@ class URLTest extends TestCase {
   public function getArrayParametersAsHash() {
     $this->assertEquals(
       array('name' => 'b', 'color' => 'c'), 
-      (new URL('http://localhost?a[name]=b&a[color]=c'))->getParam('a')
+      create(new URL('http://localhost?a[name]=b&a[color]=c'))->getParam('a')
     );
   }
 
@@ -398,7 +398,7 @@ class URLTest extends TestCase {
   public function getArrayParametersAsHashWithEncodedNames() {
     $this->assertEquals(
       array('=name=' => 'b', '=color=' => 'c'), 
-      (new URL('http://localhost?a[%3Dname%3D]=b&a[%3Dcolor%3D]=c'))->getParam('a')
+      create(new URL('http://localhost?a[%3Dname%3D]=b&a[%3Dcolor%3D]=c'))->getParam('a')
     );
   }
 
@@ -410,7 +410,7 @@ class URLTest extends TestCase {
   public function arrayOffsetsInDifferentArrays() {
     $this->assertEquals(
       array('a' => array('c'), 'b' => array('d')), 
-      (new URL('http://localhost/?a[]=c&b[]=d'))->getParams()
+      create(new URL('http://localhost/?a[]=c&b[]=d'))->getParams()
     );
   }
 
@@ -422,7 +422,7 @@ class URLTest extends TestCase {
   public function duplicateOffsetsOverwriteEachother() {
     $this->assertEquals(
       array('c'), 
-      (new URL('http://localhost/?a[0]=b&a[0]=c'))->getParam('a')
+      create(new URL('http://localhost/?a[0]=b&a[0]=c'))->getParam('a')
     );
   }
 
@@ -434,7 +434,7 @@ class URLTest extends TestCase {
   public function duplicateNamesOverwriteEachother() {
     $this->assertEquals(
       array('name' => 'c'), 
-      (new URL('http://localhost/?a[name]=b&a[name]=c'))->getParam('a')
+      create(new URL('http://localhost/?a[name]=b&a[name]=c'))->getParam('a')
     );
   }
 
@@ -446,7 +446,7 @@ class URLTest extends TestCase {
   public function twoDimensionalArray() {
     $this->assertEquals(
       array(array('b')), 
-      (new URL('http://localhost/?a[][]=b'))->getParam('a')
+      create(new URL('http://localhost/?a[][]=b'))->getParam('a')
     );
   }
 
@@ -458,7 +458,7 @@ class URLTest extends TestCase {
   public function threeDimensionalArray() {
     $this->assertEquals(
       array(array(array('b'))), 
-      (new URL('http://localhost/?a[][][]=b'))->getParam('a')
+      create(new URL('http://localhost/?a[][][]=b'))->getParam('a')
     );
   }
 
@@ -470,7 +470,7 @@ class URLTest extends TestCase {
   public function arrayOfHash() {
     $this->assertEquals(
       array(array(array('name' => 'b'))), 
-      (new URL('http://localhost/?a[][][name]=b'))->getParam('a')
+      create(new URL('http://localhost/?a[][][name]=b'))->getParam('a')
     );
   }
 
@@ -482,7 +482,7 @@ class URLTest extends TestCase {
   public function hashOfArray() {
     $this->assertEquals(
       array('name' => array(array('b'))), 
-      (new URL('http://localhost/?a[name][][]=b'))->getParam('a')
+      create(new URL('http://localhost/?a[name][][]=b'))->getParam('a')
     );
   }
 
@@ -494,7 +494,7 @@ class URLTest extends TestCase {
   public function hashOfArrayOfHash() {
     $this->assertEquals(
       array('name' => array(array('key' => 'b'))), 
-      (new URL('http://localhost/?a[name][][key]=b'))->getParam('a')
+      create(new URL('http://localhost/?a[name][][key]=b'))->getParam('a')
     );
   }
 
@@ -506,7 +506,7 @@ class URLTest extends TestCase {
   public function hashNotationWithoutValues() {
     $this->assertEquals(
       array('name' => '', 'color' => ''), 
-      (new URL('http://localhost/?a[name]&a[color]'))->getParam('a')
+      create(new URL('http://localhost/?a[name]&a[color]'))->getParam('a')
     );
   }
 
@@ -518,7 +518,7 @@ class URLTest extends TestCase {
   public function arrayNotationWithoutValues() {
     $this->assertEquals(
       array('', ''), 
-      (new URL('http://localhost/?a[]&a[]'))->getParam('a')
+      create(new URL('http://localhost/?a[]&a[]'))->getParam('a')
     );
   }
 
@@ -530,7 +530,7 @@ class URLTest extends TestCase {
   public function getArrayParams() {
     $this->assertEquals(
       array('a' => array('b', 'c')), 
-      (new URL('http://localhost?a[]=b&a[]=c'))->getParams()
+      create(new URL('http://localhost?a[]=b&a[]=c'))->getParams()
     );
   }
 
@@ -542,7 +542,7 @@ class URLTest extends TestCase {
   public function mixedOffsetsAndKeys() {
     $this->assertEquals(
       array(0 => 'b', 'name' => 'c', 1 => 'd'), 
-      (new URL('http://localhost/?a[]=b&a[name]=c&a[]=d'))->getParam('a')
+      create(new URL('http://localhost/?a[]=b&a[name]=c&a[]=d'))->getParam('a')
     );
   }
 
@@ -554,7 +554,7 @@ class URLTest extends TestCase {
   public function nestedBraces() {
     $this->assertEquals(
       array('a' => array('nested[]' => 'b')), 
-      (new URL('http://localhost/?a[nested[]]=b'))->getParams()
+      create(new URL('http://localhost/?a[nested[]]=b'))->getParams()
     );
   }
  
@@ -566,7 +566,7 @@ class URLTest extends TestCase {
   public function nestedBracesTwice() {
     $this->assertEquals(
       array('a' => array('nested[a]' => 'b', 'nested[b]' => 'c')), 
-      (new URL('http://localhost/?a[nested[a]]=b&a[nested[b]]=c'))->getParams()
+      create(new URL('http://localhost/?a[nested[a]]=b&a[nested[b]]=c'))->getParams()
     );
   }
 
@@ -578,7 +578,7 @@ class URLTest extends TestCase {
   public function nestedBracesChained() {
     $this->assertEquals(
       array('a' => array('nested[a]' => array('c'))), 
-      (new URL('http://localhost/?a[nested[a]][]=c'))->getParams()
+      create(new URL('http://localhost/?a[nested[a]][]=c'))->getParams()
     );
   }
 
@@ -587,21 +587,21 @@ class URLTest extends TestCase {
    *
    */
   #[@test]
-  public function unnamedArrayParameterDoesNotArray() {
+  public function unnamedArrayParameterDoesNotCreateArray() {
     $this->assertEquals(
       array('[]' => 'c'), 
-      (new URL('http://localhost/?[]=c'))->getParams()
+      create(new URL('http://localhost/?[]=c'))->getParams()
     );
   }
 
   #[@test]
   public function nonExistantParam() {
-    $this->assertEquals(null, (new URL('http://localhost?a=b'))->getParam('b'));
+    $this->assertEquals(null, create(new URL('http://localhost?a=b'))->getParam('b'));
   }
 
   #[@test]
   public function emptyParam() {
-    $this->assertEquals('', (new URL('http://localhost?x='))->getParam('x'));
+    $this->assertEquals('', create(new URL('http://localhost?x='))->getParam('x'));
   }
 
   /**
@@ -610,7 +610,7 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function paramDefault() {
-    $this->assertEquals('x', (new URL('http://localhost?a=b'))->getParam('c', 'x'));
+    $this->assertEquals('x', create(new URL('http://localhost?a=b'))->getParam('c', 'x'));
   }
  
   /**
@@ -621,7 +621,7 @@ class URLTest extends TestCase {
   public function addNewParam() {
     $this->assertEquals(
       'http://localhost?a=b', 
-      (new URL('http://localhost'))->addParam('a', 'b')->getURL()
+      create(new URL('http://localhost'))->addParam('a', 'b')->getURL()
     );
   }
 
@@ -633,7 +633,7 @@ class URLTest extends TestCase {
   public function setNewParam() {
     $this->assertEquals(
       'http://localhost?a=b', 
-      (new URL('http://localhost'))->setParam('a', 'b')->getURL()
+      create(new URL('http://localhost'))->setParam('a', 'b')->getURL()
     );
   }
 
@@ -645,7 +645,7 @@ class URLTest extends TestCase {
   public function addAdditionalParam() {
     $this->assertEquals(
       'http://localhost?a=b&c=d', 
-      (new URL('http://localhost?a=b'))->addParam('c', 'd')->getURL()
+      create(new URL('http://localhost?a=b'))->addParam('c', 'd')->getURL()
     );
   }
 
@@ -657,7 +657,7 @@ class URLTest extends TestCase {
   public function setAdditionalParam() {
     $this->assertEquals(
       'http://localhost?a=b&c=d', 
-      (new URL('http://localhost?a=b'))->setParam('c', 'd')->getURL()
+      create(new URL('http://localhost?a=b'))->setParam('c', 'd')->getURL()
     );
   }
 
@@ -669,7 +669,7 @@ class URLTest extends TestCase {
   public function addAdditionalParamChained() {
     $this->assertEquals(
       'http://localhost?a=b&c=d&e=f', 
-      (new URL('http://localhost?a=b'))->addParam('c', 'd')->addParam('e', 'f')->getURL()
+      create(new URL('http://localhost?a=b'))->addParam('c', 'd')->addParam('e', 'f')->getURL()
     );
   }
 
@@ -681,7 +681,7 @@ class URLTest extends TestCase {
   public function setAdditionalParamChained() {
     $this->assertEquals(
       'http://localhost?a=b&c=d&e=f', 
-      (new URL('http://localhost?a=b'))->setParam('c', 'd')->setParam('e', 'f')->getURL()
+      create(new URL('http://localhost?a=b'))->setParam('c', 'd')->setParam('e', 'f')->getURL()
     );
   }
 
@@ -691,7 +691,7 @@ class URLTest extends TestCase {
    */
   #[@test, @expect('lang.IllegalArgumentException')]
   public function addExistingParam() {
-    (new URL('http://localhost?a=b'))->addParam('a', 'b');
+    create(new URL('http://localhost?a=b'))->addParam('a', 'b');
   }
 
   /**
@@ -702,7 +702,7 @@ class URLTest extends TestCase {
   public function setExistingParam() {
     $this->assertEquals(
       'http://localhost?a=c', 
-      (new URL('http://localhost?a=b'))->setParam('a', 'c')->getURL()
+      create(new URL('http://localhost?a=b'))->setParam('a', 'c')->getURL()
     );
   }
 
@@ -712,7 +712,7 @@ class URLTest extends TestCase {
    */
   #[@test, @expect('lang.IllegalArgumentException')]
   public function addExistingParams() {
-    (new URL('http://localhost?a=b'))->addParams(array('a' => 'b'));
+    create(new URL('http://localhost?a=b'))->addParams(array('a' => 'b'));
   }
 
   /**
@@ -738,7 +738,7 @@ class URLTest extends TestCase {
   public function setExistingParams() {
     $this->assertEquals(
       'http://localhost?a=c', 
-      (new URL('http://localhost?a=b'))->setParams(array('a' => 'c'))->getURL()
+      create(new URL('http://localhost?a=b'))->setParams(array('a' => 'c'))->getURL()
     );
   }
 
@@ -750,7 +750,7 @@ class URLTest extends TestCase {
   public function addNewParams() {
     $this->assertEquals(
       'http://localhost?a=b&c=d', 
-      (new URL('http://localhost'))->addParams(array('a' => 'b', 'c' => 'd'))->getURL()
+      create(new URL('http://localhost'))->addParams(array('a' => 'b', 'c' => 'd'))->getURL()
     );
   }
 
@@ -762,7 +762,7 @@ class URLTest extends TestCase {
   public function setNewParams() {
     $this->assertEquals(
       'http://localhost?a=b&c=d', 
-      (new URL('http://localhost'))->setParams(array('a' => 'b', 'c' => 'd'))->getURL()
+      create(new URL('http://localhost'))->setParams(array('a' => 'b', 'c' => 'd'))->getURL()
     );
   }
 
@@ -774,7 +774,7 @@ class URLTest extends TestCase {
   public function addAdditionalParams() {
     $this->assertEquals(
       'http://localhost?z=x&a=b&c=d', 
-      (new URL('http://localhost?z=x'))->addParams(array('a' => 'b', 'c' => 'd'))->getURL()
+      create(new URL('http://localhost?z=x'))->addParams(array('a' => 'b', 'c' => 'd'))->getURL()
     );
   }
 
@@ -786,7 +786,7 @@ class URLTest extends TestCase {
   public function setAdditionalParams() {
     $this->assertEquals(
       'http://localhost?z=x&a=b&c=d', 
-      (new URL('http://localhost?z=x'))->setParams(array('a' => 'b', 'c' => 'd'))->getURL()
+      create(new URL('http://localhost?z=x'))->setParams(array('a' => 'b', 'c' => 'd'))->getURL()
     );
   }
 
@@ -818,77 +818,77 @@ class URLTest extends TestCase {
    */
   #[@test]
   public function params() {
-    $this->assertEquals(array('a' => 'b', 'c' => 'd'), (new URL('http://localhost?a=b&c=d'))->getParams());
+    $this->assertEquals(array('a' => 'b', 'c' => 'd'), create(new URL('http://localhost?a=b&c=d'))->getParams());
   }
 
   #[@test]
   public function withParams() {
-    $this->assertTrue((new URL('http://localhost?a=b&c=d'))->hasParams());
+    $this->assertTrue(create(new URL('http://localhost?a=b&c=d'))->hasParams());
   }
 
   #[@test]
   public function withArrayParams() {
-    $this->assertTrue((new URL('http://localhost?a[]=b&a[]=d'))->hasParams());
+    $this->assertTrue(create(new URL('http://localhost?a[]=b&a[]=d'))->hasParams());
   }
 
   #[@test]
   public function noParams() {
-    $this->assertFalse((new URL('http://localhost'))->hasParams());
+    $this->assertFalse(create(new URL('http://localhost'))->hasParams());
   }
 
   #[@test]
   public function withParam() {
-    $this->assertTrue((new URL('http://localhost?a=b&c=d'))->hasParam('a'));
+    $this->assertTrue(create(new URL('http://localhost?a=b&c=d'))->hasParam('a'));
   }
 
   #[@test]
   public function withArrayParam() {
-    $this->assertTrue((new URL('http://localhost?a[]=b&a[]=d'))->hasParam('a'));
+    $this->assertTrue(create(new URL('http://localhost?a[]=b&a[]=d'))->hasParam('a'));
   }
 
   #[@test]
   public function withNonExistantParam() {
-    $this->assertFalse((new URL('http://localhost?a=b&c=d'))->hasParam('d'));
+    $this->assertFalse(create(new URL('http://localhost?a=b&c=d'))->hasParam('d'));
   }
 
   #[@test]
   public function noParam() {
-    $this->assertFalse((new URL('http://localhost'))->hasParam('a'));
+    $this->assertFalse(create(new URL('http://localhost'))->hasParam('a'));
   }
 
   #[@test]
   public function hasDotParam() {
-    $this->assertTrue((new URL('http://localhost/?a.b=c'))->hasParam('a.b'));
+    $this->assertTrue(create(new URL('http://localhost/?a.b=c'))->hasParam('a.b'));
   }
 
   #[@test]
   public function getDotParam() {
-    $this->assertEquals('c', (new URL('http://localhost/?a.b=c'))->getParam('a.b'));
+    $this->assertEquals('c', create(new URL('http://localhost/?a.b=c'))->getParam('a.b'));
   }
 
   #[@test]
   public function getDotParams() {
-    $this->assertEquals(array('a.b' => 'c'), (new URL('http://localhost/?a.b=c'))->getParams());
+    $this->assertEquals(array('a.b' => 'c'), create(new URL('http://localhost/?a.b=c'))->getParams());
   }
 
   #[@test]
   public function addDotParam() {
-    $this->assertEquals('a.b=c', (new URL('http://localhost/'))->addParam('a.b', 'c')->getQuery());
+    $this->assertEquals('a.b=c', create(new URL('http://localhost/'))->addParam('a.b', 'c')->getQuery());
   }
 
   #[@test]
   public function removeExistingParam() {
-    $this->assertEquals(new URL('http://localhost'), (new URL('http://localhost?a=b'))->removeParam('a'));
+    $this->assertEquals(new URL('http://localhost'), create(new URL('http://localhost?a=b'))->removeParam('a'));
   }
 
   #[@test]
   public function removeNonExistantParam() {
-    $this->assertEquals(new URL('http://localhost'), (new URL('http://localhost'))->removeParam('a'));
+    $this->assertEquals(new URL('http://localhost'), create(new URL('http://localhost'))->removeParam('a'));
   }
 
   #[@test]
   public function removeExistingArrayParam() {
-    $this->assertEquals(new URL('http://localhost'), (new URL('http://localhost?a[]=b&a[]=c'))->removeParam('a'));
+    $this->assertEquals(new URL('http://localhost'), create(new URL('http://localhost?a[]=b&a[]=c'))->removeParam('a'));
   }
 
   #[@test]
@@ -904,16 +904,16 @@ class URLTest extends TestCase {
   #[@test]
   public function hashCodesForSameUrls() {
     $this->assertEquals(
-      (new URL('http://localhost'))->hashCode(), 
-      (new URL('http://localhost'))->hashCode()
+      create(new URL('http://localhost'))->hashCode(), 
+      create(new URL('http://localhost'))->hashCode()
     );
   }
 
   #[@test]
   public function hashCodesForDifferentUrls() {
     $this->assertNotEquals(
-      (new URL('http://localhost'))->hashCode(), 
-      (new URL('ftp://localhost'))->hashCode()
+      create(new URL('http://localhost'))->hashCode(), 
+      create(new URL('ftp://localhost'))->hashCode()
     );
   }
 
@@ -923,7 +923,7 @@ class URLTest extends TestCase {
     $u->addParam('a', 'b');
     
     $this->assertNotEquals(
-      (new URL('http://localhost'))->hashCode(), 
+      create(new URL('http://localhost'))->hashCode(), 
       $u->hashCode()
     );
   }
@@ -965,12 +965,12 @@ class URLTest extends TestCase {
 
   #[@test]
   public function numericAsPartOfSchemeAllowed() {
-    $this->assertEquals('foo+v2', (new URL('foo+v2://host'))->getScheme());
+    $this->assertEquals('foo+v2', create(new URL('foo+v2://host'))->getScheme());
   }
 
   #[@test]
   public function oneLetterScheme() {
-    $this->assertEquals('f', (new URL('f://host'))->getScheme());
+    $this->assertEquals('f', create(new URL('f://host'))->getScheme());
   }
 
   #[@test, @expect('lang.FormatException')]
@@ -1237,27 +1237,27 @@ class URLTest extends TestCase {
 
   #[@test]
   public function getURLWithEmptyParameter() {
-    $this->assertEquals('http://example.com/test?a=v1&b&c=v2', (new URL('http://example.com/test?a=v1&b=&c=v2'))->getURL());
+    $this->assertEquals('http://example.com/test?a=v1&b&c=v2', create(new URL('http://example.com/test?a=v1&b=&c=v2'))->getURL());
   }
 
   #[@test]
   public function getURLWithParameterWithoutValue() {
-    $this->assertEquals('http://example.com/test?a=v1&b&c=v2', (new URL('http://example.com/test?a=v1&b&c=v2'))->getURL());
+    $this->assertEquals('http://example.com/test?a=v1&b&c=v2', create(new URL('http://example.com/test?a=v1&b&c=v2'))->getURL());
   }
 
   #[@test]
   public function getURLAfterSettingEmptyQueryString() {
-    $this->assertEquals('http://example.com/test', (new URL('http://example.com/test'))->setQuery('')->getURL());
+    $this->assertEquals('http://example.com/test', create(new URL('http://example.com/test'))->setQuery('')->getURL());
   }
 
   #[@test]
   public function getURLAfterSettingNullQueryString() {
-    $this->assertEquals('http://example.com/test', (new URL('http://example.com/test'))->setQuery(null)->getURL());
+    $this->assertEquals('http://example.com/test', create(new URL('http://example.com/test'))->setQuery(null)->getURL());
   }
 
   #[@test]
   public function getURLWithEmptyQueryStringConstructor() {
-    $this->assertEquals('http://example.com/test', (new URL('http://example.com/test?'))->getURL());
+    $this->assertEquals('http://example.com/test', create(new URL('http://example.com/test?'))->getURL());
   }
 
   #[@test]
@@ -1269,12 +1269,12 @@ class URLTest extends TestCase {
  
   #[@test]
   public function ipv4Address() {
-    $this->assertEquals('64.246.30.37', (new URL('http://64.246.30.37'))->getHost());
+    $this->assertEquals('64.246.30.37', create(new URL('http://64.246.30.37'))->getHost());
   }
 
   #[@test]
   public function ipv6Address() {
-    $this->assertEquals('[::1]', (new URL('http://[::1]'))->getHost());
+    $this->assertEquals('[::1]', create(new URL('http://[::1]'))->getHost());
   }
 
   #[@test]
@@ -1342,79 +1342,79 @@ class URLTest extends TestCase {
 
   #[@test]
   public function parseIpv6LocalhostURL() {
-    $this->assertEquals('http://[::1]:80/authenticate/', (new URL('http://[::1]:80/authenticate/'))->getURL());
+    $this->assertEquals('http://[::1]:80/authenticate/', create(new URL('http://[::1]:80/authenticate/'))->getURL());
   }
 
   #[@test]
   public function parseIpv6URL() {
-    $this->assertEquals('http://[2001:8d8f:1fe:5:abba:dbff:fefe:7755]:80/authenticate/', (new URL('http://[2001:8d8f:1fe:5:abba:dbff:fefe:7755]:80/authenticate/'))->getURL());
+    $this->assertEquals('http://[2001:8d8f:1fe:5:abba:dbff:fefe:7755]:80/authenticate/', create(new URL('http://[2001:8d8f:1fe:5:abba:dbff:fefe:7755]:80/authenticate/'))->getURL());
   }
 
   #[@test]
   public function canonicalURLScheme() {
-   $this->assertEquals('https://localhost/', (new URL('https+v3://localhost'))->getCanonicalUrl());
+   $this->assertEquals('https://localhost/', create(new URL('https+v3://localhost'))->getCanonicalUrl());
   }
 
   #[@test]
   public function canonicalURLLowerCaseHost() {
-    $this->assertEquals('http://localhost/', (new URL('http://LOCALHOST'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/', create(new URL('http://LOCALHOST'))->getCanonicalUrl());
   }
   
   #[@test]
   public function failCanonicalURLLowerCaseHost() {
-    $this->assertNotEquals('http://LOCALHOST/', (new URL('http://LOCALHOST'))->getCanonicalUrl());
+    $this->assertNotEquals('http://LOCALHOST/', create(new URL('http://LOCALHOST'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLRemoveDefaultPort() {
-    $this->assertEquals('http://localhost/', (new URL('http://localhost:80'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/', create(new URL('http://localhost:80'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLPort() {
-    $this->assertEquals('http://localhost:81/', (new URL('http://localhost:81'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost:81/', create(new URL('http://localhost:81'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLCapitalizeLettersInEscapeSequenceForPath() {
-    $this->assertEquals('http://localhost/a%C2%B1b', (new URL('http://localhost/a%c2%b1b'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/a%C2%B1b', create(new URL('http://localhost/a%c2%b1b'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLdecodePercentEncodedOctetsForPath() {
-    $this->assertEquals('http://localhost/-._~', (new URL('http://localhost/%2D%2E%5F%7E'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/-._~', create(new URL('http://localhost/%2D%2E%5F%7E'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURLremoveDotSegmentsForPath() {
-    $this->assertEquals('http://localhost/a/g', (new URL('http://localhost/a/b/c/./../../g'))->getCanonicalUrl());
+    $this->assertEquals('http://localhost/a/g', create(new URL('http://localhost/a/b/c/./../../g'))->getCanonicalUrl());
   }
   
   #[@test]
   public function canonicalURL() {
     $srcURL='https+v3://LOCALHOST:443/%c2/%7E?q1=%2D&q2=%b1#/a/b/c/./../../g';
     $destURL='https://localhost/%C2/~?q1=-&q2=%B1#/a/g';
-    $this->assertEquals($destURL, (new URL($srcURL))->getCanonicalUrl());
+    $this->assertEquals($destURL, create(new URL($srcURL))->getCanonicalUrl());
   }
 
   #[@test]
   public function atInParams() {
-    $this->assertEquals('@', (new URL('http://localhost/?q=@'))->getParam('q'));
+    $this->assertEquals('@', create(new URL('http://localhost/?q=@'))->getParam('q'));
   }
 
   #[@test]
   public function atInQuerystring() {
-    $this->assertEquals('%40', (new URL('http://localhost/?@'))->getQuery());
+    $this->assertEquals('%40', create(new URL('http://localhost/?@'))->getQuery());
   }
 
   #[@test]
   public function atInFragment() {
-    $this->assertEquals('@', (new URL('http://localhost/#@'))->getFragment());
+    $this->assertEquals('@', create(new URL('http://localhost/#@'))->getFragment());
   }
 
   #[@test]
   public function atInPath() {
-    $this->assertEquals('/@', (new URL('http://localhost/@'))->getPath());
+    $this->assertEquals('/@', create(new URL('http://localhost/@'))->getPath());
   }
 
   #[@test]
@@ -1433,7 +1433,7 @@ class URLTest extends TestCase {
   #  'http://user@localhost/path?query#fragment'
   #])]
   public function string_representation($input) {
-    $this->assertEquals($input, (new URL($input))->toString());
+    $this->assertEquals($input, create(new URL($input))->toString());
   }
 
   #[@test]


### PR DESCRIPTION
This was done to have an easy way to continue writing after new. PHP 5.4, our minimum requirement since XP 6.0.0, supports this syntactically: `(new T())->method()`

***Note:*** *This pull request bumps the xp-runners version requirement  to 5.4.0+!*

See xp-framework/rfc#298