### PR TITLE
Refactor: Use finally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ XP Framework Core
 =================
 [![Build Status on TravisCI](https://secure.travis-ci.org/xp-framework/core.png)](http://travis-ci.org/xp-framework/core)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
-[![Required PHP 5.4+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_4plus.png)](http://php.net/)
+[![Required PHP 5.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_5plus.png)](http://php.net/)
 [![Required HHVM 3.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/hhvm-3_5plus.png)](http://hhvm.com/)
 [![Latest Stable Version](https://poser.pugx.org/xp-framework/core/version.png)](https://packagist.org/packages/xp-framework/core)
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "The XP framework is an all-purpose, object oriented PHP framework.",
   "keywords": ["framework", "xp"],
   "require" : {
-    "php" : ">=5.4.0"
+    "php" : ">=5.5.0"
   },
   "autoload" : {
     "files" : ["src/main/php/__xp.php", "src/main/resources/autoload.php"]

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -367,7 +367,7 @@ function __error($code, $msg, $file, $line) {
 }
 // }}}
 
-// {{{ proto void ensure ($t)
+// {{{ proto deprecated void ensure ($t)
 //     Replacement for finally() which clashes with PHP 5.5.0's finally
 function ensure(&$t) {
   if (!isset($t)) $t= null;

--- a/src/test/php/net/xp_framework/unittest/io/collections/ArchiveCollectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/ArchiveCollectionTest.class.php
@@ -65,10 +65,8 @@ class ArchiveCollectionTest extends TestCase {
       $this->assertXarUri('lang/', $first->getURI());
       $this->assertEquals(0, $first->getSize());
       $this->assertEquals(null, $c->next());
-    } catch (\lang\Throwable $e) {
-    } ensure($e); {
+    } finally {
       $c->close();
-      if ($e) throw $e;
     }
   }
   
@@ -90,10 +88,8 @@ class ArchiveCollectionTest extends TestCase {
         $this->assertXarUri($name, $element->getURI());
       }
       $this->assertEquals(null, $c->next());
-    } catch (\lang\Throwable $e) {
-    } ensure($e); {
+    } finally {
       $c->close();
-      if ($e) throw $e;
     }
   }
 

--- a/src/test/php/net/xp_framework/unittest/io/streams/ChannelWrapper.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/ChannelWrapper.class.php
@@ -33,9 +33,8 @@ class ChannelWrapper extends \lang\Object {
     
     try {
       $r->run();
-    } catch (\Exception $e) { } ensure($e); {
+    } finally {
       stream_wrapper_restore('php');
-      if ($e) throw $e;
     }
     
     return self::$streams;

--- a/src/test/php/net/xp_framework/unittest/reflection/PrimitiveAndWrappersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrimitiveAndWrappersTest.class.php
@@ -64,10 +64,9 @@ class PrimitiveAndWrappersTest extends TestCase {
     try {
       Primitive::boxed($fd);
     } catch (\lang\IllegalArgumentException $expected) {
-      // OK
-    } ensure($expected); {
+      return;
+    } finally {
       fclose($fd);    // Necessary, PHP will segfault otherwise
-      if ($expected) return;
     }
     $this->fail('Expected exception not caught', null, 'lang.IllegalArgumentException');
   }

--- a/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
@@ -214,13 +214,10 @@ class ConsoleTest extends \unittest\TestCase {
     Console::initialize($console);
     try {
       $assertions();
-    } catch (\unittest\AssertionFailedError $e) {
-      // finally
-    } ensure($e); {
+    } finally {
       Console::$in= $in;
       Console::$out= $out;
       Console::$err= $err;
-      if ($e) throw($e);
     }
   }
 


### PR DESCRIPTION
This pull request:

* [x] Deprecates the `ensure` core functionality
* [x] Rewrites code to use the `finally` statement instead
* [x] Because of this: **Bumps the minimum PHP version to PHP 5.5.0**
* [x] And of course, because of this: Removes PHP 5.4 testing from TravisCI

This is part of the road towards XP7 as per xp-framework/rfc#298

***Note:*** *Unofficially (meaning: tests will no longer verify its functionality), XP 6.5.0 will still run on PHP 5.4.X, as none of the code in src/main uses PHP 5.5 features yet! This is why the statement in [__xp.php](https://github.com/xp-framework/core/blob/v6.4.0/src/main/php/__xp.php) was deliberately left "inconsistent" with the version requirements stated in composer.json!*