### PR TITLE
Deprecate this()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@ XP Framework Core ChangeLog
 
 ### Heads up!
 
+* **Deprecated this() core functionality**.
+  See xp-framework/core#92
+  (@thekid)
 * **Remove variant of create() which returns object given**.
   See xp-framework/core#91
   (@thekid)

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -482,7 +482,7 @@ function with() {
 }
 // }}}
 
-// {{{ proto var this(var expr, var offset)
+// {{{ proto deprecated var this(var expr, var offset)
 //     Indexer access for a given expression
 function this($expr, $offset) {
   return $expr[$offset];

--- a/src/main/php/peer/net/Inet6Address.class.php
+++ b/src/main/php/peer/net/Inet6Address.class.php
@@ -93,7 +93,7 @@ class Inet6Address extends \lang\Object implements InetAddress {
       if ("\x00\x00" == $this->addr{$i}.$this->addr{$i+1}) {
         $hexquads[]= '0';
       } else {
-        $hexquads[]= ltrim(this(unpack('H*', $this->addr{$i}.$this->addr{$i+1}), 1), '0');
+        $hexquads[]= ltrim(unpack('H*', $this->addr{$i}.$this->addr{$i+1})[1], '0');
       }
     }
     
@@ -116,7 +116,7 @@ class Inet6Address extends \lang\Object implements InetAddress {
    * @return  string
    */
   public function reversedNotation() {
-    $nibbles= this(unpack('H*', $this->addr), 1);
+    $nibbles= unpack('H*', $this->addr)[1];
     $ret= '';
     for ($i= 31; $i >= 0; $i--) {
       $ret.= $nibbles{$i}.'.';

--- a/src/main/php/xp/install/GitHubArchive.class.php
+++ b/src/main/php/xp/install/GitHubArchive.class.php
@@ -1,4 +1,4 @@
-<?php namespace xp\install;
+tf<?php namespace xp\install;
 
 use peer\http\HttpConnection;
 use peer\http\HttpConstants;
@@ -61,7 +61,7 @@ class GitHubArchive extends \lang\Object implements Origin {
         case HttpConstants::STATUS_FOUND: case HttpConstants::STATUS_SEE_OTHER:
           Console::writeLine('Redirect');
           $headers['Referer']= $url;
-          $url= this($response->header('Location'), 0);
+          $url= $response->header('Location')[0];
           continue;
 
         default:

--- a/src/test/php/net/xp_framework/unittest/core/ThisTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ThisTest.class.php
@@ -3,6 +3,7 @@
 /**
  * TestCase for this() core functionality.
  *
+ * @deprecated
  */
 class ThisTest extends \unittest\TestCase {
 


### PR DESCRIPTION
This pull request deprecates the `this()` core functionality. PHP 5.4, which we depend on since XP 6, has syntax for this:

```php
// PHP 5.3
$values= $response->header('Location');
$url= $values[0];

// PHP 5.3 with XP Framework
$url= this($response->header('Location'), 0);

// PHP 5.4+
$url= $response->header('Location')[0];
```

See https://wiki.php.net/rfc/functionarraydereferencing
Part of xp-framework/rfc#298