### PR TITLE
Feature: Use "use" statements in commandline

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,11 @@ XP Framework Core ChangeLog
   See xp-framework/core#88
   (@thekid)
 
+### Features
+
+* Merged xp-framework/core#94: Use "use" statements in commandline
+  (@thekid)
+
 ## 6.3.4 / 2015-06-25
 
 ### Heads up!

--- a/src/main/php/xp/runtime/Code.class.php
+++ b/src/main/php/xp/runtime/Code.class.php
@@ -1,0 +1,72 @@
+<?php namespace xp\runtime;
+
+/**
+ * Wrap code passed in from the command line.
+ *
+ * @see   https://wiki.php.net/rfc/group_use_declarations
+ * @test  xp://net.xp_framework.unittest.core.CodeTest
+ */
+class Code extends \lang\Object {
+  private $fragment, $imports;
+
+  /**
+   * Creates a new code instance
+   *
+   * @param  string $input
+   */
+  public function __construct($input) {
+    if (0 === strncmp($input, '<?', 2)) {
+      $input= substr($input, strcspn($input, ' =') + 1);
+    }
+    $this->fragment= trim($input, ' ;').';';
+    $this->imports= [];
+    while (0 === strncmp($this->fragment, 'use ', 4)) {
+      $delim= strpos($this->fragment, ';');
+      foreach ($this->importsIn(substr($this->fragment, 4, $delim - 4)) as $import) {
+        $this->imports[]= $import;
+      }
+      $this->fragment= ltrim(substr($this->fragment, $delim + 1), ' ');
+    }
+  }
+
+  /** @return string */
+  public function fragment() { return $this->fragment; }
+
+  /** @return string */
+  public function expression() {
+    return strstr($this->fragment, 'return ') || strstr($this->fragment, 'return;')
+      ? $this->fragment
+      : 'return '.$this->fragment
+    ;
+  }
+
+  /** @return string[] */
+  public function imports() { return $this->imports; }
+
+  /** @return string */
+  public function head() {
+    return empty($this->imports) ? '' : 'use '.implode(', ', $this->imports).';';
+  }
+
+  /**
+   * Returns types used inside a `use ...` directive.
+   *
+   * @param  string $use
+   * @return string[]
+   */
+  private function importsIn($use) {
+    $name= strrpos($use, '\\') + 1;
+    $used= [];
+    if ('{' === $use{$name}) {
+      $namespace= substr($use, 0, $name);
+      foreach (explode(',', substr($use, $name + 1, -1)) as $type) {
+        $used[]= $namespace.trim($type);
+      }
+    } else {
+      foreach (explode(',', $use) as $type) {
+        $used[]= trim($type);
+      }
+    }
+    return $used;
+  }
+}

--- a/src/main/php/xp/runtime/Dump.class.php
+++ b/src/main/php/xp/runtime/Dump.class.php
@@ -14,10 +14,13 @@ class Dump extends \lang\Object {
    * @param   string[] args
    */
   public static function main(array $args) {
+    $argc= sizeof($argv);
     $way= array_shift($args);
 
     // Read sourcecode from STDIN if no further argument is given
-    if (0 === sizeof($args)) {
+    if (0 === $argc) {
+      $code= new Code(file_get_contents('php://stdin'));
+    } else if ('--' === $args[0]) {
       $code= new Code(file_get_contents('php://stdin'));
     } else {
       $code= new Code($args[0]);
@@ -25,7 +28,6 @@ class Dump extends \lang\Object {
 
     // Perform
     $argv= [XPClass::nameOf(__CLASS__)] + $args;
-    $argc= sizeof($argv);
     $return= eval($code->head().$code->expression());
     switch ($way) {
       case '-w': Console::writeLine($return); break;

--- a/src/main/php/xp/runtime/Dump.class.php
+++ b/src/main/php/xp/runtime/Dump.class.php
@@ -5,10 +5,9 @@ use lang\XPClass;
 
 /**
  * Evaluates code and dumps its output.
- *
  */
 class Dump extends \lang\Object {
-  
+
   /**
    * Main
    *
@@ -19,21 +18,15 @@ class Dump extends \lang\Object {
 
     // Read sourcecode from STDIN if no further argument is given
     if (0 === sizeof($args)) {
-      $src= file_get_contents('php://stdin');
+      $code= new Code(file_get_contents('php://stdin'));
     } else {
-      $src= $args[0];
+      $code= new Code($args[0]);
     }
-    $src= trim($src, ' ;').';';
-    
-    // Allow missing return
-    strstr($src, 'return ') || strstr($src, 'return;') || $src= 'return '.$src;
-
-    // Rewrite argc, argv
-    $argv= [XPClass::nameOf(__CLASS__)] + $args;
-    $argc= sizeof($argv);
 
     // Perform
-    $return= eval($src);
+    $argv= [XPClass::nameOf(__CLASS__)] + $args;
+    $argc= sizeof($argv);
+    $return= eval($code->head().$code->expression());
     switch ($way) {
       case '-w': Console::writeLine($return); break;
       case '-d': var_dump($return); break;

--- a/src/main/php/xp/runtime/Evaluate.class.php
+++ b/src/main/php/xp/runtime/Evaluate.class.php
@@ -28,7 +28,6 @@ class Evaluate extends \lang\Object {
 
     // Perform
     $argv= [XPClass::nameOf(__CLASS__)] + $args;
-    $argc= sizeof($argv);
     return eval($code->head().$code->fragment());
   }
 }

--- a/src/main/php/xp/runtime/Evaluate.class.php
+++ b/src/main/php/xp/runtime/Evaluate.class.php
@@ -19,22 +19,16 @@ class Evaluate extends \lang\Object {
 
     // Read sourcecode from STDIN if no further argument is given
     if (0 === $argc) {
-      $src= file_get_contents('php://stdin');
+      $code= new Code(file_get_contents('php://stdin'));
     } else if ('--' === $args[0]) {
-      $src= file_get_contents('php://stdin');
+      $code= new Code(file_get_contents('php://stdin'));
     } else {
-      $src= $args[0];
-    }
-
-    // Support <?php
-    $src= trim($src, ' ;').';';
-    if (0 === strncmp($src, '<?php', 5)) {
-      $src= substr($src, 6);
+      $code= new Code($args[0]);
     }
 
     // Perform
     $argv= [XPClass::nameOf(__CLASS__)] + $args;
     $argc= sizeof($argv);
-    return eval($src);
+    return eval($code->head().$code->fragment());
   }
 }

--- a/src/test/config/unittest/core.ini
+++ b/src/test/config/unittest/core.ini
@@ -257,3 +257,6 @@ class="net.xp_framework.unittest.reflection.ModuleTest"
 
 [modules:loading]
 class="net.xp_framework.unittest.reflection.ModuleLoadingTest"
+
+[code]
+class="net.xp_framework.unittest.core.CodeTest"

--- a/src/test/php/net/xp_framework/unittest/core/CodeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CodeTest.class.php
@@ -1,0 +1,120 @@
+<?php namespace net\xp_framework\unittest\core;
+
+use xp\runtime\Code;
+
+class CodeTest extends \unittest\TestCase {
+
+  #[@test]
+  public function can_create() {
+    new Code('"Test"');
+  }
+
+  #[@test]
+  public function can_create_with_empty() {
+    new Code('');
+  }
+
+  #[@test]
+  public function fragment() {
+    $this->assertEquals('var_dump("Test");', (new Code('var_dump("Test")'))->fragment());
+  }
+
+  #[@test]
+  public function fragment_with_semicolon() {
+    $this->assertEquals('var_dump("Test");', (new Code('var_dump("Test");'))->fragment());
+  }
+
+  #[@test, @values([
+  #  '<?php var_dump("Test")',
+  #  '<? var_dump("Test")',
+  #  '<?=var_dump("Test")',
+  #  '<?hh var_dump("Test")'
+  #])]
+  public function fragment_with_php_tag($input) {
+    $this->assertEquals('var_dump("Test");', (new Code($input))->fragment());
+  }
+
+  #[@test]
+  public function expression() {
+    $this->assertEquals('return "Test";', (new Code('"Test"'))->expression());
+  }
+
+  #[@test]
+  public function expression_with_semicolon() {
+    $this->assertEquals('return "Test";', (new Code('"Test";'))->expression());
+  }
+
+  #[@test]
+  public function expression_with_existing_return() {
+    $this->assertEquals('return "Test";', (new Code('return "Test";'))->expression());
+  }
+
+  #[@test, @values([
+  #  'use util\Date; Date::now()',
+  #  'use util\Date, util\TimeZone; Date::now()',
+  #  'use util\Date; use util\TimeZone; Date::now()',
+  #  'use util\{Date, TimeZone}; Date::now()'
+  #])]
+  public function use_is_stripped_from_fragment($input) {
+    $this->assertEquals('Date::now();', (new Code($input))->fragment());
+  }
+
+  #[@test, @values([
+  #  'use util\Date; Date::now()',
+  #  'use util\Date, util\TimeZone; Date::now()',
+  #  'use util\Date; use util\TimeZone; Date::now()',
+  #  'use util\{Date, TimeZone}; Date::now()'
+  #])]
+  public function use_is_stripped_from_expression($input) {
+    $this->assertEquals('return Date::now();', (new Code($input))->expression());
+  }
+
+  #[@test]
+  public function empty_code_has_no_imports() {
+    $this->assertEquals([], (new Code(''))->imports());
+  }
+
+  #[@test]
+  public function code_without_imports() {
+    $this->assertEquals([], (new Code('"Test"'))->imports());
+  }
+
+  #[@test]
+  public function code_with_single_import() {
+    $this->assertEquals(['util\Date'], (new Code('use util\Date; "Test"'))->imports());
+  }
+
+  #[@test]
+  public function code_with_multiple_imports() {
+    $this->assertEquals(['util\Date', 'util\TimeZone'], (new Code('use util\Date; use util\TimeZone; "Test"'))->imports());
+  }
+
+  #[@test]
+  public function code_with_combined_import() {
+    $this->assertEquals(['util\Date', 'util\TimeZone'], (new Code('use util\Date, util\TimeZone; "Test"'))->imports());
+  }
+
+  #[@test]
+  public function code_with_grouped_import() {
+    $this->assertEquals(['util\Date', 'util\TimeZone'], (new Code('use util\{Date, TimeZone}; "Test"'))->imports());
+  }
+
+  #[@test]
+  public function head_with_no_import() {
+    $this->assertEquals('', (new Code('"Test"'))->head());
+  }
+
+  #[@test]
+  public function head_with_single_import() {
+    $this->assertEquals('use util\Date;', (new Code('use util\Date; "Test"'))->head());
+  }
+
+  #[@test, @values([
+  #  'use util\Date, util\TimeZone; Date::now()',
+  #  'use util\Date; use util\TimeZone; Date::now()',
+  #  'use util\{Date, TimeZone}; Date::now()'
+  #])]
+  public function head_with_multiple_imports($input) {
+    $this->assertEquals('use util\Date, util\TimeZone;', (new Code($input))->head());
+  }
+}


### PR DESCRIPTION
This pull request enables the easy use of `use` statements in the command line.

## Example
```sh
$ xp -w 'use lang\{Type, Object}; Type::forName(nameof(new Object()))'
lang.XPClass<lang.Object>
```

## Supported syntaxes

* A single statement, such as `use T;`
* Multiple statements, such as `use T1; use T2;`
* The combined `use T1, T2` syntax
* PHP7's [grouped syntax](https://wiki.php.net/rfc/group_use_declarations) `use ns\{T1, T2};` - *regardless of the PHP version!*

## Consistency
This pull request also adds consistency to `xp -e` and `xp -w|-d`. Both now accept sourcecode with leading PHP open tags and behave in the same way for the given arguments.