### PR TITLE
Use T::class for all newinstance() calls

### DIFF
--- a/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
@@ -18,7 +18,7 @@ class CastingTest extends TestCase implements Runnable {
 
   #[@test]
   public function newinstance() {
-    $runnable= newinstance('lang.Runnable', [], [
+    $runnable= newinstance(Runnable::class, [], [
       'run' => function() { return 'Test'; }
     ]);
     $this->assertEquals('Test', cast($runnable, 'lang.Runnable')->run());

--- a/src/test/php/net/xp_framework/unittest/core/CloningTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CloningTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use unittest\TestCase;
+use lang\Object;
 use lang\CloneNotSupportedException;
 
 /**
@@ -22,7 +23,7 @@ class CloningTest extends TestCase {
 
   #[@test]
   public function cloneInterceptorCalled() {
-    $original= newinstance('lang.Object', [], '{
+    $original= newinstance(Object::class, [], '{
       public $cloned= FALSE;
 
       public function __clone() {
@@ -37,7 +38,7 @@ class CloningTest extends TestCase {
 
   #[@test, @expect('lang.CloneNotSupportedException')]
   public function cloneInterceptorThrowsException() {
-    clone(newinstance('lang.Object', [], '{
+    clone(newinstance(Object::class, [], '{
       public function __clone() {
         throw new CloneNotSupportedException("I am *UN*Cloneable");
       }

--- a/src/test/php/net/xp_framework/unittest/core/NamespacedClassesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NamespacedClassesTest.class.php
@@ -50,7 +50,7 @@ class NamespacedClassesTest extends TestCase {
   #[@test]
   public function namespacedClassUsingQualified() {
     $this->assertInstanceOf(
-      'net.xp_framework.unittest.core.NamespacedClass',
+      NamespacedClass::class,
       self::$package->loadClass('NamespacedClassUsingQualified')->newInstance()->getNamespacedClass()
     );
   }
@@ -58,20 +58,20 @@ class NamespacedClassesTest extends TestCase {
   #[@test]
   public function namespacedClassUsingQualifiedUnloaded() {
     $this->assertInstanceOf(
-      'net.xp_framework.unittest.core.UnloadedNamespacedClass',
+      UnloadedNamespacedClass::class,
       self::$package->loadClass('NamespacedClassUsingQualifiedUnloaded')->newInstance()->getNamespacedClass()
     );
   }
 
   #[@test]
   public function newInstanceOnNamespacedClass() {
-    $i= newinstance('net.xp_framework.unittest.core.NamespacedClass', [], '{}');
+    $i= newinstance(NamespacedClass::class, [], '{}');
     $this->assertInstanceOf('net.xp_framework.unittest.core.NamespacedClass', $i);
   }
 
   #[@test]
   public function packageOfNewInstancedNamespacedClass() {
-    $i= newinstance('net.xp_framework.unittest.core.NamespacedClass', [], '{}');
+    $i= newinstance(NamespacedClass::class, [], '{}');
     $this->assertEquals(
       \lang\reflect\Package::forName('net.xp_framework.unittest.core'),
       $i->getClass()->getPackage()

--- a/src/test/php/net/xp_framework/unittest/core/Operation.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/Operation.class.php
@@ -11,19 +11,19 @@ abstract class Operation extends \lang\Enum {
     $divided_by;
   
   static function __static() {
-    self::$plus= newinstance(__CLASS__, [0, 'plus'], '{
+    self::$plus= newinstance(self::class, [0, 'plus'], '{
       static function __static() { }
       public function evaluate($x, $y) { return $x + $y; } 
     }');
-    self::$minus= newinstance(__CLASS__, [1, 'minus'], '{
+    self::$minus= newinstance(self::class, [1, 'minus'], '{
       static function __static() { }
       public function evaluate($x, $y) { return $x - $y; } 
     }');
-    self::$times= newinstance(__CLASS__, [2, 'times'], '{
+    self::$times= newinstance(self::class, [2, 'times'], '{
       static function __static() { }
       public function evaluate($x, $y) { return $x * $y; } 
     }');
-    self::$divided_by= newinstance(__CLASS__, [3, 'divided_by'], '{
+    self::$divided_by= newinstance(self::class, [3, 'divided_by'], '{
       static function __static() { }
       public function evaluate($x, $y) { return $x / $y; } 
     }');

--- a/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use net\xp_framework\unittest\Name;
+use lang\Object;
 
 /**
  * Tests the xp::stringOf() core utility
@@ -17,7 +18,7 @@ class StringOfTest extends \unittest\TestCase {
    * @return lang.Object
    */
   protected function testStringInstance() {
-    return newinstance('lang.Object', [], [
+    return newinstance(Object::class, [], [
       'toString' => function() { return 'TestString(6) { String }'; }
     ]);
   }
@@ -130,7 +131,7 @@ class StringOfTest extends \unittest\TestCase {
 
   #[@test]
   public function twice_the_same_object_inside_array_not_recursion() {
-    $test= newinstance('lang.Object', [], [
+    $test= newinstance(Object::class, [], [
       'toString' => function() { return 'Test'; }
     ]);
     $this->assertEquals(
@@ -141,7 +142,7 @@ class StringOfTest extends \unittest\TestCase {
   
   #[@test]
   public function twice_the_same_object_with_huge_hashcode_inside_array_not_recursion() {
-    $test= newinstance('lang.Object', [], [
+    $test= newinstance(Object::class, [], [
       'hashCode' => function() { return 9E100; },
       'toString' => function() { return 'Test'; }
     ]);
@@ -153,7 +154,7 @@ class StringOfTest extends \unittest\TestCase {
 
   #[@test]
   public function toString_calling_xp_stringOf_does_not_loop_forever() {
-    $test= newinstance('lang.Object', [], [
+    $test= newinstance(Object::class, [], [
       'toString' => function() { return \xp::stringOf($this); }
     ]);
     $this->assertEquals(
@@ -174,7 +175,7 @@ class StringOfTest extends \unittest\TestCase {
 
   #[@test]
   public function indenting() {
-    $cl= \lang\ClassLoader::defineClass('net.xp_framework.unittest.core.StringOfTest_IndentingFixture', 'lang.Object', [], '{
+    $cl= \lang\ClassLoader::defineClass('net.xp_framework.unittest.core.StringOfTest_IndentingFixture', Object::class, [], '{
       protected $inner= NULL;
       public function __construct($inner) {
         $this->inner= $inner;
@@ -206,7 +207,7 @@ class StringOfTest extends \unittest\TestCase {
 
   #[@test]
   public function closure_inside_object_does_not_raise_serialization_exception() {
-    $instance= newinstance('lang.Object', [function($a, $b) { }], [
+    $instance= newinstance(Object::class, [function($a, $b) { }], [
       'closure'     => null,
       '__construct' => function($closure) { $this->closure= $closure; },
     ]);

--- a/src/test/php/net/xp_framework/unittest/io/FileUtilTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/FileUtilTest.class.php
@@ -36,7 +36,7 @@ class FileUtilTest extends TestCase {
 
   #[@test]
   public function get_contents_read_returns_less_than_size() {
-    $f= new File(Streams::readableFd(newinstance('io.streams.MemoryInputStream', ['Test'], [
+    $f= new File(Streams::readableFd(newinstance(MemoryInputStream::class, ['Test'], [
       'read' => function($size= 4096) { return parent::read(min(1, $size)); }
     ])));
     $this->assertEquals('Test', FileUtil::getContents($f));

--- a/src/test/php/net/xp_framework/unittest/io/StreamWrappingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/StreamWrappingTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\io;
 
 use unittest\TestCase;
+use io\streams\InputStream;
 use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
 use io\streams\Streams;
@@ -164,7 +165,7 @@ class StreamWrappingTest extends TestCase {
 
   #[@test, @expect('io.IOException')]
   public function readAll_propagates_exception() {
-    Streams::readAll(newinstance('io.streams.InputStream', [], [
+    Streams::readAll(newinstance(InputStream::class, [], [
       'read'      => function($limit= 8192) { throw new IOException('FAIL'); },
       'available' => function() { return 1; },
       'close'     => function() { }

--- a/src/test/php/net/xp_framework/unittest/io/streams/ChannelStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/ChannelStreamTest.class.php
@@ -3,6 +3,7 @@
 use unittest\TestCase;
 use io\streams\ChannelOutputStream;
 use io\streams\ChannelInputStream;
+use lang\Runnable;
 
 /**
  * TestCase
@@ -81,7 +82,7 @@ class ChannelStreamTest extends TestCase {
    */
   #[@test, @expect('io.IOException')]
   public function writeToClosedChannel() {
-    ChannelWrapper::capture(newinstance('lang.Runnable', [], [
+    ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
         $s= new ChannelOutputStream("output");
         $s->close();
@@ -96,7 +97,7 @@ class ChannelStreamTest extends TestCase {
    */
   #[@test, @expect('io.IOException')]
   public function readingFromClosedChannel() {
-    ChannelWrapper::capture(newinstance('lang.Runnable', [], [
+    ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
         $s= new ChannelInputStream('input');
         $s->close();
@@ -111,7 +112,7 @@ class ChannelStreamTest extends TestCase {
    */
   #[@test]
   public function output() {
-    $r= ChannelWrapper::capture(newinstance('lang.Runnable', [], [
+    $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
         $s= new ChannelOutputStream('output');
         $s->write("+OK Hello");
@@ -126,7 +127,7 @@ class ChannelStreamTest extends TestCase {
    */
   #[@test]
   public function stdout() {
-    $r= ChannelWrapper::capture(newinstance('lang.Runnable', [], [
+    $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
         $s= new ChannelOutputStream('stdout');
         $s->write("+OK Hello");
@@ -141,7 +142,7 @@ class ChannelStreamTest extends TestCase {
    */
   #[@test]
   public function stderr() {
-    $r= ChannelWrapper::capture(newinstance('lang.Runnable', [], [
+    $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
         $s= new ChannelOutputStream('stderr');
         $s->write("+OK Hello");
@@ -156,7 +157,7 @@ class ChannelStreamTest extends TestCase {
    */
   #[@test]
   public function stdin() {
-    $r= ChannelWrapper::capture(newinstance('lang.Runnable', [], [
+    $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
         $i= new ChannelInputStream('stdin');
         $o= new ChannelOutputStream('stdout');
@@ -174,7 +175,7 @@ class ChannelStreamTest extends TestCase {
    */
   #[@test]
   public function input() {
-    $r= ChannelWrapper::capture(newinstance('lang.Runnable', [], [
+    $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
         $i= new ChannelInputStream('input');
         $o= new ChannelOutputStream('stdout');

--- a/src/test/php/net/xp_framework/unittest/io/streams/LinesInTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/LinesInTest.class.php
@@ -3,6 +3,7 @@
 use io\File;
 use io\streams\TextReader;
 use io\streams\LinesIn;
+use io\streams\InputStream;
 use io\streams\MemoryInputStream;
 use io\IOException;
 use lang\IllegalArgumentException;
@@ -71,7 +72,7 @@ class LinesInTest extends \unittest\TestCase {
 
   #[@test]
   public function can_only_iterate_unseekable_once() {
-    $fixture= new LinesIn(newinstance('io.streams.InputStream', [], [
+    $fixture= new LinesIn(newinstance(InputStream::class, [], [
       'bytes' => "A\nB\n",
       'offset' => 0,
       'read' => function($length= 8192) {

--- a/src/test/php/net/xp_framework/unittest/io/streams/StreamTransferTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/StreamTransferTest.class.php
@@ -2,9 +2,10 @@
 
 use unittest\TestCase;
 use io\streams\StreamTransfer;
+use io\streams\InputStream;
+use io\streams\OutputStream;
 use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
-
 
 /**
  * TestCase
@@ -19,7 +20,7 @@ class StreamTransferTest extends TestCase {
    * @return  io.streams.InputStream
    */
   protected function uncloseableInputStream() {
-    return newinstance('io.streams.InputStream', [], '{
+    return newinstance(InputStream::class, [], '{
       public function read($length= 8192) { }
       public function available() { }
       public function close() { throw new \io\IOException("Close error"); }
@@ -32,7 +33,7 @@ class StreamTransferTest extends TestCase {
    * @return  io.streams.InputStream
    */
   protected function closeableInputStream() {
-    return newinstance('io.streams.InputStream', [], '{
+    return newinstance(InputStream::class, [], '{
       public $closed= FALSE;
       public function read($length= 8192) { }
       public function available() { }
@@ -46,7 +47,7 @@ class StreamTransferTest extends TestCase {
    * @return  io.streams.OutputStream
    */
   protected function uncloseableOutputStream() {
-    return newinstance('io.streams.OutputStream', [], '{
+    return newinstance(OutputStream::class, [], '{
       public function write($data) { }
       public function flush() { }
       public function close() { throw new \io\IOException("Close error"); }
@@ -59,7 +60,7 @@ class StreamTransferTest extends TestCase {
    * @return  io.streams.OutputStream
    */
   protected function closeableOutputStream() {
-    return newinstance('io.streams.OutputStream', [], '{
+    return newinstance(OutputStream::class, [], '{
       public $closed= FALSE;
       public function write($data) { }
       public function flush() { }

--- a/src/test/php/net/xp_framework/unittest/io/streams/StringWriterTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/StringWriterTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
 use unittest\TestCase;
+use lang\Object;
 use io\streams\StringWriter;
 use io\streams\MemoryOutputStream;
 use net\xp_framework\unittest\Name;
@@ -43,7 +44,7 @@ class StringWriterTest extends TestCase {
       ["[\n]", []], ["[1, 2, 3]", [1, 2, 3]],
       ["[\n  a => \"b\"\n  c => \"d\"\n]", ['a' => 'b', 'c' => 'd']],
       ['Test', new Name('Test')],
-      ['Test', newinstance('lang.Object', [], ['toString' => function() { return 'Test'; } ])]
+      ['Test', newinstance(Object::class, [], ['toString' => function() { return 'Test'; } ])]
     ];
   }
 

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
+use io\Channel;
 use io\streams\TextReader;
 use io\streams\InputStream;
 use io\streams\MemoryInputStream;
@@ -26,7 +27,7 @@ class TextReaderTest extends \unittest\TestCase {
 
   #[@test]
   public function can_create_with_channel() {
-    new TextReader(newinstance('io.Channel', [], [
+    new TextReader(newinstance(Channel::class, [], [
       'in'  => function() { return new MemoryInputStream(''); },
       'out' => function() { return new MemoryOutputStream(); }
     ]));
@@ -54,7 +55,7 @@ class TextReaderTest extends \unittest\TestCase {
    * @return  io.streams.InputStream
    */
   protected function unseekableStream() {
-    return newinstance('io.streams.InputStream', [], [
+    return newinstance(InputStream::class, [], [
       'bytes' => "A\nB\n",
       'offset' => 0,
       'read' => function($length= 8192) {

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextWriterTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextWriterTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
 use lang\types\Character;
+use io\Channel;
 use io\streams\TextWriter;
 use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
@@ -22,7 +23,7 @@ class TextWriterTest extends \unittest\TestCase {
 
   #[@test]
   public function can_create_with_channel() {
-    new TextWriter(newinstance('io.Channel', [], [
+    new TextWriter(newinstance(Channel::class, [], [
       'in'  => function() { return new MemoryInputStream(''); },
       'out' => function() { return new MemoryOutputStream(); }
     ]));

--- a/src/test/php/net/xp_framework/unittest/logging/ConsoleAppenderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/logging/ConsoleAppenderTest.class.php
@@ -5,8 +5,8 @@ use util\cmd\Console;
 use util\log\ConsoleAppender;
 use util\log\LogCategory;
 use util\log\Layout;
+use util\log\LoggingEvent;
 use io\streams\MemoryOutputStream;
-
 
 /**
  * TestCase
@@ -24,11 +24,11 @@ class ConsoleAppenderTest extends TestCase {
    */
   public function setUp() {
     $this->cat= (new LogCategory('default'))->withAppender(
-      (new ConsoleAppender())->withLayout(newinstance('util.log.Layout', [], '{
-        public function format(LoggingEvent $event) {
-          return implode(" ", $event->getArguments());
+      (new ConsoleAppender())->withLayout(newinstance(Layout::class, [], [
+        'format' => function(LoggingEvent $event) {
+          return implode(' ', $event->getArguments());
         }
-      }'))
+      ]))
     );
     $this->stream= Console::$err->getStream();
   }

--- a/src/test/php/net/xp_framework/unittest/logging/FileAppenderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/logging/FileAppenderTest.class.php
@@ -166,7 +166,7 @@ class FileAppenderTest extends AppenderTest {
 
   #[@test]
   public function filename_syncs_with_time() {
-    $fixture= newinstance('util.log.FileAppender', ['test://fn%H'], '{
+    $fixture= newinstance(FileAppender::class, ['test://fn%H'], '{
       protected $hour= 0;
       public function filename($ref= null) {
         return parent::filename(0 + 3600 * $this->hour++);

--- a/src/test/php/net/xp_framework/unittest/logging/LogAppenderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/logging/LogAppenderTest.class.php
@@ -21,7 +21,7 @@ class LogAppenderTest extends TestCase {
    */
   public function setUp() {
     $this->events= create('new util.collections.Vector<string>()');
-    $appender= newinstance('util.log.Appender', [$this->events], [
+    $appender= newinstance(Appender::class, [$this->events], [
       'events' => null,
       '__construct' => function($events) { $this->events= $events; },
       'append' => function(LoggingEvent $event) {

--- a/src/test/php/net/xp_framework/unittest/logging/LogCategoryTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/logging/LogCategoryTest.class.php
@@ -21,7 +21,7 @@ class LogCategoryTest extends \unittest\TestCase {
    * @return  util.log.Appender
    */
   private function mockAppender() {
-    $appender= newinstance('util.log.Appender', [], [
+    $appender= newinstance(Appender::class, [], [
       'messages' => [],
       'append' => function(LoggingEvent $event) {
         $this->messages[]= [
@@ -39,7 +39,7 @@ class LogCategoryTest extends \unittest\TestCase {
    * @return  util.log.Appender
    */
   private function emptyAppender() {
-    return newinstance('util.log.Appender', [], [
+    return newinstance(Appender::class, [], [
       'append' => function(LoggingEvent $event) { }
     ]);
   }
@@ -75,7 +75,7 @@ class LogCategoryTest extends \unittest\TestCase {
 
   #[@test]
   public function can_create_with_identifier_level_and_context() {
-    new LogCategory('identifier', LogLevel::ALL, newinstance('util.log.Context', [], [
+    new LogCategory('identifier', LogLevel::ALL, newinstance(Context::class, [], [
       'format' => function() { return ''; }
     ]));
   }

--- a/src/test/php/net/xp_framework/unittest/logging/SmtpAppenderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/logging/SmtpAppenderTest.class.php
@@ -18,7 +18,7 @@ class SmtpAppenderTest extends AppenderTest {
    * @return  util.log.SmtpAppender
    */
   protected function newFixture($prefix, $sync) {
-    $appender= newinstance('util.log.SmtpAppender', ['test@example.com', $prefix, $sync], '{
+    $appender= newinstance(SmtpAppender::class, ['test@example.com', $prefix, $sync], '{
       public $sent= [];
       protected function send($prefix, $content) {
         $this->sent[]= [$prefix, $content];

--- a/src/test/php/net/xp_framework/unittest/peer/net/NameserverLookupTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/net/NameserverLookupTest.class.php
@@ -10,23 +10,19 @@ use peer\net\NameserverLookup;
  * @see   xp://peer.net.NameserverLookup'
  */
 class NameserverLookupTest extends \unittest\TestCase {
-  protected $cut= null;
+  private $cut= null;
 
   /**
    * Sets up test case and defines dummy nameserver lookup fixture
+   *
+   * @return void
    */
   public function setUp() {
-    $this->cut= newinstance('peer.net.NameserverLookup', [], '{
-      protected $results= [];
-
-      public function addLookup($ip, $type= "ip") {
-        $this->results[]= [$type => $ip];
-      }
-
-      protected function _nativeLookup($what, $type) {
-        return $this->results;
-      }
-    }');
+    $this->cut= newinstance(NameserverLookup::class, [], [
+      'results' => [],
+      'addLookup' => function($ip, $type= 'ip') { $this->results[]= [$type => $ip]; },
+      '_nativeLookup' => function($what, $type) { return $this->results; }
+    ]);
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/peer/sockets/TestingServer.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/sockets/TestingServer.class.php
@@ -1,11 +1,8 @@
 <?php namespace net\xp_framework\unittest\peer\sockets;
 
-
-
 use util\cmd\Console;
 use peer\server\Server;
 use peer\server\ServerProtocol;
-
 
 /**
  * Socket server used by SocketTest. Implements a simple line-based
@@ -51,7 +48,7 @@ class TestingServer extends \lang\Object {
    * @param   string[] args
    */
   public static function main(array $args) {
-    $protocol= newinstance('peer.server.ServerProtocol', [], '{
+    $protocol= newinstance(ServerProtocol::class, [], '{
       public function initialize() { }
       public function handleDisconnect($socket) { }
       public function handleError($socket, $e) { }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassFromArchiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassFromArchiveTest.class.php
@@ -24,7 +24,7 @@ class ClassFromArchiveTest extends ClassFromUriTest {
    * @return  net.xp_framework.unittest.reflection.ClassFromUriBase
    */
   protected static function baseImpl() {
-    return newinstance('net.xp_framework.unittest.reflection.ClassFromUriBase', [], '{
+    return newinstance(ClassFromUriBase::class, [], '{
       protected $t= NULL;
 
       public function initialize($initializer) {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassFromDynamicDefinitionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassFromDynamicDefinitionTest.class.php
@@ -24,7 +24,7 @@ class ClassFromDynamicDefinitionTest extends ClassFromUriTest {
    * @return  net.xp_framework.unittest.reflection.ClassFromUriBase
    */
   protected static function baseImpl() {
-    return newinstance('net.xp_framework.unittest.reflection.ClassFromUriBase', [], '{
+    return newinstance(ClassFromUriBase::class, [], '{
       protected $t= NULL;
 
       public function create() {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassFromFileSystemTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassFromFileSystemTest.class.php
@@ -24,7 +24,7 @@ class ClassFromFileSystemTest extends ClassFromUriTest {
    * @return  net.xp_framework.unittest.reflection.ClassFromUriBase
    */
   protected static function baseImpl() {
-    return newinstance('net.xp_framework.unittest.reflection.ClassFromUriBase', [], '{
+    return newinstance(ClassFromUriBase::class, [], '{
       protected $t= NULL;
 
       public function create() {

--- a/src/test/php/net/xp_framework/unittest/reflection/IsInstanceTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/IsInstanceTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use lang\XPClass;
+use lang\Runnable;
 
 /**
  * TestCase
@@ -41,9 +42,9 @@ class IsInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function newInterfaceInstanceIsRunnable() {
-    $this->assertTrue(XPClass::forName('lang.Runnable')->isInstance(newinstance('lang.Runnable', [], '{
-      public function run() { }
-    }')));
+    $this->assertTrue(XPClass::forName('lang.Runnable')->isInstance(newinstance(Runnable::class, [], [
+      'run' => function() { }
+    ])));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodsTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use lang\XPClass;
+use lang\Object;
 use lang\Type;
 use lang\MapType;
 use lang\Primitive;
@@ -382,7 +383,7 @@ class MethodsTest extends \unittest\TestCase {
 
   #[@test, @ignore('No reflection support yet'), @action(new RuntimeVersion('>=7.0'))]
   public function nativeReturnTypeName() {
-    $o= newinstance('lang.Object', [], '{
+    $o= newinstance(Object::class, [], '{
       public function fixture(): Object { }
     }');
     $this->assertEquals('lang.Object', $o->getClass()->getMethod('fixture')->getReturnTypeName());
@@ -390,7 +391,7 @@ class MethodsTest extends \unittest\TestCase {
 
   #[@test, @ignore('No reflection support yet'), @action(new RuntimeVersion('>=7.0'))]
   public function nativeReturnType() {
-    $o= newinstance('lang.Object', [], '{
+    $o= newinstance(Object::class, [], '{
       public function fixture(): Object { }
     }');
     $this->assertEquals(XPClass::forName('lang.Object'), $o->getClass()->getMethod('fixture')->getReturnType());
@@ -398,7 +399,7 @@ class MethodsTest extends \unittest\TestCase {
 
   #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0'))]
   public function violatingReturnType() {
-    $o= newinstance('lang.Object', [], '{
+    $o= newinstance(Object::class, [], '{
       public function fixture(): Object { return "Test"; }
     }');
     $o->fixture();

--- a/src/test/php/net/xp_framework/unittest/reflection/ProxyTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ProxyTest.class.php
@@ -22,7 +22,7 @@ class ProxyTest extends \unittest\TestCase {
    * Setup method 
    */
   public function setUp() {
-    $this->handler= newinstance('lang.reflect.InvocationHandler', [], [
+    $this->handler= newinstance(InvocationHandler::class, [], [
       'invocations' => [],
       'invoke'      => function($proxy, $method, $args) {
         $this->invocations[$method.'_'.sizeof($args)]= $args;

--- a/src/test/php/net/xp_framework/unittest/security/PasswordStrengthTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/PasswordStrengthTest.class.php
@@ -1,6 +1,8 @@
 <?php namespace net\xp_framework\unittest\security;
 
 use security\password\PasswordStrength;
+use security\password\StandardAlgorithm;
+use security\password\Algorithm;
 
 /**
  * TestCase for PasswordStrength entry point class
@@ -11,20 +13,17 @@ class PasswordStrengthTest extends \unittest\TestCase {
 
   #[@test]
   public function standard_algorithm_is_always_available() {
-    $this->assertInstanceOf(
-      'security.password.StandardAlgorithm',
-      PasswordStrength::getAlgorithm('standard')
-    );
+    $this->assertInstanceOf(StandardAlgorithm::class, PasswordStrength::getAlgorithm('standard'));
   }
 
   #[@test]
   public function register_algorithm() {
-    with ($class= newinstance('security.password.Algorithm', [], '{
-      public function strengthOf($password) { return 0; }
-    }')->getClass()); {
-      PasswordStrength::setAlgorithm('null', $class);
-      $this->assertEquals($class, PasswordStrength::getAlgorithm('null')->getClass());
-    }
+    $algorithm= newinstance(Algorithm::class, [], [
+      'strengthOf' => function($password) { return 0; }
+    ]);
+
+    PasswordStrength::setAlgorithm('test', typeof($algorithm));
+    $this->assertInstanceOf(nameof($algorithm), PasswordStrength::getAlgorithm('test'));
   }
 
   #[@test, @expect('util.NoSuchElementException')]
@@ -34,6 +33,6 @@ class PasswordStrengthTest extends \unittest\TestCase {
 
   #[@test, @expect('lang.IllegalArgumentException')]
   public function setAlgorithm_throws_an_exception_for_non_algorithms() {
-    PasswordStrength::setAlgorithm('object', $this->getClass());
+    PasswordStrength::setAlgorithm('object', typeof($this));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/text/encode/QuotedPrintableInputStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/text/encode/QuotedPrintableInputStreamTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace net\xp_framework\unittest\text\encode;
 
 use unittest\TestCase;
+use io\streams\InputStream;
 use io\streams\MemoryInputStream;
 use text\encode\QuotedPrintableInputStream;
-
 
 /**
  * Test QuotedPrintable decoder
@@ -132,7 +132,7 @@ class QuotedPrintableInputStreamTest extends TestCase {
   #[@test]
   public function chunkedRead() {
     $expected= 'Hello Übercoder & World';
-    $stream= new QuotedPrintableInputStream(newinstance('io.streams.InputStream', [['Hello =', 'DCbercoder=', "\n", ' & World']], '{
+    $stream= new QuotedPrintableInputStream(newinstance(InputStream::class, [['Hello =', 'DCbercoder=', "\n", ' & World']], '{
       protected $chunks;
       
       public function __construct(array $chunks) {

--- a/src/test/php/net/xp_framework/unittest/util/DeferredInvokationHandlerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DeferredInvokationHandlerTest.class.php
@@ -1,101 +1,93 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\AbstractDeferredInvokationHandler;
-
+use lang\Runnable;
+use lang\IllegalStateException;
 
 /**
  * TestCase for AbstractDeferredInvokationHandler
  */
-class DeferredInvokationHandlerTest extends TestCase {
+class DeferredInvokationHandlerTest extends \unittest\TestCase {
 
   #[@test]
   public function echo_runnable_invokation() {
-    $handler= newinstance('util.AbstractDeferredInvokationHandler', [], '{
-      public function initialize() { 
-        return newinstance("lang.Runnable", [], "{
-          public function run() {
-            return func_get_args();
-          }
-        }");
+    $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
+      'initialize' => function() {
+        return newinstance(Runnable::class, [], '{
+          public function run() { return func_get_args(); }
+        }');
       }
-    }');
+    ]);
     $args= [1, 2, 'Test'];
     $this->assertEquals($args, $handler->invoke($this, 'run', $args));
   }
 
-  #[@test, @expect(class = 'lang.XPException', withMessage= 'Test')]
+  #[@test, @expect(class = 'lang.IllegalStateException', withMessage= 'Test')]
   public function throwing_runnable_invokation() {
-    $handler= newinstance('util.AbstractDeferredInvokationHandler', [], '{
-      public function initialize() { 
-        return newinstance("lang.Runnable", [], "{
-          public function run() {
-            throw new \lang\XPException(func_get_arg(0));
-          }
-        }");
+    $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
+      'initialize' => function() {
+        return newinstance(Runnable::class, [], '{
+          public function run() { throw new \lang\IllegalStateException(func_get_arg(0)); }
+        }');
       }
-    }');
+    ]);
     $handler->invoke($this, 'run', ['Test']);
   }
 
   #[@test, @expect(class = 'util.DeferredInitializationException', withMessage= 'run')]
   public function initialize_returns_null() {
-    $handler= newinstance('util.AbstractDeferredInvokationHandler', [], '{
-      public function initialize() { 
-        return NULL;
+    $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
+      'initialize' => function() {
+        return null;
       }
-    }');
+    ]);
     $handler->invoke($this, 'run', []);
   }
 
   #[@test, @expect(class = 'util.DeferredInitializationException', withMessage= 'run')]
   public function initialize_throws_exception() {
-    $handler= newinstance('util.AbstractDeferredInvokationHandler', [], '{
-      public function initialize() { 
-        throw new \lang\IllegalStateException("Cannot initialize yet");
+    $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
+      'initialize' => function() {
+        throw new IllegalStateException('Cannot initialize yet');
       }
-    }');
+    ]);
     $handler->invoke($this, 'run', []);
   }
 
   #[@test]
   public function initialize_not_called_again_after_success() {
-    $handler= newinstance('util.AbstractDeferredInvokationHandler', [], '{
-      private $actions;
-      public function __construct() {
+    $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
+      'actions' => [],
+      '__construct' => function() {
         $this->actions= [
-          function() { return newinstance("lang.Runnable", [], "{
-            public function run() { return TRUE; }
-          }"); },
-          function() { throw new \lang\IllegalStateException("Initialization called again"); },
+          function() { return newinstance(Runnable::class, [], ['run' => function() { return true; }]); },
+          function() { throw new IllegalStateException('Initialization called again'); },
         ];
-      }
-      public function initialize() {
+      },
+      'initialize' => function() {
         $f= array_shift($this->actions);
         return $f();
       }
-    }');
+    ]);
     $this->assertEquals(true, $handler->invoke($this, 'run', []));
     $this->assertEquals(true, $handler->invoke($this, 'run', []));
   }  
 
   #[@test]
   public function initialize_called_again_after_failure() {
-    $handler= newinstance('util.AbstractDeferredInvokationHandler', [], '{
-      private $actions;
-      public function __construct() {
+    $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
+      'actions' => [],
+      '__construct' => function() {
         $this->actions= [
-          function() { throw new \lang\IllegalStateException("Error initializing"); },
-          function() { return newinstance("lang.Runnable", [], "{
-            public function run() { return TRUE; }
-          }"); }
+          function() { throw new IllegalStateException('Error initializing'); },
+          function() { return newinstance(Runnable::class, [], ['run' => function() { return true; }]); },
         ];
-      }
-      public function initialize() {
+      },
+      'initialize' => function() {
         $f= array_shift($this->actions);
         return $f();
       }
-    }');
+    ]);
     try {
       $handler->invoke($this, 'run', []);
     } catch (\util\DeferredInitializationException $expected) {

--- a/src/test/php/net/xp_framework/unittest/util/HashmapTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/HashmapTest.class.php
@@ -218,7 +218,7 @@ class HashmapTest extends TestCase {
     $this->map->put('two', 'two');
     $this->map->put('eins', 'one');
 
-    $this->map->usort(newinstance('util.Comparator', [], [
+    $this->map->usort(newinstance(Comparator::class, [], [
       'compare' => function($a, $b) { 
         return strcasecmp($a, $b); 
       }

--- a/src/test/php/net/xp_framework/unittest/util/ObservableTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/ObservableTest.class.php
@@ -1,14 +1,14 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\Observable;
+use util\Observer;
 
 /**
  * Test Observable class
  *
  * @see  xp://util.Observable
  */
-class ObservableTest extends TestCase {
+class ObservableTest extends \unittest\TestCase {
   protected static $observable;
 
   /**
@@ -54,7 +54,7 @@ class ObservableTest extends TestCase {
 
   #[@test]
   public function add_observer_returns_added_observer() {
-    $observer= newinstance('util.Observer', [], [
+    $observer= newinstance(Observer::class, [], [
       'update' => function($obs, $arg= null) {
         /* Intentionally empty */
       }
@@ -65,7 +65,7 @@ class ObservableTest extends TestCase {
 
   #[@test]
   public function observer_gets_called_with_observable() {
-    $observer= newinstance('util.Observer', [], [
+    $observer= newinstance(Observer::class, [], [
       'calls' => [],
       'update' => function($obs, $arg= null) {
         $this->calls[]= [$obs, $arg];

--- a/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\util\cmd;
 
 use util\cmd\Console;
+use lang\Object;
 use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
 
@@ -117,7 +118,7 @@ class ConsoleTest extends \unittest\TestCase {
 
   #[@test]
   public function write_an_object() {
-    Console::write(newinstance('lang.Object', [], '{
+    Console::write(newinstance(Object::class, [], '{
       public function toString() { return "Hello"; }
     }'));
     $this->assertEquals('Hello', $this->streams[1]->getBytes());
@@ -126,7 +127,7 @@ class ConsoleTest extends \unittest\TestCase {
   #[@test]
   public function exception_from_toString() {
     try {
-      Console::write(newinstance('lang.Object', [], '{
+      Console::write(newinstance(Object::class, [], '{
         public function toString() { throw new IllegalStateException("Cannot render string"); }
       }'));
       $this->fail('Expected exception not thrown', null, 'lang.IllegalStateException');

--- a/src/test/php/net/xp_framework/unittest/util/cmd/RunnerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/cmd/RunnerTest.class.php
@@ -71,7 +71,7 @@ class RunnerTest extends \unittest\TestCase {
    * @return  util.cmd.Command
    */
   protected function newCommand() {
-    return newinstance('util.cmd.Command', [], '{
+    return newinstance(Command::class, [], '{
       public static $wasRun= FALSE;
       public function __construct() { self::$wasRun= FALSE; }
       public function run() { self::$wasRun= TRUE; }
@@ -179,7 +179,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function runWritingToStandardOutput() {
-    $command= newinstance('util.cmd.Command', [], [
+    $command= newinstance(Command::class, [], [
       'run' => function() { $this->out->write('UNITTEST'); }
     ]);
 
@@ -195,7 +195,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function runWritingToStandardError() {
-    $command= newinstance('util.cmd.Command', [], [
+    $command= newinstance(Command::class, [], [
       'run' => function() { $this->err->write('UNITTEST'); }
     ]);
 
@@ -211,7 +211,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function runEchoInput() {
-    $command= newinstance('util.cmd.Command', [], [
+    $command= newinstance(Command::class, [], [
       'run' => function() {
         while ($chunk= $this->in->read()) {
           $this->out->write($chunk);
@@ -231,7 +231,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function positionalArgument() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $arg= NULL;
 
       #[@arg(position= 0)]
@@ -252,7 +252,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function missingPositionalArgumentt() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $arg= NULL;
 
       #[@arg(position= 0)]
@@ -272,7 +272,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function shortNamedArgument() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $arg= NULL;
 
       #[@arg]
@@ -292,7 +292,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function longNamedArgument() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $arg= NULL;
 
       #[@arg]
@@ -313,7 +313,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function shortRenamedArgument() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $arg= NULL;
 
       #[@arg(name= "pass")]
@@ -333,7 +333,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function longRenamedArgument() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $arg= NULL;
 
       #[@arg(name= "pass")]
@@ -354,7 +354,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function missingNamedArgument() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $arg= NULL;
 
       #[@arg]
@@ -374,7 +374,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function existanceArgumentNotPassed() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $verbose= FALSE;
 
       #[@arg]
@@ -394,7 +394,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function optionalArgument() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $name= NULL;
 
@@ -415,7 +415,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function optionalArgumentNotPassed() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $name= NULL;
 
@@ -437,7 +437,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function shortExistanceArgumentPassed() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $verbose= FALSE;
 
       #[@arg]
@@ -458,7 +458,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function longExistanceArgumentPassed() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $verbose= FALSE;
 
       #[@arg]
@@ -478,7 +478,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function positionalArgumentException() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       
       #[@arg(position= 0)]
       public function setHost($host) { 
@@ -500,7 +500,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function namedArgumentException() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       
       #[@arg]
       public function setHost($host) { 
@@ -536,7 +536,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function allArgs() {
-    $this->assertAllArgs('a, b, c, d, e, f, g', newinstance('util.cmd.Command', [], '{
+    $this->assertAllArgs('a, b, c, d, e, f, g', newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $args= [];
 
@@ -553,7 +553,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function allArgsCompactNotation() {
-    $this->assertAllArgs('a, b, c, d, e, f, g', newinstance('util.cmd.Command', [], '{
+    $this->assertAllArgs('a, b, c, d, e, f, g', newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $args= [];
 
@@ -570,7 +570,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function boundedArgs() {
-    $this->assertAllArgs('a, b, c', newinstance('util.cmd.Command', [], '{
+    $this->assertAllArgs('a, b, c', newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $args= [];
 
@@ -587,7 +587,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function boundedArgsFromOffset() {
-    $this->assertAllArgs('c, d, e', newinstance('util.cmd.Command', [], '{
+    $this->assertAllArgs('c, d, e', newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $args= [];
 
@@ -604,7 +604,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function positionalAndBoundedArgsFromOffset() {
-    $this->assertAllArgs('a, c, d, e', newinstance('util.cmd.Command', [], '{
+    $this->assertAllArgs('a, c, d, e', newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $args= [];
 
@@ -621,7 +621,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function boundedAndPositionalArgsWithOverlap() {
-    $this->assertAllArgs('a, b, c, b', newinstance('util.cmd.Command', [], '{
+    $this->assertAllArgs('a, b, c, b', newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $args= [];
 
@@ -638,7 +638,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function positionalArgs() {
-    $this->assertAllArgs('a, c, e, f', newinstance('util.cmd.Command', [], '{
+    $this->assertAllArgs('a, c, e, f', newinstance(Command::class, [], '{
       protected $verbose= FALSE;
       protected $args= [];
 
@@ -654,7 +654,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function configOption() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $choke= FALSE;
 
       #[@arg]
@@ -678,7 +678,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function classPathOption() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $copy= NULL;
       
       #[@arg(short= "cp")]
@@ -706,7 +706,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function unknownInjectionType() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       #[@inject(type= "io.Folder", name= "output")]
       public function setOutput($f) { 
       }
@@ -726,7 +726,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function noInjectionType() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       #[@inject(name= "output")]
       public function setOutput($f) { 
       }
@@ -746,7 +746,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function loggerCategoryInjection() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $cat= NULL;
       
       #[@inject(type= "util.log.LogCategory", name= "debug")]
@@ -768,7 +768,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function loggerCategoryInjectionViaTypeRestriction() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $cat= NULL;
       
       #[@inject(name= "debug")]
@@ -790,7 +790,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function loggerCategoryInjectionViaTypeDocumentation() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $cat= NULL;
       
       /**
@@ -815,7 +815,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function injectionOccursBeforeArguments() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       protected $cat= NULL;
 
       /**
@@ -847,7 +847,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function injectionException() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
       
       #[@inject(name= "debug")]
       public function setTrace(\util\log\LogCategory $cat) { 
@@ -869,7 +869,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function injectProperties() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
 
       #[@inject(name= "debug")]
       public function setTrace(\util\Properties $prop) {
@@ -891,7 +891,7 @@ class RunnerTest extends \unittest\TestCase {
    */
   #[@test]
   public function injectCompositeProperties() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
 
       #[@inject(name= "debug")]
       public function setTrace(\util\Properties $prop) {
@@ -917,7 +917,7 @@ key=overwritten_value'
    */
   #[@test]
   public function injectPropertiesMultipleSources() {
-    $command= newinstance('util.cmd.Command', [], '{
+    $command= newinstance(Command::class, [], '{
 
       #[@inject(name= "debug")]
       public function setTrace(\util\Properties $prop) {

--- a/src/test/php/net/xp_framework/unittest/util/collections/ArraysTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/ArraysTest.class.php
@@ -3,7 +3,10 @@
 use unittest\TestCase;
 use lang\types\Integer;
 use lang\types\Float;
+use lang\types\ArrayList;
 use util\collections\Arrays;
+use util\collections\IList;
+use util\Comparator;
 
 /**
  * TestCase
@@ -14,8 +17,8 @@ class ArraysTest extends TestCase {
 
   #[@test]
   public function asList() {
-    $list= Arrays::asList(new \lang\types\ArrayList(new Integer(1), new Integer(2), new Integer(3)));
-    $this->assertInstanceOf('util.collections.IList', $list);
+    $list= Arrays::asList(new ArrayList(new Integer(1), new Integer(2), new Integer(3)));
+    $this->assertInstanceOf(IList::class, $list);
     $this->assertEquals(3, $list->size());
     $this->assertEquals(new Integer(1), $list->get(0));
     $this->assertEquals(new Integer(2), $list->get(1));
@@ -24,8 +27,8 @@ class ArraysTest extends TestCase {
 
   #[@test]
   public function asListWithPrimitives() {
-    $list= Arrays::asList(new \lang\types\ArrayList('one', 'two', 'three'));
-    $this->assertInstanceOf('util.collections.IList', $list);
+    $list= Arrays::asList(new ArrayList('one', 'two', 'three'));
+    $this->assertInstanceOf(IList::class, $list);
     $this->assertEquals(3, $list->size());
     $this->assertEquals('one', $list->get(0));
     $this->assertEquals('two', $list->get(1));
@@ -34,37 +37,37 @@ class ArraysTest extends TestCase {
 
   #[@test]
   public function empty_array() {
-    $this->assertEquals(\lang\types\ArrayList::newInstance(0), Arrays::$EMPTY);
+    $this->assertEquals(ArrayList::newInstance(0), Arrays::$EMPTY);
   }
 
   #[@test]
   public function sort() {
-    $a= new \lang\types\ArrayList(1, 4, 3, 2);
+    $a= new ArrayList(1, 4, 3, 2);
     Arrays::sort($a);
-    $this->assertEquals(new \lang\types\ArrayList(1, 2, 3, 4), $a);
+    $this->assertEquals(new ArrayList(1, 2, 3, 4), $a);
   }
 
   #[@test]
   public function sortWithComparator() {
-    $a= new \lang\types\ArrayList(new Integer(2), new Integer(4), new Integer(3));
-    Arrays::sort($a, newinstance('util.Comparator', [], '{
-      public function compare($a, $b) {
+    $a= new ArrayList(new Integer(2), new Integer(4), new Integer(3));
+    Arrays::sort($a, newinstance(Comparator::class, [], [
+      'compare' => function($a, $b) {
         return $a->value - $b->value;
       }
-    }'));
-    $this->assertEquals(new \lang\types\ArrayList(new Integer(2), new Integer(3), new Integer(4)), $a);
+    ]));
+    $this->assertEquals(new ArrayList(new Integer(2), new Integer(3), new Integer(4)), $a);
   }
 
   #[@test]
   public function sorted() {
-    $a= new \lang\types\ArrayList(1, 4, 3, 2);
-    $this->assertEquals(new \lang\types\ArrayList(1, 2, 3, 4), Arrays::sorted($a));
-    $this->assertEquals(new \lang\types\ArrayList(1, 4, 3, 2), $a);
+    $a= new ArrayList(1, 4, 3, 2);
+    $this->assertEquals(new ArrayList(1, 2, 3, 4), Arrays::sorted($a));
+    $this->assertEquals(new ArrayList(1, 4, 3, 2), $a);
   }
 
   #[@test]
   public function containsWithPrimitives() {
-    $a= new \lang\types\ArrayList(1, 4, 3, 2);
+    $a= new ArrayList(1, 4, 3, 2);
     $this->assertTrue(Arrays::contains($a, 1));
     $this->assertFalse(Arrays::contains($a, 5));
     $this->assertFalse(Arrays::contains($a, '1'));
@@ -72,7 +75,7 @@ class ArraysTest extends TestCase {
 
   #[@test]
   public function containsWithGenerics() {
-    $a= new \lang\types\ArrayList(new Integer(1), new Integer(2), new Integer(3));
+    $a= new ArrayList(new Integer(1), new Integer(2), new Integer(3));
     $this->assertTrue(Arrays::contains($a, new Integer(1)));
     $this->assertFalse(Arrays::contains($a, new Integer(5)));
     $this->assertFalse(Arrays::contains($a, new Float(1.0)));

--- a/src/test/php/net/xp_framework/unittest/util/collections/HashProviderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/HashProviderTest.class.php
@@ -2,7 +2,7 @@
  
 use unittest\TestCase;
 use util\collections\HashProvider;
-
+use util\collections\HashImplementation;
 
 /**
  * Test HashProvider class
@@ -12,21 +12,16 @@ use util\collections\HashProvider;
 class HashProviderTest extends TestCase {
   protected $fixture;
 
-  /**
-   * Creates fixture
-   */
+  /** @return void */
   public function setUp() {
     $this->fixture= HashProvider::getInstance();
   }
 
-  /**
-   * Tests getImplementation() and setImplementation()
-   */
   #[@test]
   public function implementation_accessors() {
-    $impl= newinstance('util.collections.HashImplementation', [], '{
-      public function hashOf($str) { /* Intentionally empty */ }
-    }');
+    $impl= newinstance(HashImplementation::class, [], [
+      'hashOf' => function($str) { /* Intentionally empty */ }
+    ]);
 
     $backup= $this->fixture->getImplementation();    // Backup
     $this->fixture->setImplementation($impl);
@@ -36,9 +31,6 @@ class HashProviderTest extends TestCase {
     $this->assertEquals($impl, $cmp);
   }
 
-  /**
-   * Tests hashOf()
-   */
   #[@test]
   public function hashof_uses_implementations_hashof() {
     $this->assertEquals(

--- a/src/test/php/net/xp_framework/unittest/util/collections/HashTableTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/HashTableTest.class.php
@@ -4,6 +4,7 @@ use util\collections\HashTable;
 use util\collections\Pair;
 use lang\types\Integer;
 use lang\types\Double;
+use lang\Object;
 
 /**
  * Test HashTable class
@@ -48,7 +49,7 @@ class HashTableTest extends \unittest\TestCase {
 
   /** @return lang.Object */
   protected function hashCodeCounter() {
-    return newinstance('lang.Object', [], [
+    return newinstance(Object::class, [], [
       'invoked'  => 0,
       'hashCode' => function() { $this->invoked++; }
     ]);


### PR DESCRIPTION
This pull request changes the test suite to use [`::class`](http://php.net/oop5.basic#language.oop5.basic.class.class) where applicable.

*Note 1: It depends on PR #97 being merged first!*
*Note 2: It does not touch code inside the `net.xp_framework.unittest.tests` package as they have been extracted and then deprecated* 