### PR TITLE
Use ::class literal throughout tests

### DIFF
--- a/src/test/php/net/xp_framework/unittest/annotations/AnnotationParsingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/AnnotationParsingTest.class.php
@@ -2,6 +2,7 @@
 
 use net\xp_framework\unittest\annotations\fixture\Namespaced;
 use lang\reflect\ClassParser;
+use lang\ClassFormatException;
 
 /**
  * Tests the XP Framework's annotation parsing implementation
@@ -551,7 +552,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
     );
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Cannot access private static field .+AbstractAnnotationParsingTest::\$parentsInternal/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Cannot access private static field .+AbstractAnnotationParsingTest::\$parentsInternal/')]
   public function parent_private_static_member() {
     $this->parse('#[@value(parent::$parentsInternal)]');
   }

--- a/src/test/php/net/xp_framework/unittest/annotations/BrokenAnnotationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/BrokenAnnotationTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\XPClass;
 use lang\reflect\ClassParser;
+use lang\ClassFormatException;
 
 /**
  * Tests the XP Framework's annotations
@@ -22,182 +23,182 @@ class BrokenAnnotationTest extends \unittest\TestCase {
     return (new ClassParser())->parseAnnotations($input, nameof($this));
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Unterminated annotation/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Unterminated annotation/')]
   public function no_ending_bracket() {
     XPClass::forName('net.xp_framework.unittest.annotations.NoEndingBracket')->getAnnotations();
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error/')]
   public function missing_ending_bracket_in_key_value_pairs() {
     $this->parse("#[@attribute(key= 'value']");
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error/')]
   public function unterminated_single_quoted_string_literal() {
     $this->parse("#[@attribute(key= 'value)]");
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error/')]
   public function unterminated_double_quoted_string_literal() {
     $this->parse('#[@attribute(key= "value)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Expecting "@"/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Expecting "@"/')]
   public function missing_annotation_after_comma_and_value() {
     $this->parse('#[@ignore("Test"), ]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Expecting "@"/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Expecting "@"/')]
   public function missing_annotation_after_comma() {
     $this->parse('#[@ignore, ]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Expecting "@"/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Expecting "@"/')]
   public function missing_annotation_after_second_comma() {
     $this->parse('#[@ignore, @test, ]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error: Unterminated string/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unterminated string/')]
   public function unterminated_dq_string() {
     $this->parse('#[@ignore("Test)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error: Unterminated string/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unterminated string/')]
   public function unterminated_sq_string() {
     $this->parse("#[@ignore('Test)]");
   }
 
   /** @deprecated */
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Malformed array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
   public function unterminated_array() {
     $this->parse('#[@ignore(array(1]');
   }
 
   /** @deprecated */
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Malformed array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
   public function unterminated_array_key() {
     $this->parse('#[@ignore(name = array(1]');
   }
 
   /** @deprecated */
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Malformed array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
   public function malformed_array() {
     $this->parse('#[@ignore(array(1 ,, 2))]');
   }
 
   /** @deprecated */
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Malformed array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
   public function malformed_array_inside_key_value_pairs() {
     $this->parse('#[@ignore(name= array(1 ,, 2))]');
   }
 
   /** @deprecated */
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Malformed array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
   public function malformed_array_no_commas() {
     $this->parse('#[@ignore(array(1 2))]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Unterminated array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Unterminated array/')]
   public function unterminated_short_array() {
     $this->parse('#[@ignore([1');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Unterminated array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Unterminated array/')]
   public function unterminated_short_array_key() {
     $this->parse('#[@ignore(name = [1');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Malformed array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
   public function malformed_short_array() {
     $this->parse('#[@ignore([1 ,, 2])]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Malformed array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
   public function malformed_short_array_inside_key_value_pairs() {
     $this->parse('#[@ignore(name= [1 ,, 2])]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Malformed array/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
   public function malformed_short_array_no_commas() {
     $this->parse('#[@ignore([1 2])]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error: Expecting either "\(", "," or "\]"/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Expecting either "\(", "," or "\]"/')]
   public function annotation_not_separated_by_commas() {
     $this->parse("#[@test @throws('rdbms.SQLConnectException')]");
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error: Expecting either "\(", "," or "\]"/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Expecting either "\(", "," or "\]"/')]
   public function too_many_closing_braces() {
     $this->parse("#[@throws('rdbms.SQLConnectException'))]");
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Undefined constant "editor"/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Undefined constant "editor"/')]
   public function undefined_constant() {
     $this->parse('#[@$editorId: param(editor)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/No such constant "EDITOR" in class/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/No such constant "EDITOR" in class/')]
   public function undefined_class_constant() {
     $this->parse('#[@$editorId: param(self::EDITOR)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Class ".+" could not be found/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Class ".+" could not be found/')]
   public function undefined_class_in_new() {
     $this->parse('#[@$editorId: param(new NonExistantClass())]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Class ".+" could not be found/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Class ".+" could not be found/')]
   public function undefined_class_in_constant() {
     $this->parse('#[@$editorId: param(NonExistantClass::CONSTANT)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/No such field "EDITOR" in class/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/No such field "EDITOR" in class/')]
   public function undefined_class_member() {
     $this->parse('#[@$editorId: param(self::$EDITOR)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Cannot access protected static field .+AnnotationParsingTest::\$hidden/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Cannot access protected static field .+AnnotationParsingTest::\$hidden/')]
   public function class_protected_static_member() {
     $this->parse('#[@value(AnnotationParsingTest::$hidden)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Cannot access private static field .+AnnotationParsingTest::\$internal/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Cannot access private static field .+AnnotationParsingTest::\$internal/')]
   public function class_private_static_member() {
     $this->parse('#[@value(AnnotationParsingTest::$internal)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/In `.+`: Syntax error/i')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/In `.+`: Syntax error/i')]
   public function function_without_braces() {
     $this->parse('#[@value(function)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/In `.+`: Syntax error/i')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/In `.+`: Syntax error/i')]
   public function function_without_body() {
     $this->parse('#[@value(function())]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/In `.+`: Syntax error/i')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/In `.+`: Syntax error/i')]
   public function function_without_closing_curly() {
     $this->parse('#[@value(function() {)]');
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error: Unexpected ","/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unexpected ","/')]
   public function multi_value() {
     $this->parse("#[@xmlmapping('hw_server', 'server')]");
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error: Unexpected ","/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unexpected ","/')]
   public function multi_value_without_whitespace() {
     $this->parse("#[@xmlmapping('hw_server','server')]");
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error: Unexpected ","/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unexpected ","/')]
   public function multi_value_with_variable_types_backwards_compatibility() {
     $this->parse("#[@xmlmapping('hw_server', TRUE)]");
   }
 
-  #[@test, @expect(class= 'lang.ClassFormatException', withMessage= '/Parse error: Unexpected ","/')]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unexpected ","/')]
   public function parsingContinuesAfterMultiValue() {
     $this->parse("#[@xmlmapping('hw_server', 'server'), @restricted]");
   }

--- a/src/test/php/net/xp_framework/unittest/archive/ArchiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/archive/ArchiveTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\archive;
 
-use unittest\TestCase;
 use lang\archive\Archive;
+use lang\FormatException;
 use io\File;
 use io\streams\Streams;
 use io\streams\MemoryInputStream;
@@ -14,7 +14,7 @@ use io\streams\MemoryOutputStream;
  * @see  xp://net.xp_framework.unittest.archive.ArchiveV2Test
  * @see   xp://lang.archive.Archive
  */
-abstract class ArchiveTest extends TestCase {
+abstract class ArchiveTest extends \unittest\TestCase {
   
   /**
    * Returns the xar version to test
@@ -55,7 +55,7 @@ abstract class ArchiveTest extends TestCase {
     return new File(Streams::readableFd(new MemoryInputStream($header[$version].str_repeat("\0", 248))));
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function open_non_archive() {
     $a= new Archive($this->file(0));
     $a->open(Archive::READ);

--- a/src/test/php/net/xp_framework/unittest/archive/ArchiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/archive/ArchiveTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\archive\Archive;
 use lang\FormatException;
+use lang\ElementNotFoundException;
 use io\File;
 use io\streams\Streams;
 use io\streams\MemoryInputStream;
@@ -82,7 +83,7 @@ abstract class ArchiveTest extends \unittest\TestCase {
     $this->assertFalse($a->contains('DOES-NOT-EXIST'));
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function extract_non_existant() {
     $a= new Archive($this->file($this->version()));
     $a->open(Archive::READ);

--- a/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace net\xp_framework\unittest\core;
 
+use lang\XPClass;
+use lang\ElementNotFoundException;
+
 /**
  * Tests the XP Framework's annotations
  *
@@ -9,13 +12,11 @@
  * @see   rfc://0016
  */
 class AnnotationTest extends \unittest\TestCase {
-  protected $class = null;
+  private $class;
 
-  /**
-   * Setup method
-   */
+  /** @return void */
   public function setUp() {
-    $this->class= \lang\XPClass::forName('net.xp_framework.unittest.core.AnnotatedClass');
+    $this->class= XPClass::forName('net.xp_framework.unittest.core.AnnotatedClass');
   }
 
   #[@test]
@@ -35,10 +36,10 @@ class AnnotationTest extends \unittest\TestCase {
 
   #[@test]
   public function simpleAnnotationValue() {
-    $this->assertEquals(NULL, $this->class->getMethod('simple')->getAnnotation('simple'));
+    $this->assertEquals(null, $this->class->getMethod('simple')->getAnnotation('simple'));
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function getAnnotationForMethodWithout() {
     $this->getClass()->getMethod('setUp')->getAnnotation('any');
   }
@@ -48,7 +49,7 @@ class AnnotationTest extends \unittest\TestCase {
     $this->assertFalse($this->getClass()->getMethod('setUp')->hasAnnotation('any'));
   }
   
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function getNonExistantAnnotation() {
     $this->class->getMethod('simple')->getAnnotation('doesnotexist');
   }

--- a/src/test/php/net/xp_framework/unittest/core/ArchiveClassLoaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ArchiveClassLoaderTest.class.php
@@ -4,6 +4,7 @@ use lang\archive\ArchiveClassLoader;
 use lang\archive\Archive;
 use lang\ClassNotFoundException;
 use lang\ElementNotFoundException;
+use lang\XPClass;
 use io\FileUtil;
 
 /**
@@ -66,7 +67,7 @@ class ArchiveClassLoaderTest extends \unittest\TestCase {
 
   #[@test]
   public function load_existing_class_from_archive() {
-    $this->assertInstanceOf('lang.XPClass', $this->fixture->loadClass('test.ClassLoadedFromArchive'));
+    $this->assertInstanceOf(XPClass::class, $this->fixture->loadClass('test.ClassLoadedFromArchive'));
   }
 
   #[@test, @expect(ClassNotFoundException::class)]

--- a/src/test/php/net/xp_framework/unittest/core/ArchiveClassLoaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ArchiveClassLoaderTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use unittest\TestCase;
 use lang\archive\ArchiveClassLoader;
 use lang\archive\Archive;
+use lang\ClassNotFoundException;
+use lang\ElementNotFoundException;
 use io\FileUtil;
 
 /**
@@ -19,11 +20,13 @@ use io\FileUtil;
  * 
  * @see   xp://lang.archive.ArchiveClassLoader
  */
-class ArchiveClassLoaderTest extends TestCase {
-  protected $fixture= NULL;
+class ArchiveClassLoaderTest extends \unittest\TestCase {
+  private $fixture;
   
   /**
    * Sets fixture to point to archive.xar from src/test/resources/
+   *
+   * @return void
    */
   public function setUp() {
     $this->fixture= new ArchiveClassLoader(new Archive(
@@ -66,7 +69,7 @@ class ArchiveClassLoaderTest extends TestCase {
     $this->assertInstanceOf('lang.XPClass', $this->fixture->loadClass('test.ClassLoadedFromArchive'));
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function loading_non_existant_class_raises_exception() {
     $this->fixture->loadClass('non.existant.Class');
   }
@@ -83,12 +86,12 @@ class ArchiveClassLoaderTest extends TestCase {
     $this->assertEquals('<?php', substr($contents, 0, strpos($contents, "\n")));
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function load_non_existant_resource_from_archive() {
     $this->fixture->getResource('non/existant/resource.file');
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function load_non_existant_resource_stream_from_archive() {
     $this->fixture->getResourceAsStream('non/existant/resource.file');
   }

--- a/src/test/php/net/xp_framework/unittest/core/ArrayTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ArrayTypeTest.class.php
@@ -12,7 +12,7 @@ class ArrayTypeTest extends \unittest\TestCase {
 
   #[@test]
   public function typeForName() {
-    $this->assertInstanceOf('lang.ArrayType', Type::forName('string[]'));
+    $this->assertInstanceOf(ArrayType::class, Type::forName('string[]'));
   }
 
   #[@test, @expect(IllegalArgumentException::class)]

--- a/src/test/php/net/xp_framework/unittest/core/ArrayTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ArrayTypeTest.class.php
@@ -1,17 +1,13 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\ArrayType;
-use lang\IllegalArgumentException;
 use lang\Primitive;
 use lang\Type;
 use lang\XPClass;
 use lang\Object;
+use lang\IllegalArgumentException;
+use lang\ClassCastException;
 
-/**
- * TestCase
- *
- * @see      xp://lang.ArrayType
- */
 class ArrayTypeTest extends \unittest\TestCase {
 
   #[@test]
@@ -142,7 +138,7 @@ class ArrayTypeTest extends \unittest\TestCase {
     $this->assertEquals($expected, ArrayType::forName('string[]')->cast($value));
   }
 
-  #[@test, @expect('lang.ClassCastException'), @values([
+  #[@test, @expect(ClassCastException::class), @values([
   #  0, -1, 0.5, '', 'Test', new Object(), true, false,
   #  [['key' => 'color', 'value' => 'price']]
   #])]

--- a/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
@@ -2,16 +2,17 @@
 
 use unittest\TestCase;
 use lang\Runnable;
+use lang\Object;
+use lang\Generic;
+use lang\CommandLine;
+use lang\ClassCastException;
 
 /**
  * Tests cast() functionality
  */
 class CastingTest extends TestCase implements Runnable {
 
-  /**
-   * Runnable implementation
-   *
-   */
+  /** @return void */
   public function run() { 
     // Intentionally empty
   }
@@ -21,27 +22,27 @@ class CastingTest extends TestCase implements Runnable {
     $runnable= newinstance(Runnable::class, [], [
       'run' => function() { return 'Test'; }
     ]);
-    $this->assertEquals('Test', cast($runnable, 'lang.Runnable')->run());
+    $this->assertEquals('Test', cast($runnable, Runnable::class)->run());
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function null() {
-    cast(null, 'lang.Object');
+    cast(null, Object::class);
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function is_nullsafe_per_default() {
-    cast(null, 'lang.Runnable')->run();
+    cast(null, Runnable::class)->run();
   }
 
   #[@test]
   public function passig_null_allowed_when_nullsafe_set_to_false() {
-    $this->assertNull(cast(null, 'lang.Object', false));
+    $this->assertNull(cast(null, Object::class, false));
   }
 
   #[@test]
   public function thisClass() {
-    $this->assertTrue($this === cast($this, $this->getClass()));
+    $this->assertTrue($this === cast($this, typeof($this)));
   }
 
   #[@test]
@@ -50,42 +51,47 @@ class CastingTest extends TestCase implements Runnable {
   }
 
   #[@test]
+  public function thisClassLiteral() {
+    $this->assertTrue($this === cast($this, self::class));
+  }
+
+  #[@test]
   public function runnableInterface() {
-    $this->assertTrue($this === cast($this, 'lang.Runnable'));
+    $this->assertTrue($this === cast($this, Runnable::class));
   }
 
   #[@test]
   public function parentClass() {
-    $this->assertTrue($this === cast($this, 'unittest.TestCase'));
+    $this->assertTrue($this === cast($this, TestCase::class));
   }
 
   #[@test]
   public function objectClass() {
-    $this->assertTrue($this === cast($this, 'lang.Object'));
+    $this->assertTrue($this === cast($this, Object::class));
   }
 
   #[@test]
   public function genericInterface() {
-    $this->assertTrue($this === cast($this, 'lang.Generic'));
+    $this->assertTrue($this === cast($this, Generic::class));
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function unrelated() {
-    cast($this, 'lang.CommandLine');
+    cast($this, CommandLine::class);
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function subClass() {
-    cast(new \lang\Object(), 'lang.CommandLine');
+    cast(new Object(), CommandLine::class);
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function nonExistant() {
     cast($this, '@@NON_EXISTANT_CLASS@@');
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function primitive() {
-    cast('primitive', 'lang.Object');
+    cast('primitive', Object::class);
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/CloningTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CloningTest.class.php
@@ -1,34 +1,28 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use unittest\TestCase;
 use lang\Object;
+use lang\NullPointerException;
 use lang\CloneNotSupportedException;
 
-/**
- * Tests cloning functionality
- */
-class CloningTest extends TestCase {
+class CloningTest extends \unittest\TestCase {
 
   /** @deprecated */
-  #[@test, @expect('lang.NullPointerException')]
+  #[@test, @expect(NullPointerException::class)]
   public function cloningOfNulls() {
     clone(\xp::null());
   }
 
   #[@test]
   public function cloneOfObject() {
-    $original= new \lang\Object();
+    $original= new Object();
     $this->assertFalse($original == clone($original));
   }
 
   #[@test]
   public function cloneInterceptorCalled() {
     $original= newinstance(Object::class, [], '{
-      public $cloned= FALSE;
-
-      public function __clone() {
-        $this->cloned= true;
-      }
+      public $cloned= false;
+      public function __clone() { $this->cloned= true; }
     }');
     $this->assertFalse($original->cloned);
     $clone= clone($original);
@@ -36,12 +30,10 @@ class CloningTest extends TestCase {
     $this->assertTrue($clone->cloned);
   }
 
-  #[@test, @expect('lang.CloneNotSupportedException')]
+  #[@test, @expect(CloneNotSupportedException::class)]
   public function cloneInterceptorThrowsException() {
-    clone(newinstance(Object::class, [], '{
-      public function __clone() {
-        throw new CloneNotSupportedException("I am *UN*Cloneable");
-      }
-    }'));
+    clone(newinstance(Object::class, [], [
+      '__clone' => function() { throw new CloneNotSupportedException('I am *UN*Cloneable'); }
+    ]));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\XPClass;
+use lang\IllegalArgumentException;
 use util\collections\Vector;
 use util\collections\HashTable;
 
@@ -39,7 +40,7 @@ class CreateTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function create_raises_exception_when_non_generic_given() {
     create('new lang.Object<lang.Object>');
   }

--- a/src/test/php/net/xp_framework/unittest/core/EnumTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnumTest.class.php
@@ -50,12 +50,12 @@ class EnumTest extends \unittest\TestCase {
 
   #[@test]
   public function coinIsAnEnums() {
-    $this->assertTrue(XPClass::forName('net.xp_framework.unittest.core.Coin')->isEnum());
+    $this->assertTrue(XPClass::forName(Coin::class)->isEnum());
   }
   
   #[@test]
   public function operationIsAnEnums() {
-    $this->assertTrue(XPClass::forName('net.xp_framework.unittest.core.Operation')->isEnum());
+    $this->assertTrue(XPClass::forName(Operation::class)->isEnum());
   }
 
   #[@test]
@@ -65,27 +65,27 @@ class EnumTest extends \unittest\TestCase {
 
   #[@test]
   public function enumBaseClassIsAbstract() {
-    $this->assertAbstract(XPClass::forName('lang.Enum')->getModifiers());
+    $this->assertAbstract(XPClass::forName(Enum::class)->getModifiers());
   }
 
   #[@test]
   public function operationEnumIsAbstract() {
-    $this->assertAbstract(XPClass::forName('net.xp_framework.unittest.core.Operation')->getModifiers());
+    $this->assertAbstract(XPClass::forName(Operation::class)->getModifiers());
   }
 
   #[@test]
   public function coinEnumIsNotAbstract() {
-    $this->assertNotAbstract(XPClass::forName('net.xp_framework.unittest.core.Coin')->getModifiers());
+    $this->assertNotAbstract(XPClass::forName(Coin::class)->getModifiers());
   }
 
   #[@test]
   public function coinMemberAreSameClass() {
-    $this->assertInstanceOf('net.xp_framework.unittest.core.Coin', Coin::$penny);
+    $this->assertInstanceOf(Coin::class, Coin::$penny);
   }
 
   #[@test]
   public function operationMembersAreSubclasses() {
-    $this->assertInstanceOf('net.xp_framework.unittest.core.Operation', Operation::$plus);
+    $this->assertInstanceOf(Operation::class, Operation::$plus);
   }
 
   #[@test]
@@ -112,7 +112,7 @@ class EnumTest extends \unittest\TestCase {
 
   #[@test]
   public function pennyCoinClass() {
-    $this->assertInstanceOf('net.xp_framework.unittest.core.Coin', Coin::$penny);
+    $this->assertInstanceOf(Coin::class, Coin::$penny);
   }
 
   #[@test]
@@ -149,13 +149,13 @@ class EnumTest extends \unittest\TestCase {
   public function valueOf() {
     $this->assertEquals(
       Coin::$penny, 
-      Enum::valueOf(XPClass::forName('net.xp_framework.unittest.core.Coin'), 'penny')
+      Enum::valueOf(XPClass::forName(Coin::class), 'penny')
     );
   }
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function valueOfNonExistant() {
-    Enum::valueOf(XPClass::forName('net.xp_framework.unittest.core.Coin'), '@@DOES_NOT_EXIST@@');
+    Enum::valueOf(XPClass::forName(Coin::class), '@@DOES_NOT_EXIST@@');
   }
 
   #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
@@ -172,7 +172,7 @@ class EnumTest extends \unittest\TestCase {
   public function valueOfAbstractEnum() {
     $this->assertEquals(
       Operation::$plus, 
-      Enum::valueOf(XPClass::forName('net.xp_framework.unittest.core.Operation'), 'plus')
+      Enum::valueOf(XPClass::forName(Operation::class), 'plus')
     );
   }
 
@@ -180,7 +180,7 @@ class EnumTest extends \unittest\TestCase {
   public function valuesOf() {
     $this->assertEquals(
       [Coin::$penny, Coin::$nickel, Coin::$dime, Coin::$quarter],
-      Enum::valuesOf(XPClass::forName('net.xp_framework.unittest.core.Coin'))
+      Enum::valuesOf(XPClass::forName(Coin::class))
     );
   }
 
@@ -188,7 +188,7 @@ class EnumTest extends \unittest\TestCase {
   public function valuesOfAbstractEnum() {
     $this->assertEquals(
       [Operation::$plus, Operation::$minus, Operation::$times, Operation::$divided_by],
-      Enum::valuesOf(XPClass::forName('net.xp_framework.unittest.core.Operation'))
+      Enum::valuesOf(XPClass::forName(Operation::class))
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/EnumTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnumTest.class.php
@@ -3,6 +3,9 @@
 use lang\reflect\Modifiers;
 use lang\XPClass;
 use lang\Enum;
+use lang\Error;
+use lang\IllegalArgumentException;
+use lang\CloneNotSupportedException;
 use unittest\actions\RuntimeVersion;
 
 /**
@@ -20,8 +23,9 @@ class EnumTest extends \unittest\TestCase {
   /**
    * Asserts given modifiers contain abstract
    *
-   * @param   int modifiers
-   * @throws  unittest.AssertionFailedError
+   * @param  int $modifiers
+   * @return void
+   * @throws unittest.AssertionFailedError
    */
   protected function assertAbstract($modifiers) {
     $this->assertTrue(
@@ -33,8 +37,9 @@ class EnumTest extends \unittest\TestCase {
   /**
    * Asserts given modifiers do not contain abstract
    *
-   * @param   int modifiers
-   * @throws  unittest.AssertionFailedError
+   * @param  int $modifiers
+   * @return void
+   * @throws unittest.AssertionFailedError
    */
   protected function assertNotAbstract($modifiers) {
     $this->assertFalse(
@@ -135,7 +140,7 @@ class EnumTest extends \unittest\TestCase {
     $this->assertNotEquals(Coin::$penny, Coin::$quarter);
   }
 
-  #[@test, @expect('lang.CloneNotSupportedException')]
+  #[@test, @expect(CloneNotSupportedException::class)]
   public function enumMembersAreNotCloneable() {
     clone Coin::$penny;
   }
@@ -148,17 +153,17 @@ class EnumTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function valueOfNonExistant() {
     Enum::valueOf(XPClass::forName('net.xp_framework.unittest.core.Coin'), '@@DOES_NOT_EXIST@@');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function valueOfNonEnum() {
     Enum::valueOf($this, 'irrelevant');
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function valueOfNonEnum7() {
     Enum::valueOf($this, 'irrelevant');
   }
@@ -187,12 +192,12 @@ class EnumTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function valuesOfNonEnum() {
     Enum::valuesOf($this);
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function valuesOfNonEnum7() {
     Enum::valuesOf($this);
   }
@@ -233,7 +238,7 @@ class EnumTest extends \unittest\TestCase {
     );
   }
   
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function staticMemberNotWithEnumValueOf() {
     Enum::valueOf(XPClass::forName('net.xp_framework.unittest.core.Profiling'), 'fixture');
   }

--- a/src/test/php/net/xp_framework/unittest/core/ErrorsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ErrorsTest.class.php
@@ -1,6 +1,12 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\Object;
+use lang\Error;
+use lang\XPException;
+use lang\NullPointerException;
+use lang\IndexOutOfBoundsException;
+use lang\IllegalArgumentException;
+use lang\ClassCastException;
 use unittest\actions\RuntimeVersion;
 use net\xp_framework\unittest\IgnoredOnHHVM;
 
@@ -37,8 +43,8 @@ class ErrorsTest extends \unittest\TestCase {
     trigger_error('Test error');
       
     try {
-      throw new \lang\XPException('');
-    } catch (\lang\XPException $e) {
+      throw new XPException('');
+    } catch (XPException $e) {
       $element= $e->getStackTrace()[0];
       $this->assertEquals(
         ['file' => __FILE__, 'message' => 'Test error'],
@@ -69,60 +75,60 @@ class ErrorsTest extends \unittest\TestCase {
     $this->assertTrue((bool)\xp::errorAt(__FILE__, __LINE__ - 1));
   }
 
-  #[@test, @expect('lang.NullPointerException')]
+  #[@test, @expect(NullPointerException::class)]
   public function undefined_variable_yields_npe() {
     $a++;
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function undefined_array_offset_yields_ioobe() {
     $a= [];
     $a[0];
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function undefined_map_key_yields_ioobe() {
     $a= [];
     $a['test'];
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException'), @action(new IgnoredOnHHVM())]
+  #[@test, @expect(IndexOutOfBoundsException::class), @action(new IgnoredOnHHVM())]
   public function undefined_string_offset_yields_ioobe() {
     $a= '';
     $a{0};
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function call_to_member_on_non_object_yields_npe() {
     $a= null;
     $a->method();
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function argument_mismatch_yield_iae() {
     $f= function(Object $arg) { };
     $f('Primitive');
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function argument_mismatch_yield_type_exception() {
     $f= function(Object $arg) { };
     $f('Primitive');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new IgnoredOnHHVM())]
+  #[@test, @expect(IllegalArgumentException::class), @action(new IgnoredOnHHVM())]
   public function missing_argument_mismatch_yield_iae() {
     $f= function($arg) { };
     $f();
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function cannot_convert_object_to_string_yields_cce() {
     $object= new Object();
     $object.'String';
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function cannot_convert_array_to_string_yields_cce() {
     $array= [];
     $array.'String';

--- a/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
@@ -1,21 +1,21 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use unittest\TestCase;
 use io\streams\Streams;
 use io\streams\MemoryOutputStream;
 use lang\Throwable;
+use lang\Error;
+use lang\XPException;
+use lang\XPClass;
+use lang\IllegalArgumentException;
 use unittest\actions\RuntimeVersion;
 
-/**
- * Test the XP exception mechanism
- */
-class ExceptionsTest extends TestCase {
+class ExceptionsTest extends \unittest\TestCase {
 
   #[@test]
   public function noException() {
     try {
       // Nothing
-    } catch (\lang\XPException $caught) {
+    } catch (Throwable $caught) {
       $this->fail('Caught an exception but none where thrown', $caught);
     }
   }
@@ -36,10 +36,10 @@ class ExceptionsTest extends TestCase {
   #[@test]
   public function multipleCatches() {
     try {
-      throw new \lang\XPException('Test');
-    } catch (\lang\IllegalArgumentException $caught) {
+      throw new XPException('Test');
+    } catch (IllegalArgumentException $caught) {
       return $this->fail('Exception should have been caught in Exception block', 'IllegalArgumentException');
-    } catch (\lang\XPException $caught) {
+    } catch (XPException $caught) {
       return true;
     } catch (Throwable $caught) {
       return $this->fail('Exception should have been caught in Exception block', 'Throwable');
@@ -87,7 +87,7 @@ class ExceptionsTest extends TestCase {
 
   #[@test]
   public function classMethod() {
-    $this->assertEquals(\lang\XPClass::forName('lang.Throwable'), (new Throwable('Test'))->getClass());
+    $this->assertEquals(XPClass::forName('lang.Throwable'), (new Throwable('Test'))->getClass());
   }
 
   /** @deprecated */
@@ -112,13 +112,13 @@ class ExceptionsTest extends TestCase {
     $this->assertEquals($e->toString(), $out->getBytes());
   }
   
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function withCause_must_be_a_throwable() {
-    new \lang\XPException('Message', 'Anything...');
+    new XPException('Message', 'Anything...');
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function withCause_must_be_a_throwable7() {
-    new \lang\XPException('Message', 'Anything...');
+    new XPException('Message', 'Anything...');
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
@@ -25,7 +25,7 @@ class ExceptionsTest extends \unittest\TestCase {
     try {
       throw new Throwable('Test');
     } catch (Throwable $caught) {
-      $this->assertInstanceOf('lang.Throwable', $caught);
+      $this->assertInstanceOf(Throwable::class, $caught);
       unset($caught);
       return true;
     }

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\FunctionType;
 use lang\Primitive;
+use lang\Object;
 use lang\XPClass;
 use lang\Type;
 use lang\ArrayType;
@@ -321,7 +322,7 @@ class FunctionTypeTest extends \unittest\TestCase {
   #])]
   public function create_instances_from_array_referencing_constructor($value) {
     $new= (new FunctionType([], XPClass::forName('lang.Object')))->newInstance($value);
-    $this->assertInstanceOf('lang.Object', $new());
+    $this->assertInstanceOf(Object::class, $new());
   }
 
   #[@test, @values([

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -6,6 +6,9 @@ use lang\XPClass;
 use lang\Type;
 use lang\ArrayType;
 use lang\MapType;
+use lang\ClassCastException;
+use lang\IllegalArgumentException;
+use lang\reflect\TargetInvocationException;
 
 /**
  * TestCase
@@ -251,7 +254,7 @@ class FunctionTypeTest extends \unittest\TestCase {
     $this->assertNull((new FunctionType([Type::$VAR], Type::$VAR))->cast(null));
   }
 
-  #[@test, @expect('lang.ClassCastException'), @values([
+  #[@test, @expect(ClassCastException::class), @values([
   #  0, -1, 0.5, true, false, '', 'Test',
   #  [[]], [['key' => 'value']],
   #  [['non-existant', 'method']], [['lang.XPClass', 'non-existant']],
@@ -261,17 +264,17 @@ class FunctionTypeTest extends \unittest\TestCase {
     (new FunctionType([Type::$VAR], Type::$VAR))->cast($value);
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function return_type_verified_for_instance_methods_when_casting() {
     (new FunctionType([], Primitive::$VOID))->cast([$this, 'getName']);
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function number_of_required_parameters_is_verified_when_casting() {
     (new FunctionType([], Type::$VAR))->cast('strlen');
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function excess_parameters_are_verified_when_casting() {
     (new FunctionType([Type::$VAR, Type::$VAR], Type::$VAR))->cast('strlen');
   }
@@ -288,12 +291,12 @@ class FunctionTypeTest extends \unittest\TestCase {
     $this->assertEquals(4, $value('Test'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function number_of_required_parameters_is_verified_when_creating_instances() {
     (new FunctionType([], Type::$VAR))->newInstance('strlen');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function excess_parameters_are_verified_when_creating_instances() {
     (new FunctionType([Type::$VAR, Type::$VAR], Type::$VAR))->newInstance('strlen');
   }
@@ -336,12 +339,12 @@ class FunctionTypeTest extends \unittest\TestCase {
     $this->assertInstanceOf('util.collections.Vector<int>', $new());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values([[['lang.Generic', 'new']], ['lang.Generic::new']])]
+  #[@test, @expect(IllegalArgumentException::class), @values([[['lang.Generic', 'new']], ['lang.Generic::new']])]
   public function cannot_create_instances_from_interfaces($value) {
     (new FunctionType([Type::$VAR], Type::forName('lang.Generic')))->newInstance($value);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values([[['util.collections.IList<int>', 'new']], ['util.collections.IList<int>::new']])]
+  #[@test, @expect(IllegalArgumentException::class), @values([[['util.collections.IList<int>', 'new']], ['util.collections.IList<int>::new']])]
   public function cannot_create_instances_from_generic_interfaces($value) {
     (new FunctionType([Type::$VAR], Type::forName('util.collections.IList<int>')))->newInstance($value);
   }
@@ -359,24 +362,24 @@ class FunctionTypeTest extends \unittest\TestCase {
     $this->assertEquals([1, 2, 3], $value());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function generic_argument_parameter_types_are_verified_when_creating_instances() {
     $vector= create('new util.collections.Vector<int>');
     (new FunctionType([Primitive::$STRING], Primitive::$INT))->newInstance([$vector, 'add']);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function generic_argument_return_type_is_verified_when_creating_instances() {
     $vector= create('new util.collections.Vector<int>');
     (new FunctionType([Primitive::$INT], Primitive::$STRING))->newInstance([$vector, 'add']);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function return_type_verified_for_instance_methods_when_creating_instances() {
     (new FunctionType([], Primitive::$VOID))->newInstance([$this, 'getName']);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values([
+  #[@test, @expect(IllegalArgumentException::class), @values([
   #  null,
   #  0, -1, 0.5, true, false, '', 'Test',
   #  [[]], [['key' => 'value']],
@@ -446,7 +449,7 @@ class FunctionTypeTest extends \unittest\TestCase {
     $this->assertEquals('string', $t->invoke($f, [Primitive::$STRING]));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values([
+  #[@test, @expect(IllegalArgumentException::class), @values([
   #  null,
   #  0, -1, 0.5, true, false, '', 'Test',
   #  [[]], [['key' => 'value']],
@@ -459,7 +462,7 @@ class FunctionTypeTest extends \unittest\TestCase {
     $t->invoke($value);
   }
 
-  #[@test, @expect('lang.reflect.TargetInvocationException')]
+  #[@test, @expect(TargetInvocationException::class)]
   public function invoke_wraps_exceptions_in_TargetInvocationExceptions() {
     $t= new FunctionType([], Primitive::$VOID);
     $t->invoke(function() { throw new \lang\IllegalArgumentException('Test'); }, []);

--- a/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
@@ -2,6 +2,8 @@
 
 use util\collections\Vector;
 use lang\Object;
+use lang\Runnable;
+use lang\ClassLoader;
 
 /**
  * Tests the is() core functionality
@@ -149,13 +151,13 @@ class IsTest extends \unittest\TestCase {
 
   #[@test]
   public function interfaces() {
-    \lang\ClassLoader::defineClass(
+    ClassLoader::defineClass(
       'net.xp_framework.unittest.core.RunnableImpl', 
-      'lang.Object',
-      ['lang.Runnable'],
+      Object::class,
+      [Runnable::class],
       ['run' => function() { }]
     );
-    \lang\ClassLoader::defineClass(
+    ClassLoader::defineClass(
       'net.xp_framework.unittest.core.RunnableImplEx', 
       'net.xp_framework.unittest.core.RunnableImpl',
       [],

--- a/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
@@ -13,7 +13,7 @@ class MapTypeTest extends \unittest\TestCase {
 
   #[@test]
   public function typeForName() {
-    $this->assertInstanceOf('lang.MapType', Type::forName('[:string]'));
+    $this->assertInstanceOf(MapType::class, Type::forName('[:string]'));
   }
 
   #[@test, @expect(IllegalArgumentException::class)]

--- a/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
@@ -1,18 +1,14 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\ArrayType;
-use lang\IllegalArgumentException;
 use lang\MapType;
 use lang\Primitive;
 use lang\Type;
 use lang\XPClass;
 use lang\Object;
+use lang\IllegalArgumentException;
+use lang\ClassCastException;
 
-/**
- * TestCase
- *
- * @see      xp://lang.MapType
- */
 class MapTypeTest extends \unittest\TestCase {
 
   #[@test]
@@ -161,7 +157,7 @@ class MapTypeTest extends \unittest\TestCase {
     $this->assertEquals($expected, MapType::forName('[:string]')->cast($value));
   }
 
-  #[@test, @expect('lang.ClassCastException'), @values([
+  #[@test, @expect(ClassCastException::class), @values([
   #  0, -1, 0.5, '', 'Test', new Object(), true, false,
   #  [[0, 1, 2]]
   #])]

--- a/src/test/php/net/xp_framework/unittest/core/MissingMethodsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/MissingMethodsTest.class.php
@@ -24,7 +24,7 @@ class MissingMethodsTest extends \unittest\TestCase {
 
   #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method lang.Object::run()/')]
   public function missingParentMethodInvocation() {
-    $c= ClassLoader::defineClass('MissingMethodsTest_Fixture', 'lang.Object', [], '{
+    $c= ClassLoader::defineClass('MissingMethodsTest_Fixture', Object::class, [], '{
       public function run() {
         parent::run();
       }
@@ -34,7 +34,7 @@ class MissingMethodsTest extends \unittest\TestCase {
 
   #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method .+::run()/')]
   public function missingParentParentMethodInvocation() {
-    $b= ClassLoader::defineClass('MissingMethodsTest_BaseFixture', 'lang.Object', [], '{}');
+    $b= ClassLoader::defineClass('MissingMethodsTest_BaseFixture', Object::class, [], '{}');
     $c= ClassLoader::defineClass('MissingMethodsTest_ChildFixture', $b->getName(), [], '{
       public function run() {
         parent::run();
@@ -45,7 +45,7 @@ class MissingMethodsTest extends \unittest\TestCase {
 
   #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method lang.Object::run()/')]
   public function missingParentPassMethodInvocation() {
-    $b= ClassLoader::defineClass('MissingMethodsTest_PassBaseFixture', 'lang.Object', [], '{
+    $b= ClassLoader::defineClass('MissingMethodsTest_PassBaseFixture', Object::class, [], '{
       public function run() {
         parent::run();
       }
@@ -60,7 +60,7 @@ class MissingMethodsTest extends \unittest\TestCase {
 
   #[@test, @expect(class= Error::class, withMessage= '/Call to undefined static method lang.Object::run()/')]
   public function missingStaticParentMethodInvocation() {
-    $c= ClassLoader::defineClass('MissingMethodsTest_StaticFixture', 'lang.Object', [], '{
+    $c= ClassLoader::defineClass('MissingMethodsTest_StaticFixture', Object::class, [], '{
       public static function run() {
         parent::run();
       }
@@ -70,7 +70,7 @@ class MissingMethodsTest extends \unittest\TestCase {
 
   #[@test, @expect(class= Error::class, withMessage= '/Call to undefined static method .+::run()/')]
   public function missingStaticParentParentMethodInvocation() {
-    $b= ClassLoader::defineClass('MissingMethodsTest_StaticBaseFixture', 'lang.Object', [], '{}');
+    $b= ClassLoader::defineClass('MissingMethodsTest_StaticBaseFixture', Object::class, [], '{}');
     $c= ClassLoader::defineClass('MissingMethodsTest_StaticChildFixture', $b->getName(), [], '{
       public static function run() {
         parent::run();
@@ -81,7 +81,7 @@ class MissingMethodsTest extends \unittest\TestCase {
 
   #[@test, @expect(class= Error::class, withMessage= '/Call to undefined static method lang.Object::run()/')]
   public function missingStaticParentPassMethodInvocation() {
-    $b= ClassLoader::defineClass('MissingMethodsTest_StaticPassBaseFixture', 'lang.Object', [], '{
+    $b= ClassLoader::defineClass('MissingMethodsTest_StaticPassBaseFixture', Object::class, [], '{
       public static function run() {
         parent::run();
       }

--- a/src/test/php/net/xp_framework/unittest/core/MissingMethodsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/MissingMethodsTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\ClassLoader;
 use lang\Object;
+use lang\Error;
 
 /**
  * Verifies lang.Object's `__call()` implementation
@@ -16,12 +17,12 @@ class MissingMethodsTest extends \unittest\TestCase {
     $f();
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method lang.Object::run()/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method lang.Object::run()/')]
   public function missingMethodInvocation() {
     $this->callRunOn(new Object());
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method lang.Object::run()/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method lang.Object::run()/')]
   public function missingParentMethodInvocation() {
     $c= ClassLoader::defineClass('MissingMethodsTest_Fixture', 'lang.Object', [], '{
       public function run() {
@@ -31,7 +32,7 @@ class MissingMethodsTest extends \unittest\TestCase {
     $this->callRunOn($c->newInstance());
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method .+::run()/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method .+::run()/')]
   public function missingParentParentMethodInvocation() {
     $b= ClassLoader::defineClass('MissingMethodsTest_BaseFixture', 'lang.Object', [], '{}');
     $c= ClassLoader::defineClass('MissingMethodsTest_ChildFixture', $b->getName(), [], '{
@@ -42,7 +43,7 @@ class MissingMethodsTest extends \unittest\TestCase {
     $this->callRunOn($c->newInstance());
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method lang.Object::run()/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method lang.Object::run()/')]
   public function missingParentPassMethodInvocation() {
     $b= ClassLoader::defineClass('MissingMethodsTest_PassBaseFixture', 'lang.Object', [], '{
       public function run() {
@@ -57,7 +58,7 @@ class MissingMethodsTest extends \unittest\TestCase {
     $this->callRunOn($c->newInstance());
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined static method lang.Object::run()/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined static method lang.Object::run()/')]
   public function missingStaticParentMethodInvocation() {
     $c= ClassLoader::defineClass('MissingMethodsTest_StaticFixture', 'lang.Object', [], '{
       public static function run() {
@@ -67,7 +68,7 @@ class MissingMethodsTest extends \unittest\TestCase {
     $this->callRunOn($c->literal());
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined static method .+::run()/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined static method .+::run()/')]
   public function missingStaticParentParentMethodInvocation() {
     $b= ClassLoader::defineClass('MissingMethodsTest_StaticBaseFixture', 'lang.Object', [], '{}');
     $c= ClassLoader::defineClass('MissingMethodsTest_StaticChildFixture', $b->getName(), [], '{
@@ -78,7 +79,7 @@ class MissingMethodsTest extends \unittest\TestCase {
     $this->callRunOn($c->literal());
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined static method lang.Object::run()/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined static method lang.Object::run()/')]
   public function missingStaticParentPassMethodInvocation() {
     $b= ClassLoader::defineClass('MissingMethodsTest_StaticPassBaseFixture', 'lang.Object', [], '{
       public static function run() {

--- a/src/test/php/net/xp_framework/unittest/core/NamespaceAliasTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NamespaceAliasTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace net\xp_framework\unittest\core;
 
+use lang\Object;
 use lang\ClassLoader;
 
 /**
@@ -26,7 +27,7 @@ class NamespaceAliasTest extends \unittest\TestCase {
   public function defined_class_exists() {
     ClassLoader::defineClass(
       'net.xp_framework.unittest.core.NamespaceAliasClassFixture', 
-      'lang.Object', 
+      Object::class, 
       [], 
       '{}'
     );

--- a/src/test/php/net/xp_framework/unittest/core/NamespacedClassesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NamespacedClassesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use unittest\TestCase;
+use lang\Object;
 use lang\reflect\Package;
 use util\collections\Vector;
 
@@ -12,12 +12,9 @@ use util\collections\Vector;
  * @see   xp://net.xp_framework.unittest.core.NamespacedClass
  * @see   php://namespaces
  */
-class NamespacedClassesTest extends TestCase {
-  protected static $package= null;
+class NamespacedClassesTest extends \unittest\TestCase {
+  protected static $package;
 
-  /**
-   * Initializes package member
-   */
   #[@beforeClass]
   public static function initializePackage() {
     self::$package= Package::forName('net.xp_framework.unittest.core');
@@ -26,7 +23,7 @@ class NamespacedClassesTest extends TestCase {
   #[@test]
   public function namespacedClassLiteral() {
     $this->assertEquals(
-      'net\\xp_framework\\unittest\\core\\NamespacedClass', 
+      NamespacedClass::class, 
       self::$package->loadClass('NamespacedClass')->literal()
     );
   }
@@ -42,7 +39,7 @@ class NamespacedClassesTest extends TestCase {
   #[@test]
   public function namespacedClassUsingUnqualified() {
     $this->assertInstanceOf(
-      'lang.Object',
+      Object::class,
       self::$package->loadClass('NamespacedClassUsingUnqualified')->newInstance()->newObject()
     );
   }
@@ -66,14 +63,14 @@ class NamespacedClassesTest extends TestCase {
   #[@test]
   public function newInstanceOnNamespacedClass() {
     $i= newinstance(NamespacedClass::class, [], '{}');
-    $this->assertInstanceOf('net.xp_framework.unittest.core.NamespacedClass', $i);
+    $this->assertInstanceOf(NamespacedClass::class, $i);
   }
 
   #[@test]
   public function packageOfNewInstancedNamespacedClass() {
     $i= newinstance(NamespacedClass::class, [], '{}');
     $this->assertEquals(
-      \lang\reflect\Package::forName('net.xp_framework.unittest.core'),
+      Package::forName('net.xp_framework.unittest.core'),
       $i->getClass()->getPackage()
     );
   }

--- a/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\Runnable;
+use lang\Object;
 use lang\Runtime;
 use lang\Process;
 use lang\reflect\Package;
@@ -42,25 +43,25 @@ class NewInstanceTest extends \unittest\TestCase {
   
   #[@test]
   public function new_class_with_empty_body() {
-    $o= newinstance('lang.Object', []);
-    $this->assertInstanceOf('lang.Object', $o);
+    $o= newinstance(Object::class, []);
+    $this->assertInstanceOf(Object::class, $o);
   }
 
   #[@test]
   public function new_class_with_empty_body_as_string() {
-    $o= newinstance('lang.Object', [], '{}');
-    $this->assertInstanceOf('lang.Object', $o);
+    $o= newinstance(Object::class, [], '{}');
+    $this->assertInstanceOf(Object::class, $o);
   }
 
   #[@test]
   public function new_class_with_empty_body_as_closuremap() {
-    $o= newinstance('lang.Object', [], []);
-    $this->assertInstanceOf('lang.Object', $o);
+    $o= newinstance(Object::class, [], []);
+    $this->assertInstanceOf(Object::class, $o);
   }
 
   #[@test]
   public function new_class_with_member_as_string() {
-    $o= newinstance('lang.Object', [], '{
+    $o= newinstance(Object::class, [], '{
       public $test= "Test";
     }');
     $this->assertEquals('Test', $o->test);
@@ -68,7 +69,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function new_class_with_member_as_closuremap() {
-    $o= newinstance('lang.Object', [], [
+    $o= newinstance(Object::class, [], [
       'test' => 'Test'
     ]);
     $this->assertEquals('Test', $o->test);
@@ -82,7 +83,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function new_class_with_field_annotations() {
-    $o= newinstance('lang.Object', [], [
+    $o= newinstance(Object::class, [], [
       '#[@test] fixture' => null
     ]);
     $this->assertTrue($o->getClass()->getField('fixture')->hasAnnotation('test'));
@@ -90,7 +91,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function new_class_with_method_annotations() {
-    $o= newinstance('lang.Object', [], [
+    $o= newinstance(Object::class, [], [
       '#[@test] fixture' => function() { }
     ]);
     $this->assertTrue($o->getClass()->getMethod('fixture')->hasAnnotation('test'));
@@ -98,16 +99,16 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function new_interface_with_body_as_string() {
-    $o= newinstance('lang.Runnable', [], '{ public function run() { } }');
-    $this->assertInstanceOf('lang.Runnable', $o);
+    $o= newinstance(Runnable::class, [], '{ public function run() { } }');
+    $this->assertInstanceOf(Runnable::class, $o);
   }
 
   #[@test]
   public function new_interface_with_body_as_closuremap() {
-    $o= newinstance('lang.Runnable', [], [
+    $o= newinstance(Runnable::class, [], [
       'run' => function() { }
     ]);
-    $this->assertInstanceOf('lang.Runnable', $o);
+    $this->assertInstanceOf(Runnable::class, $o);
   }
 
   #[@test]
@@ -120,7 +121,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function new_trait_with_body_as_string() {
-    $o= newinstance('net.xp_framework.unittest.core.Named', ['Test'], '{
+    $o= newinstance(Named::class, ['Test'], '{
       public function __construct($name) { $this->name= $name; }
     }');
     $this->assertEquals('Test', $o->name());
@@ -128,7 +129,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function new_trait_with_body_as_closuremap() {
-    $o= newinstance('net.xp_framework.unittest.core.Named', ['Test'], [
+    $o= newinstance(Named::class, ['Test'], [
       '__construct' => function($name) { $this->name= $name; }
     ]);
     $this->assertEquals('Test', $o->name());
@@ -144,13 +145,13 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function new_trait_with_constructor() {
-    $o= newinstance('net.xp_framework.unittest.core.ListOf', [[1, 2, 3]], []);
+    $o= newinstance(ListOf::class, [[1, 2, 3]], []);
     $this->assertEquals([1, 2, 3], $o->elements());
   }
 
   #[@test]
   public function arguments_are_passed_to_constructor() {
-    $instance= newinstance('lang.Object', [$this], '{
+    $instance= newinstance(Object::class, [$this], '{
       public $test= null;
       public function __construct($test) {
         $this->test= $test;
@@ -161,7 +162,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function arguments_are_passed_to_constructor_in_closuremap() {
-    $instance= newinstance('lang.Object', [$this], [
+    $instance= newinstance(Object::class, [$this], [
       'test' => null,
       '__construct' => function($test) {
         $this->test= $test;
@@ -172,7 +173,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function arguments_are_passed_to_base_constructor_in_closuremap() {
-    $base= ClassLoader::defineClass(nameof($this).'_BaseFixture', 'lang.Object', [], [
+    $base= ClassLoader::defineClass(nameof($this).'_BaseFixture', Object::class, [], [
       'test' => null,
       '__construct' => function($test) {
         $this->test= $test;
@@ -256,7 +257,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function packageOfNewInstancedClass() {
-    $i= newinstance('lang.Object', [], '{}');
+    $i= newinstance(Object::class, [], '{}');
     $this->assertEquals(
       Package::forName('lang'),
       $i->getClass()->getPackage()
@@ -264,15 +265,15 @@ class NewInstanceTest extends \unittest\TestCase {
   }
 
   #[@test, @values(['php.IteratorAggregate', 'IteratorAggregate'])]
-  public function packageOfNewInstancedPHPClass() {
-    $i= newinstance('php.IteratorAggregate', [], '{ public function getIterator() { /* Empty */ }}');
+  public function packageOfNewInstancedPHPClass($class) {
+    $i= newinstance($class, [], '{ public function getIterator() { /* Empty */ }}');
     $this->assertEquals(
       Package::forName(''),
       $i->getClass()->getPackage()
     );
   }
 
-  #[@test, @values(['net.xp_framework.unittest.core.NamespacedClass', 'net\\xp_framework\\unittest\\core\\NamespacedClass'])]
+  #[@test, @values(['net.xp_framework.unittest.core.NamespacedClass', NamespacedClass::class])]
   public function packageOfNewInstancedNamespacedClass($class) {
     $i= newinstance($class, [], '{}');
     $this->assertEquals(
@@ -283,7 +284,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function packageOfNewInstancedNamespacedInterface() {
-    $i= newinstance('net.xp_framework.unittest.core.NamespacedInterface', [], '{}');
+    $i= newinstance(NamespacedInterface::class, [], '{}');
     $this->assertEquals(
       Package::forName('net.xp_framework.unittest.core'),
       $i->getClass()->getPackage()
@@ -292,7 +293,7 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function className() {
-    $instance= newinstance('lang.Object', [], '{ }');
+    $instance= newinstance(Object::class, [], '{ }');
     $n= nameof($instance);
     $this->assertEquals(
       'lang.Object',
@@ -303,33 +304,33 @@ class NewInstanceTest extends \unittest\TestCase {
 
   #[@test]
   public function anonymousClassWithoutConstructor() {
-    newinstance('util.log.Traceable', [], '{
-      public function setTrace($cat) {}
+    newinstance(Runnable::class, [], '{
+      public function run() {}
     }');
   }
 
   #[@test]
   public function anonymousClassWithoutConstructorIgnoresConstructArgs() {
-    newinstance('util.log.Traceable', ['arg1'], '{
-      public function setTrace($cat) {}
+    newinstance(Runnable::class, ['arg1'], '{
+      public function run() {}
     }');
   }
 
   #[@test]
   public function anonymousClassWithConstructor() {
-    newinstance('util.log.Traceable', ['arg1'], '{
+    newinstance(Runnable::class, ['arg1'], '{
       public function __construct($arg) {
         if ($arg != "arg1") {
           throw new \\unittest\\AssertionFailedError("equals", $arg, "arg1");
         }
       }
-      public function setTrace($cat) {}
+      public function run() {}
     }');
   }
 
   #[@test]
   public function this_can_be_accessed() {
-    $instance= newinstance('lang.Object', [], [
+    $instance= newinstance(Object::class, [], [
       'test'    => null,
       'setTest' => function($test) {
         $this->test= $test;

--- a/src/test/php/net/xp_framework/unittest/core/NullTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NullTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace net\xp_framework\unittest\core;
 
+use lang\IllegalAccessException;
+use lang\NullPointerException;
+
 /**
  * Tests the "NULL-safe" xp::null.
  *
@@ -27,29 +30,29 @@ class NullTest extends \unittest\TestCase {
     $this->assertEquals('<null>', \xp::stringOf(\xp::null()));
   }
   
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function newInstance() {
     new \__null();
   }
 
-  #[@test, @expect('lang.NullPointerException')]
+  #[@test, @expect(NullPointerException::class)]
   public function cloneNull() {
     clone(\xp::null());
   }
 
-  #[@test, @expect('lang.NullPointerException')]
+  #[@test, @expect(NullPointerException::class)]
   public function methodInvocation() {
     $null= \xp::null();
     $null->method();
   }
 
-  #[@test, @expect('lang.NullPointerException')]
+  #[@test, @expect(NullPointerException::class)]
   public function memberReadAccess() {
     $null= \xp::null();
     $i= $null->member;
   }
   
-  #[@test, @expect('lang.NullPointerException')]
+  #[@test, @expect(NullPointerException::class)]
   public function memberWriteccess() {
     $null= \xp::null();
     $null->member= 15;

--- a/src/test/php/net/xp_framework/unittest/core/ObjectTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ObjectTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\XPClass;
 use lang\Object;
+use lang\Error;
 
 /**
  * Tests the lang.Object class
@@ -73,22 +74,23 @@ class ObjectTest extends \unittest\TestCase {
     $this->assertEquals("lang.Object {\n  __id => \"".$o->hashCode()."\"\n}", $o->toString());
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
   public function calling_undefined_methods_raises_an_error() {
     (new Object())->undefMethod();
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
   public function calling_undefined_methods_via_call_user_func_array_raises_an_error() {
     call_user_func_array([new Object(), 'undefMethod'], []);
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
   public function calling_undefined_static_methods_raises_an_error() {
     Object::undefMethod();
   }
 
-  #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
+  #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
   public function calling_undefined_static_methods_via_call_user_func_array_raises_an_error() {
     call_user_func_array(['lang\Object', 'undefMethod'], []);
-  }}
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/core/ProcessResolveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ProcessResolveTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use unittest\TestCase;
 use lang\Process;
+use io\IOException;
 use unittest\actions\IsPlatform;
 
 /**
@@ -9,19 +9,15 @@ use unittest\actions\IsPlatform;
  *
  * @see      xp://lang.Process
  */
-class ProcessResolveTest extends TestCase {
-  protected $origDir;
+class ProcessResolveTest extends \unittest\TestCase {
+  private $origDir;
 
-  /**
-   * Setup test. Backs up current directory.
-   */
+  /** @return void */
   public function setUp() {
     $this->origDir= getcwd();
   }
   
-  /**
-   * Tear down test. Returns the previous working directory.
-   */
+  /** @return void */
   public function tearDown() {
     chdir($this->origDir);
   }
@@ -82,27 +78,27 @@ class ProcessResolveTest extends TestCase {
     $this->assertTrue(is_executable(Process::resolve('explorer')));
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function resolveSlashDirectory() {
     Process::resolve('/');
   }
 
-  #[@test, @action(new IsPlatform('WIN')), @expect('io.IOException')]
+  #[@test, @action(new IsPlatform('WIN')), @expect(IOException::class)]
   public function resolveBackslashDirectory() {
     Process::resolve('\\');
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function resolveEmpty() {
     Process::resolve('');
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function resolveNonExistant() {
     Process::resolve('@@non-existant@@');
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function resolveNonExistantFullyQualified() {
     Process::resolve('/@@non-existant@@');
   }

--- a/src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
@@ -5,6 +5,8 @@ use unittest\AssertionFailedError;
 use lang\Runtime;
 use lang\System;
 use lang\Process;
+use lang\IllegalStateException;
+use io\IOException;
 use io\streams\Streams;
 use io\streams\MemoryOutputStream;
 
@@ -28,7 +30,7 @@ class ProcessTest extends \unittest\TestCase {
   /**
    * Return executable name
    *
-   * @return  string
+   * @return string
    */
   private function executable() {
     return Runtime::getInstance()->getExecutable()->getFilename();
@@ -131,22 +133,22 @@ class ProcessTest extends \unittest\TestCase {
     $this->assertEquals('ERR', $err);
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function runningNonExistantFile() {
     new Process(':FILE_DOES_NOT_EXIST:');
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function runningDirectory() {
     new Process(System::tempDir());
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function runningEmpty() {
     new Process('');
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function nonExistantProcessId() {
     Process::getProcessById(-1);
   }
@@ -166,7 +168,7 @@ class ProcessTest extends \unittest\TestCase {
     $this->assertEquals(222, $p->close());
   }
 
-  #[@test, @expect(class= 'lang.IllegalStateException', withMessage= '/Cannot close not-owned/')]
+  #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot close not-owned/')]
   public function closingProcessByProcessId() {
     Process::getProcessById(getmypid())->close();
   }

--- a/src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
@@ -19,6 +19,8 @@ class ProcessTest extends \unittest\TestCase {
 
   /**
    * Skips tests if process execution has been disabled.
+   *
+   * @return void
    */
   #[@beforeClass]
   public static function verifyProcessExecutionEnabled() {
@@ -157,7 +159,7 @@ class ProcessTest extends \unittest\TestCase {
   public function getByProcessId() {
     $pid= getmypid();
     $p= Process::getProcessById($pid);
-    $this->assertInstanceOf('lang.Process', $p);
+    $this->assertInstanceOf(Process::class, $p);
     $this->assertEquals($pid, $p->getProcessId());
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/ReferencesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ReferencesTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\ClassLoader;
+use lang\Object;
 
 /**
  * References test.
@@ -10,7 +11,7 @@ class ReferencesTest extends \unittest\TestCase {
   static function __static() {
     
     // For singletonInstance test
-    ClassLoader::defineClass('net.xp_framework.unittest.core.AnonymousSingleton', 'lang.Object', [], '{
+    ClassLoader::defineClass('net.xp_framework.unittest.core.AnonymousSingleton', Object::class, [], '{
       protected static $instance= NULL;
 
       static function getInstance() {
@@ -20,17 +21,17 @@ class ReferencesTest extends \unittest\TestCase {
     }');
 
     // For returnNewObject and returnNewObjectViaReflection tests
-    ClassLoader::defineClass('net.xp_framework.unittest.core.AnonymousList', 'lang.Object', [], '{
+    ClassLoader::defineClass('net.xp_framework.unittest.core.AnonymousList', Object::class, [], '{
       public function __construct() {
         \net\xp_framework\unittest\core\ReferencesTest::registry("list", $this);
       }
     }');
-    ClassLoader::defineClass('net.xp_framework.unittest.core.AnonymousFactory', 'lang.Object', [], '{
+    ClassLoader::defineClass('net.xp_framework.unittest.core.AnonymousFactory', Object::class, [], '{
       static function factory() {
         return new AnonymousList();
       }
     }');
-    ClassLoader::defineClass('net.xp_framework.unittest.core.AnonymousNewInstanceFactory', 'lang.Object', [], '{
+    ClassLoader::defineClass('net.xp_framework.unittest.core.AnonymousNewInstanceFactory', Object::class, [], '{
       static function factory() {
         return \lang\XPClass::forName("net.xp_framework.unittest.core.AnonymousList")->newInstance();
       }
@@ -40,8 +41,8 @@ class ReferencesTest extends \unittest\TestCase {
   /**
    * Helper method that asserts to objects are references to each other
    *
-   * @param   &lang.Object a
-   * @param   &lang.Object b
+   * @param   &lang.Object $a
+   * @param   &lang.Object $b
    * @throws  unittest.AssertionFailedError
    */
   protected function assertReference($a, $b) {

--- a/src/test/php/net/xp_framework/unittest/core/ResourceProviderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ResourceProviderTest.class.php
@@ -2,6 +2,7 @@
 
 use io\File;
 use io\FileUtil;
+use io\FileNotFoundException;
 use lang\ResourceProvider;
 
 /**
@@ -21,7 +22,7 @@ class ResourceProviderTest extends \unittest\TestCase {
     $this->assertEquals('Foobar', trim(FileUtil::getContents(new File('res://net/xp_framework/unittest/core/resourceprovider/one/Dummy.txt'))));
   }
 
-  #[@test, @expect('io.FileNotFoundException')]
+  #[@test, @expect(FileNotFoundException::class)]
   public function loadingNonexistantFile() {
     $this->assertEquals('Foobar', trim(FileUtil::getContents(new File('res://one/Dummy.txt'))));
   }

--- a/src/test/php/net/xp_framework/unittest/core/RuntimeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/RuntimeTest.class.php
@@ -1,12 +1,8 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\Runtime;
+use lang\FormatException;
 
-/**
- * TestCase
- *
- * @see   xp://lang.Runtime
- */
 class RuntimeTest extends \unittest\TestCase {
 
   /**
@@ -14,6 +10,8 @@ class RuntimeTest extends \unittest\TestCase {
    *
    * @param  string[] $expected
    * @param  lang.RuntimeOptions $actual
+   * @return void
+   * @throws unittest.AssertionFailedError
    */
   private function assertArguments($expected, $actual) {
     if (defined('HHVM_VERSION')) {
@@ -96,7 +94,7 @@ class RuntimeTest extends \unittest\TestCase {
     $this->assertEquals('tools/xar.php', $startup['bootstrap']);
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function parseUnknownSwtich() {
     Runtime::parseArguments(['-@']);
   }

--- a/src/test/php/net/xp_framework/unittest/core/RuntimeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/RuntimeTest.class.php
@@ -1,6 +1,9 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\Runtime;
+use lang\RuntimeOptions;
+use lang\Process;
+use lang\XPClass;
 use lang\FormatException;
 
 class RuntimeTest extends \unittest\TestCase {
@@ -14,16 +17,14 @@ class RuntimeTest extends \unittest\TestCase {
    * @throws unittest.AssertionFailedError
    */
   private function assertArguments($expected, $actual) {
-    if (defined('HHVM_VERSION')) {
-      array_unshift($expected, '--php');
-    }
+    defined('HHVM_VERSION') && array_unshift($expected, '--php');
     $this->assertEquals($expected, $actual->asArguments());
   }
 
   #[@test]
   public function getExecutable() {
     $exe= Runtime::getInstance()->getExecutable();
-    $this->assertInstanceOf('lang.Process', $exe);
+    $this->assertInstanceOf(Process::class, $exe);
     $this->assertEquals(getmypid(), $exe->getProcessId());
   }
 
@@ -40,7 +41,7 @@ class RuntimeTest extends \unittest\TestCase {
   #[@test]
   public function startupOptions() {
     $startup= Runtime::getInstance()->startupOptions();
-    $this->assertInstanceOf('lang.RuntimeOptions', $startup);
+    $this->assertInstanceOf(RuntimeOptions::class, $startup);
   }
 
   #[@test]
@@ -65,7 +66,7 @@ class RuntimeTest extends \unittest\TestCase {
   #[@test]
   public function mainClass() {
     $main= Runtime::getInstance()->mainClass();
-    $this->assertInstanceOf('lang.XPClass', $main);
+    $this->assertInstanceOf(XPClass::class, $main);
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/core/SystemExitTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/SystemExitTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use unittest\TestCase;
 use lang\System;
+use lang\Object;
+use lang\ClassLoader;
 use lang\SystemExit;
 
 /**
@@ -9,15 +10,12 @@ use lang\SystemExit;
  *
  * @see      xp://lang.SystemExit
  */
-class SystemExitTest extends TestCase {
-  protected static $exiterClass= NULL;
+class SystemExitTest extends \unittest\TestCase {
+  protected static $exiterClass;
 
-  /**
-   * Defines Exiter class
-   */
   #[@beforeClass]
   public static function defineExiterClass() {
-    self::$exiterClass= \lang\ClassLoader::defineClass('net.xp_framework.unittest.core.Exiter', 'lang.Object', [], '{
+    self::$exiterClass= ClassLoader::defineClass('net.xp_framework.unittest.core.Exiter', Object::class, [], '{
       public function __construct() { throw new \lang\SystemExit(0); }
       public static function doExit() { new self(); }
     }');

--- a/src/test/php/net/xp_framework/unittest/core/TypeHintsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeHintsTest.class.php
@@ -1,6 +1,10 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use unittest\actions\RuntimeVersion;
+use lang\Generic;
+use lang\Object;
+use lang\Error;
+use lang\IllegalArgumentException;
 
 /**
  * Test type hints.
@@ -13,7 +17,7 @@ class TypeHintsTest extends \unittest\TestCase {
    * @param  lang.Generic $o
    * @return lang.Generic
    */
-  protected function pass(\lang\Generic $o) { return $o; }
+  protected function pass(Generic $o) { return $o; }
 
   /**
    * Pass a nullable object
@@ -21,47 +25,47 @@ class TypeHintsTest extends \unittest\TestCase {
    * @param  lang.Generic $o
    * @return lang.Generic
    */
-  protected function nullable(\lang\Generic $o= null) { return $o; }
+  protected function nullable(Generic $o= null) { return $o; }
 
 
   #[@test]
   public function pass_an_object() {
-    $o= new \lang\Object();
+    $o= new Object();
     $this->assertEquals($o, $this->pass($o));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function pass_a_primitive() {
     $this->pass(1);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function pass_null() {
     $this->pass(null);
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function pass_a_primitive7() {
     $this->pass(1);
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function pass_null7() {
     $this->pass(null);
   }
 
   #[@test]
   public function pass_object_to_nullable() {
-    $o= new \lang\Object();
+    $o= new Object();
     $this->assertEquals($o, $this->nullable($o));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function pass_a_primitive_to_nullable() {
     $this->nullable(1);
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function pass_a_primitive_to_nullable7() {
     $this->nullable(1);
   }

--- a/src/test/php/net/xp_framework/unittest/core/WildcardTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/WildcardTypeTest.class.php
@@ -7,12 +7,10 @@ use lang\Primitive;
 use lang\ArrayType;
 use lang\MapType;
 use lang\Type;
+use lang\IllegalArgumentException;
+use lang\IllegalAccessException;
+use lang\ClassCastException;
 
-/**
- * TestCase
- *
- * @see      xp://lang.WildcardType
- */
 class WildcardTypeTest extends \unittest\TestCase {
 
   #[@test]
@@ -42,7 +40,7 @@ class WildcardTypeTest extends \unittest\TestCase {
     $this->assertEquals($components, (new WildcardType($base, $components))->components());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values([
+  #[@test, @expect(IllegalArgumentException::class), @values([
   #  'util.collections.Vector',
   #  'int',
   #  'string[]',
@@ -192,7 +190,7 @@ class WildcardTypeTest extends \unittest\TestCase {
     $this->assertFalse(WildcardType::forName('util.collections.Vector<?>')->isAssignableFrom($value));
   }
 
-  #[@test, @expect('lang.ClassCastException'), @values('hashTableOfAny')]
+  #[@test, @expect(ClassCastException::class), @values('hashTableOfAny')]
   public function generic_hashtables_cannot_be_cast_to_vector_of_any($value) {
     WildcardType::forName('util.collections.Vector<?>')->cast($value->newInstance());
   }
@@ -207,7 +205,7 @@ class WildcardTypeTest extends \unittest\TestCase {
     $this->assertFalse(WildcardType::forName('util.collections.Vector<?>')->isAssignableFrom($value));
   }
 
-  #[@test, @expect('lang.ClassCastException'), @values('unGenericInstances')]
+  #[@test, @expect(ClassCastException::class), @values('unGenericInstances')]
   public function ungeneric_instancess_cannot_be_cast_to_vector_of_any($value) {
     WildcardType::forName('util.collections.Vector<?>')->cast($value);
   }
@@ -269,7 +267,7 @@ class WildcardTypeTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function wildcard_types_cannot_be_instantiated() {
     Type::forName('util.collections.Vector<?>')->newInstance();
   }

--- a/src/test/php/net/xp_framework/unittest/core/WithTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/WithTest.class.php
@@ -1,22 +1,23 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\Object;
+use lang\Closeable;
 use lang\ClassLoader;
+use lang\IllegalStateException;
 
 /**
  * Tests with() functionality
  */
 class WithTest extends \unittest\TestCase {
-  protected static $closes= null;
-  protected static $raises= null;
+  private static $closes, $raises;
 
   #[@beforeClass]
   public static function defineCloseableSubclasses() {
-    self::$closes= ClassLoader::defineClass('_WithTest_C0', 'lang.Object', ['lang.Closeable'], '{
+    self::$closes= ClassLoader::defineClass('_WithTest_C0', Object::class, [Closeable::class], '{
       public $closed= false;
       public function close() { $this->closed= true; }
     }');
-    self::$raises= ClassLoader::defineClass('_WithTest_C1', 'lang.Object', ['lang.Closeable'], '{
+    self::$raises= ClassLoader::defineClass('_WithTest_C1', Object::class, [Closeable::class], '{
       public function close() { throw new \lang\IllegalArgumentException("Cannot close"); }
     }');
   }
@@ -24,14 +25,14 @@ class WithTest extends \unittest\TestCase {
   #[@test]
   public function backwards_compatible_usage_without_closure() {
     with ($f= new Object()); {
-      $this->assertInstanceOf('lang.Object', $f);
+      $this->assertInstanceOf(Object::class, $f);
     }
   }
 
   #[@test]
   public function new_usage_with_closure() {
     with (new Object(), function($f) {
-      $this->assertInstanceOf('lang.Object', $f);
+      $this->assertInstanceOf(Object::class, $f);
     });
   }
 
@@ -67,10 +68,10 @@ class WithTest extends \unittest\TestCase {
     $b= self::$closes->newInstance();
     try {
       with ($a, $b, function() {
-        throw new \lang\IllegalStateException('Test');
+        throw new IllegalStateException('Test');
       });
       $this->fail('No exception thrown', null, 'lang.IllegalStateException');
-    } catch (\lang\IllegalStateException $expected) {
+    } catch (IllegalStateException $expected) {
       $this->assertEquals([true, true], [$a->closed, $b->closed]);
     }
   }

--- a/src/test/php/net/xp_framework/unittest/core/extensions/ExtensionInvocationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/extensions/ExtensionInvocationTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\extensions;
 
-use unittest\TestCase;
+use lang\Error;
+use lang\Throwable;
 use lang\types\ArrayList;
 new import('net.xp_framework.unittest.core.extensions.ArrayListExtensions');
 new import('net.xp_framework.unittest.core.extensions.ThrowableExtensions');
@@ -12,7 +13,7 @@ new import('net.xp_framework.unittest.core.extensions.ThrowableExtensions');
  * @see   xp://net.xp_framework.unittest.core.extensions.ThrowableExtensions
  * @see   https://github.com/xp-framework/xp-framework/issues/137
  */
-class ExtensionInvocationTest extends TestCase {
+class ExtensionInvocationTest extends \unittest\TestCase {
 
   #[@test]
   public function mapMethod() {
@@ -30,14 +31,14 @@ class ExtensionInvocationTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.Error')]
+  #[@test, @expect(Error::class)]
   public function nonExistantExtensionMethod() {
     (new ArrayList(1, 2, 3))->nonExistant();
   }
 
   #[@test]
   public function throwabeExtensions() {
-    $t= new \lang\Throwable('Test');
+    $t= new Throwable('Test');
     $this->assertNotEquals([], $t->getStackTrace());
     $t->clearStackTrace();
     $this->assertEquals([], $t->getStackTrace());

--- a/src/test/php/net/xp_framework/unittest/core/extensions/NotImportedHereTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/extensions/NotImportedHereTest.class.php
@@ -1,22 +1,18 @@
 <?php namespace net\xp_framework\unittest\core\extensions;
 
-use unittest\TestCase;
+use lang\Error;
 use lang\types\ArrayList;
 
 /**
- * TestCase
+ * Tests situation when ArrayListExtensions hasn't been imported here
+ * but inside another class which is imported here.
  *
  * @see   xp://net.xp_framework.unittest.core.extensions.ArrayListExtensions
  * @see   xp://net.xp_framework.unittest.core.extensions.ArrayListDemo
  */
-class NotImportedHereTest extends TestCase {
+class NotImportedHereTest extends \unittest\TestCase {
 
-  /**
-   * Tests situation when ArrayListExtensions hasn't been imported here
-   * but inside another class which is imported here.
-   *
-   */
-  #[@test, @expect('lang.Error')]
+  #[@test, @expect(Error::class)]
   public function test() {
     (new ArrayList(7, 0, 10, 1, -1))->sorted();
   }

--- a/src/test/php/net/xp_framework/unittest/core/extensions/NotImportedTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/extensions/NotImportedTest.class.php
@@ -1,20 +1,16 @@
 <?php namespace net\xp_framework\unittest\core\extensions;
 
-use unittest\TestCase;
 use lang\types\ArrayList;
+use lang\Error;
 
 /**
- * TestCase
+ * Tests situation when ArrayListExtensions hasn't been imported
  *
  * @see   xp://net.xp_framework.unittest.core.extensions.ArrayListExtensions
  */
-class NotImportedTest extends TestCase {
+class NotImportedTest extends \unittest\TestCase {
 
-  /**
-   * Tests situation when ArrayListExtensions hasn't been imported
-   *
-   */
-  #[@test, @expect('lang.Error')]
+  #[@test, @expect(Error::class)]
   public function test() {
     (new ArrayList(7, 0, 10, 1, -1))->sorted();
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/AbstractDefinitionReflectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/AbstractDefinitionReflectionTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\XPClass;
 use lang\Primitive;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase for definition reflection
@@ -93,17 +94,17 @@ abstract class AbstractDefinitionReflectionTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function missingArguments() {
     $this->fixture->newGenericType([]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function missingArgument() {
     $this->fixture->newGenericType([$this->getClass()]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function tooManyArguments() {
     $c= $this->getClass();
     $this->fixture->newGenericType([$c, $c, $c]);

--- a/src/test/php/net/xp_framework/unittest/core/generics/ArrayTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/ArrayTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
+use lang\IllegalArgumentException;
+
 /**
  * TestCase for generic behaviour at runtime.
  *
@@ -22,7 +24,7 @@ class ArrayTest extends \unittest\TestCase {
     $this->assertEquals($this, $l->get(['this']));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringToArrayOfStringInvalid() {
     create('new net.xp_framework.unittest.core.generics.Lookup<string, string[]>')
       ->put('greeting', ['Hello', 'World', '!!!', 1])

--- a/src/test/php/net/xp_framework/unittest/core/generics/GenericTypesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/GenericTypesTest.class.php
@@ -8,7 +8,7 @@ use lang\XPClass;
  * TestCase for lang.GenericTypes
  */
 class GenericTypesTest extends \unittest\TestCase {
-  protected static $filter;
+  private static $filter;
 
   #[@beforeClass]
   public static function defineBase() {
@@ -26,7 +26,7 @@ class GenericTypesTest extends \unittest\TestCase {
   #[@test]
   public function newType_returns_XPClass_instance() {
     $this->assertInstanceOf(
-      'lang.XPClass',
+      XPClass::class,
       (new GenericTypes())->newType(self::$filter, [Primitive::$INT])
     );
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/ImplementationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/ImplementationTest.class.php
@@ -4,6 +4,7 @@ use lang\Type;
 use lang\Primitive;
 use lang\XPClass;
 use lang\ElementNotFoundException;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase for instance reflection
@@ -61,7 +62,7 @@ class ImplementationTest extends \unittest\TestCase {
     $fixture->put(Primitive::$STRING, 'string');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function putInvalid() {
     $fixture= create('new net.xp_framework.unittest.core.generics.TypeDictionary<string>');
     $fixture->put($this, 'string');

--- a/src/test/php/net/xp_framework/unittest/core/generics/NotGenericTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/NotGenericTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
+use lang\IllegalStateException;
+
 /**
  * TestCase for reflection on a non-generic
- *
  */
 class NotGenericTest extends \unittest\TestCase {
   
@@ -16,17 +17,17 @@ class NotGenericTest extends \unittest\TestCase {
     $this->assertFalse($this->getClass()->isGenericDefinition());
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function cannotCreateGenericTypeFromThis() {
     $this->getClass()->newGenericType([]);
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function cannotGetGenericArgumentsForThis() {
     $this->getClass()->genericArguments();
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function cannotGetGenericComponentsForThis() {
     $this->getClass()->genericComponents();
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/PrimitivesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/PrimitivesTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\XPClass;
 use lang\Primitive;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase for generic behaviour at runtime.
@@ -25,13 +26,13 @@ class PrimitivesTest extends \unittest\TestCase {
     $this->assertEquals('this', $l->get($this));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function primitiveVerification() {
     $l= create('new net.xp_framework.unittest.core.generics.Lookup<string, unittest.TestCase>()');
     $l->put(1, $this);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function instanceVerification() {
     $l= create('new net.xp_framework.unittest.core.generics.Lookup<string, unittest.TestCase>()');
     $l->put($this, $this);

--- a/src/test/php/net/xp_framework/unittest/core/generics/VarArgsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/VarArgsTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
+use lang\IllegalArgumentException;
+
 /**
  * TestCase for generic construction behaviour at runtime.
  *
@@ -23,7 +25,7 @@ class VarArgsTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function withIncorrectArguments() {
     create('new net.xp_framework.unittest.core.generics.ListOf<string>', 'Hello', 1);
   }

--- a/src/test/php/net/xp_framework/unittest/core/types/ArrayListTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/ArrayListTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\types;
 
 use lang\types\ArrayList;
+use lang\IllegalArgumentException;
 use lang\IndexOutOfBoundsException;
 use net\xp_framework\unittest\Name;
 
@@ -86,7 +87,7 @@ class ArrayListTest extends \unittest\TestCase {
     $this->assertEquals(4, $c[2]);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function reading_non_existant_element_raises_an_exception() {
     $c= new ArrayList();
     $c[0];
@@ -97,25 +98,25 @@ class ArrayListTest extends \unittest\TestCase {
     $this->assertNull((new ArrayList())->get(0, null));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function adding_an_element_raises_an_exception() {
     $c= new ArrayList();
     $c[]= 4;
   }
 
-  #[@test, @values([0, 4]), @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @values([0, 4]), @expect(IndexOutOfBoundsException::class)]
   public function adding_an_element_by_supplying_nonexistant_offset_raises_an_exception($offset) {
     $c= new ArrayList();
     $c[$offset]= 4;
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function negative_key_raises_an_exception() {
     $c= new ArrayList();
     $c[-1]= 4;
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function key_of_incorrect_type_raises_an_exception() {
     $c= new ArrayList(1, 2, 3);
     $c['foo']= 4;
@@ -158,7 +159,7 @@ class ArrayListTest extends \unittest\TestCase {
     $this->assertFalse(isset($c[$offset]));
   }
 
-  #[@test, @values([0, 1, 2, 3, 4, -1]), @expect('lang.IllegalArgumentException')]
+  #[@test, @values([0, 1, 2, 3, 4, -1]), @expect(IllegalArgumentException::class)]
   public function array_unset_operator_is_overloaded() {
     $c= new ArrayList(1, 2, 3);
     unset($c[0]);

--- a/src/test/php/net/xp_framework/unittest/core/types/ArrayMapTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/ArrayMapTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\types\ArrayMap;
 use lang\IndexOutOfBoundsException;
+use lang\IllegalArgumentException;
 use net\xp_framework\unittest\Name;
 
 /**
@@ -66,7 +67,7 @@ class ArrayMapTest extends \unittest\TestCase {
     $this->assertEquals('Test', (new ArrayMap(['key' => 'Test']))['key']);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function accessing_non_existant_key_raises_an_exception() {
     (new ArrayMap([]))['key'];
   }
@@ -95,7 +96,7 @@ class ArrayMapTest extends \unittest\TestCase {
     $this->assertEquals('Written', $map['key']);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function adding_values_is_forbidden() {
     $map= new ArrayMap([]);
     $map[]= 'Forbidden';

--- a/src/test/php/net/xp_framework/unittest/core/types/BooleanTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/BooleanTest.class.php
@@ -1,8 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\types;
 
-use unittest\TestCase;
 use lang\types\Boolean;
-
+use lang\IllegalArgumentException;
 
 /**
  * Tests the boolean wrapper type
@@ -10,7 +9,7 @@ use lang\types\Boolean;
  * @deprecated Wrapper types will move to their own library
  * @see      xp://lang.types.Boolean
  */
-class BooleanTest extends TestCase {
+class BooleanTest extends \unittest\TestCase {
 
   #[@test]
   public function trueBoolPrimitiveIsTrue() {
@@ -87,17 +86,17 @@ class BooleanTest extends TestCase {
     $this->assertEquals(Boolean::$FALSE, new Boolean('0'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function emptyStringIsNotAValidBoolean() {
     new Boolean('');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function misspelledFalse() {
     new Boolean('fals3');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function doublePrimitiveIsNotAValidBoolean() {
     new Boolean(1.0);
   }

--- a/src/test/php/net/xp_framework/unittest/core/types/BytesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/BytesTest.class.php
@@ -4,6 +4,9 @@ use lang\types\Bytes;
 use lang\types\String;
 use lang\types\Character;
 use lang\types\Byte;
+use lang\FormatException;
+use lang\IllegalArgumentException;
+use lang\IndexOutOfBoundsException;
 
 /**
  * TestCase for Bytes class
@@ -68,7 +71,7 @@ class BytesTest extends \unittest\TestCase {
     $this->assertEquals(new Byte(100), $b[3]);
   }
  
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function illegalConstructorArgument() {
     new Bytes(1);
   }
@@ -139,25 +142,25 @@ class BytesTest extends \unittest\TestCase {
     $this->assertEquals(new Byte(3), $b[0]);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function setNegative() {
     $b= new Bytes('negative');
     $b[-1]= new Byte(3);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function setPastEnd() {
     $b= new Bytes('ends');
     $b[5]= new Byte(3);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function getNegative() {
     $b= new Bytes('negative');
     $read= $b[-1];
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function getPastEnd() {
     $b= new Bytes('ends');
     $read= $b[5];
@@ -193,13 +196,13 @@ class BytesTest extends \unittest\TestCase {
     $this->assertEquals(new Bytes('GIF9a'), $b);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function removingNegative() {
     $b= new Bytes('negative');
     unset($b[-1]);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function removingPastEnd() {
     $b= new Bytes('ends');
     unset($b[5]);
@@ -302,7 +305,7 @@ class BytesTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function string_from_invalid_utf8_bytes() {
     new String(new Bytes("H\344llo"), 'utf-8');
   }

--- a/src/test/php/net/xp_framework/unittest/core/types/CharacterTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/CharacterTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace net\xp_framework\unittest\core\types;
 
-use unittest\TestCase;
 use lang\types\String;
 use lang\types\Character;
 use lang\types\Bytes;
+use lang\FormatException;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
@@ -11,9 +12,9 @@ use lang\types\Bytes;
  * @deprecated Wrapper types will move to their own library
  * @see  xp://lang.types.Character
  */
-class CharacterTest extends TestCase {
+class CharacterTest extends \unittest\TestCase {
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function incompleteMultiByteCharacter() {
     new Character("\xe4", 'utf-8');
   }
@@ -28,12 +29,12 @@ class CharacterTest extends TestCase {
     $this->assertEquals(new Bytes("\xe2\x82\xac"), (new Character(8364))->getBytes('utf-8')); // &#8364; in HTML
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function illegalCharacter() {
     new Character("\xe4", 'US-ASCII');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function illegalLength() {
     new Character('ABC');
   }

--- a/src/test/php/net/xp_framework/unittest/core/types/NumberTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/NumberTest.class.php
@@ -1,11 +1,13 @@
 <?php namespace net\xp_framework\unittest\core\types;
 
+use lang\types\Number;
 use lang\types\Long;
 use lang\types\Byte;
 use lang\types\Short;
 use lang\types\Integer;
 use lang\types\Float;
 use lang\types\Double;
+use lang\IllegalArgumentException;
 
 /**
  * Tests the number wrapper typess
@@ -27,7 +29,7 @@ class NumberTest extends \unittest\TestCase {
    * @param   int int
    * @param   float float
    */
-  protected function testType(\lang\types\Number $number, $int, $float) {
+  protected function testType(Number $number, $int, $float) {
     $this->assertEquals($int, $number->intValue(), 'intValue');
     $this->assertEquals($float, $number->doubleValue(), 'doubleValue');
     $this->assertEquals($number, clone($number), 'clone');
@@ -125,92 +127,92 @@ class NumberTest extends \unittest\TestCase {
     $this->assertEquals(43690, $long->intValue());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringIsNotANumber() {
     Long::valueOf('string');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function booleanIsNotANumber() {
     Long::valueOf(true);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function nullIsNotANumber() {
     Long::valueOf(null);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function writtenNumberIsNotANumber() {
     Long::valueOf('one');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function commaNotationIsNotANumber() {
     Long::valueOf('1,1');
   }
 
-  #[@test, @values(['1E+', '1E-', '1E', 'E+4', 'E-4', 'E4', 'E']), @expect('lang.IllegalArgumentException')]
+  #[@test, @values(['1E+', '1E-', '1E', 'E+4', 'E-4', 'E4', 'E']), @expect(IllegalArgumentException::class)]
   public function brokenExponentNotationIsNotANumber($value) {
     Long::valueOf($value);
   }
 
-  #[@test, @values(['..5', '--1', '++1']), @expect('lang.IllegalArgumentException')]
+  #[@test, @values(['..5', '--1', '++1']), @expect(IllegalArgumentException::class)]
   public function doubleLeadingSignsAreNotNumeric($value) {
     Long::valueOf($value);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function leadingLetterIsNotANumber() {
     Long::valueOf('a123');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function currencyValueIsNotANumber() {
     Long::valueOf('$44.00');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function whitespaceSeparatedNumbersAreNotNumeric() {
     Long::valueOf('4 4');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function floatingPointNumberIsNotLong() {
     Long::valueOf(4.4);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function floatingPointInStringIsNotLong() {
     Long::valueOf('4.4');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function floatingPointNumberIsNotInteger() {
     Integer::valueOf(4.4);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function floatingPointInStringIsNotInteger() {
     Integer::valueOf('4.4');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function floatingPointNumberIsNotShort() {
     Short::valueOf(4.4);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function floatingPointInStringIsNotShort() {
     Short::valueOf('4.4');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function floatingPointNumberIsNotByte() {
     Byte::valueOf(4.4);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function floatingPointInStringIsNotByte() {
     Byte::valueOf('4.4');
   }

--- a/src/test/php/net/xp_framework/unittest/core/types/StringTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/types/StringTest.class.php
@@ -1,6 +1,9 @@
 <?php namespace net\xp_framework\unittest\core\types;
 
 use lang\types\String;
+use lang\FormatException;
+use lang\IllegalArgumentException;
+use lang\IndexOutOfBoundsException;
 
 /**
  * TestCase for String class
@@ -26,12 +29,12 @@ class StringTest extends \unittest\TestCase {
     $this->assertFalse((new String('ABC'))->equals(new String('CBA')));
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function incompleteMultiByteCharacter() {
     new String("\303|", 'utf-8');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function illegalCharacter() {
     new String('ä', 'US-ASCII');
   }
@@ -213,17 +216,17 @@ class StringTest extends \unittest\TestCase {
     $this->assertEquals(new \lang\types\Character('ü'), (new String('www.müller.com'))->charAt(5));
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function charAtNegative() {
     (new String('ABC'))->charAt(-1);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function charAtAfterEnd() {
     (new String('ABC'))->charAt(4);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function charAtEnd() {
     (new String('ABC'))->charAt(3);
   }
@@ -242,25 +245,25 @@ class StringTest extends \unittest\TestCase {
     $this->assertEquals(new String('www.muller.com'), $str);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function offsetSetNegative() {
     $str= new String('www.müller.com');
     $str[-1]= 'u';
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function offsetSetAfterEnd() {
     $str= new String('www.müller.com');
     $str[$str->length()]= 'u';
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function offsetSetIncorrectLength() {
     $str= new String('www.müller.com');
     $str[5]= 'ue';
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function offsetAdd() {
     $str= new String('www.müller.com');
     $str[]= '.';
@@ -302,13 +305,13 @@ class StringTest extends \unittest\TestCase {
     $this->assertEquals(new String('www.mller.com'), $str);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function offsetUnsetNegative() {
     $str= new String('www.müller.com');
     unset($str[-1]);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function offsetUnsetAfterEnd() {
     $str= new String('www.müller.com');
     unset($str[1024]);
@@ -334,7 +337,7 @@ class StringTest extends \unittest\TestCase {
     ));
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function getUmlautsAsAsciiBytes() {
     (new String('äöü', 'iso-8859-1'))->getBytes('ASCII');
   }

--- a/src/test/php/net/xp_framework/unittest/io/EncapsedStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/EncapsedStreamTest.class.php
@@ -1,17 +1,13 @@
 <?php namespace net\xp_framework\unittest\io;
 
-use unittest\TestCase;
 use io\EncapsedStream;
 use io\File;
 use io\streams\Streams;
 use io\streams\MemoryInputStream;
+use lang\IllegalAccessException;
+use lang\IllegalStateException;
 
-/**
- * TestCase
- *
- * @see   xp://io.EncapsedStream
- */
-class EncapsedStreamTest extends TestCase {
+class EncapsedStreamTest extends \unittest\TestCase {
     
   /**
    * Returns a new EncapsedStream instance
@@ -26,7 +22,7 @@ class EncapsedStreamTest extends TestCase {
     );
   }
   
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function file_given_must_be_open() {
     new EncapsedStream(new File('irrelevant.txt'), 0, 0);
   }
@@ -36,7 +32,7 @@ class EncapsedStreamTest extends TestCase {
     $this->newStream()->open(File::READ);
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function cannot_open_for_writing() {
     $this->newStream()->open(File::WRITE);
   }

--- a/src/test/php/net/xp_framework/unittest/io/FileIntegrationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/FileIntegrationTest.class.php
@@ -2,14 +2,12 @@
 
 use io\File;
 use io\Folder;
+use io\IOException;
+use io\FileNotFoundException;
 use lang\System;
+use lang\IllegalStateException;
 use unittest\PrerequisitesNotMetError;
 
-/**
- * TestCase
- *
- * @see      xp://io.File
- */
 class FileIntegrationTest extends \unittest\TestCase {
   protected static $temp= null;
   protected $file= null;
@@ -141,18 +139,18 @@ class FileIntegrationTest extends \unittest\TestCase {
     $this->assertFalse($this->file->exists());
   }
   
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function cannotDeleteNonExistant() {
     $this->file->unlink();
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function cannotDeleteOpenFile() {
     $this->file->open(File::WRITE);
     $this->file->unlink();
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function cannotCloseUnopenedFile() {
     $this->file->close();
   }
@@ -345,7 +343,7 @@ class FileIntegrationTest extends \unittest\TestCase {
     }
   }
 
-  #[@test, @expect('io.FileNotFoundException')]
+  #[@test, @expect(FileNotFoundException::class)]
   public function cannotOpenNonExistantForReading() {
     $this->file->open(File::READ);
   }
@@ -381,7 +379,7 @@ class FileIntegrationTest extends \unittest\TestCase {
     }
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function cannotCopyOpenFile() {
     $this->file->open(File::WRITE);
     $this->file->copy('irrelevant');
@@ -426,7 +424,7 @@ class FileIntegrationTest extends \unittest\TestCase {
     }
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function cannotMoveOpenFile() {
     $this->file->open(File::WRITE);
     $this->file->move('irrelevant');

--- a/src/test/php/net/xp_framework/unittest/io/FileTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/FileTest.class.php
@@ -1,17 +1,17 @@
 <?php namespace net\xp_framework\unittest\io;
 
-use unittest\TestCase;
 use io\Folder;
 use io\File;
 use io\Path;
 use lang\Runtime;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
  *
  * @see      xp://io.File
  */
-class FileTest extends TestCase {
+class FileTest extends \unittest\TestCase {
 
   /**
    * Return a file that is known to exist
@@ -104,27 +104,27 @@ class FileTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function nulCharacterNotAllowedInFilename() {
     new File("editor.txt\0.html");
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function nulCharacterNotInTheBeginningOfFilename() {
     new File("\0editor.txt");
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function emptyFilenameNotAllowed() {
     new File('');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function nullFilenameNotAllowed() {
     new File(null);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function filterScheme() {
     new File('php://filter/read=string.toupper|string.rot13/resource=http://www.example.comn');
   }

--- a/src/test/php/net/xp_framework/unittest/io/FolderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/FolderTest.class.php
@@ -1,18 +1,14 @@
 <?php namespace net\xp_framework\unittest\io;
 
 use io\Folder;
+use io\FolderEntries;
 use io\Path;
 use io\IOException;
 use lang\System;
 use unittest\PrerequisitesNotMetError;
 
-/**
- * TestCase
- *
- * @see      xp://io.Folder
- */
 class FolderTest extends \unittest\TestCase {
-  protected $temp= '';
+  private $temp;
   
   /**
    * Normalizes path by adding a trailing slash to the end if not already
@@ -185,7 +181,7 @@ class FolderTest extends \unittest\TestCase {
 
   #[@test]
   public function entries() {
-    $this->assertInstanceOf('io.FolderEntries', (new Folder($this->temp))->entries());
+    $this->assertInstanceOf(FolderEntries::class, (new Folder($this->temp))->entries());
   }
 
   #[@test, @expect(IOException::class)]

--- a/src/test/php/net/xp_framework/unittest/io/StreamWrappingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/StreamWrappingTest.class.php
@@ -146,13 +146,13 @@ class StreamWrappingTest extends TestCase {
     $this->assertEquals($buffer, $m->getBytes());
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function reading_from_writeable_fd_raises_exception() {
     $fd= Streams::writeableFd(new MemoryOutputStream());
     fread($fd, 1024);
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function writing_to_readable_fd_raises_exception() {
     $fd= Streams::readableFd(new MemoryInputStream(''));
     fwrite($fd, 1024);
@@ -163,7 +163,7 @@ class StreamWrappingTest extends TestCase {
     $this->assertEquals($value, Streams::readAll(new MemoryInputStream($value)));
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function readAll_propagates_exception() {
     Streams::readAll(newinstance(InputStream::class, [], [
       'read'      => function($limit= 8192) { throw new IOException('FAIL'); },

--- a/src/test/php/net/xp_framework/unittest/io/collections/ArchiveCollectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/ArchiveCollectionTest.class.php
@@ -1,21 +1,17 @@
 <?php namespace net\xp_framework\unittest\io\collections;
 
-use unittest\TestCase;
 use io\TempFile;
-use lang\archive\Archive;
+use io\IOException;
 use io\collections\ArchiveCollection;
+use lang\archive\Archive;
 
-/**
- * TestCase
- *
- * @see  xp://io.collections.ArchiveCollection
- */
-class ArchiveCollectionTest extends TestCase {
-  protected $file= null;
-  protected $archive= null;
+class ArchiveCollectionTest extends \unittest\TestCase {
+  private $file, $archive;
 
   /**
    * Sets up test case (creates temporary xar archive)
+   *
+   * @return void
    */
   public function setUp() {
     $this->file= new TempFile();
@@ -33,12 +29,14 @@ class ArchiveCollectionTest extends TestCase {
   
   /**
    * Tears down test case (removes temporary xar archive)
+   *
+   * @return void
    */
   public function tearDown() {
     try {
       $this->file->isOpen() && $this->file->close();
       $this->file->unlink();
-    } catch (\io\IOException $ignored) {
+    } catch (IOException $ignored) {
       // Can't really do much about it..
     }
   }
@@ -130,17 +128,17 @@ class ArchiveCollectionTest extends TestCase {
     }
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function writeObjectEntry() {
     $this->firstElement(new ArchiveCollection($this->archive, 'lang'))->getOutputStream();
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function readLangEntry() {
     $this->firstElement(new ArchiveCollection($this->archive))->getInputStream();
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function writeLangEntry() {
     $this->firstElement(new ArchiveCollection($this->archive))->getOutputStream();
   }

--- a/src/test/php/net/xp_framework/unittest/io/collections/ArchiveCollectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/ArchiveCollectionTest.class.php
@@ -3,6 +3,8 @@
 use io\TempFile;
 use io\IOException;
 use io\collections\ArchiveCollection;
+use io\collections\IOElement;
+use io\collections\IOCollection;
 use lang\archive\Archive;
 
 class ArchiveCollectionTest extends \unittest\TestCase {
@@ -59,7 +61,7 @@ class ArchiveCollectionTest extends \unittest\TestCase {
     try {
       $c->open();
       $first= $c->next();
-      $this->assertInstanceOf('io.collections.IOCollection', $first);
+      $this->assertInstanceOf(IOCollection::class, $first);
       $this->assertXarUri('lang/', $first->getURI());
       $this->assertEquals(0, $first->getSize());
       $this->assertEquals(null, $c->next());
@@ -75,11 +77,11 @@ class ArchiveCollectionTest extends \unittest\TestCase {
     try {
       $c->open();
       $expect= [
-        'lang/Object.xp'    => 'io.collections.IOElement', 
-        'lang/Type.xp'      => 'io.collections.IOElement',
-        'lang/reflect/'     => 'io.collections.IOCollection',
-        'lang/types/'       => 'io.collections.IOCollection',
-        'lang/Runnable.xp'  => 'io.collections.IOElement',
+        'lang/Object.xp'    => IOElement::class,
+        'lang/Type.xp'      => IOElement::class,
+        'lang/reflect/'     => IOCollection::class,
+        'lang/types/'       => IOCollection::class,
+        'lang/Runnable.xp'  => IOElement::class
       ];
       for (reset($expect); $element= $c->next(), $name= key($expect); next($expect)) {
         $this->assertInstanceOf($expect[$name], $element);

--- a/src/test/php/net/xp_framework/unittest/io/collections/CollectionCompositeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/CollectionCompositeTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\io\collections;
 
 use io\collections\CollectionComposite;
+use io\collections\IOElement;
 use lang\IllegalArgumentException;
 
 /**
@@ -19,7 +20,7 @@ class CollectionCompositeTest extends AbstractCollectionTest {
    * @throws  unittest.AssertionFailedError
    */
   protected function assertElement($uri, $element) {
-    $this->assertInstanceOf('io.collections.IOElement', $element);
+    $this->assertInstanceOf(IOElement::class, $element);
     $this->assertEquals($uri, $element->getURI());
   }
   

--- a/src/test/php/net/xp_framework/unittest/io/collections/CollectionCompositeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/CollectionCompositeTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\io\collections;
 
 use io\collections\CollectionComposite;
+use lang\IllegalArgumentException;
 
 /**
  * Unit tests for CollectionComposite class
@@ -32,7 +33,7 @@ class CollectionCompositeTest extends AbstractCollectionTest {
     return $this->newCollection($name, []);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function constructorThrowsExceptionForEmptyList() {
     new CollectionComposite([]);
   }

--- a/src/test/php/net/xp_framework/unittest/io/collections/IOCollectionIteratorTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/IOCollectionIteratorTest.class.php
@@ -16,6 +16,7 @@ use io\collections\iterate\UriMatchesFilter;
 use io\collections\iterate\SizeBiggerThanFilter;
 use io\collections\iterate\SizeEqualsFilter;
 use io\collections\iterate\SizeSmallerThanFilter;
+use io\collections\IOElement;
 use util\Filters;
 
 /**
@@ -48,7 +49,7 @@ class IOCollectionIteratorTest extends AbstractCollectionTest {
   public function iteration() {
     for ($it= new IOCollectionIterator($this->fixture), $i= 0; $it->hasNext(); $i++) {
       $element= $it->next();
-      $this->assertInstanceOf('io.collections.IOElement', $element);
+      $this->assertInstanceOf(IOElement::class, $element);
     }
     $this->assertEquals($this->sizes[$this->fixture->getURI()], $i);
   }
@@ -57,7 +58,7 @@ class IOCollectionIteratorTest extends AbstractCollectionTest {
   public function recursiveIteration() {
     for ($it= new IOCollectionIterator($this->fixture, true), $i= 0; $it->hasNext(); $i++) {
       $element= $it->next();
-      $this->assertInstanceOf('io.collections.IOElement', $element);
+      $this->assertInstanceOf(IOElement::class, $element);
     }
     $this->assertEquals($this->total, $i);
   }
@@ -65,7 +66,7 @@ class IOCollectionIteratorTest extends AbstractCollectionTest {
   #[@test]
   public function foreachLoop() {
     foreach (new IOCollectionIterator($this->fixture) as $i => $element) {
-      $this->assertInstanceOf('io.collections.IOElement', $element);
+      $this->assertInstanceOf(IOElement::class, $element);
     }
     $this->assertEquals($this->sizes[$this->fixture->getURI()]- 1, $i);
   }
@@ -73,7 +74,7 @@ class IOCollectionIteratorTest extends AbstractCollectionTest {
   #[@test]
   public function foreachLoopRecursive() {
     foreach (new IOCollectionIterator($this->fixture, true) as $i => $element) {
-      $this->assertInstanceOf('io.collections.IOElement', $element);
+      $this->assertInstanceOf(IOElement::class, $element);
     }
     $this->assertEquals($this->total- 1, $i);
   }

--- a/src/test/php/net/xp_framework/unittest/io/collections/IOCollectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/IOCollectionTest.class.php
@@ -1,6 +1,9 @@
 <?php namespace net\xp_framework\unittest\io\collections;
 
 use io\collections\IOCollection;
+use io\collections\IOElement;
+use io\streams\InputStream;
+use io\streams\OutputStream;
 use io\IOException;
 use lang\IllegalStateException;
 use lang\IllegalArgumentException;
@@ -74,7 +77,7 @@ class IOCollectionTest extends AbstractCollectionTest {
   public function next_returns_IOElement_instances() {
     $this->fixture->open();
     for ($i= 0; $e= $this->fixture->next(); $i++) {
-      $this->assertInstanceOf('io.collections.IOElement', $e);
+      $this->assertInstanceOf(IOElement::class, $e);
     }
     $this->assertEquals($this->sizes[$this->fixture->getURI()], $i);
     $this->fixture->close();
@@ -122,7 +125,7 @@ class IOCollectionTest extends AbstractCollectionTest {
   #[@test]
   public function get_elements_input_stream() {
     with ($stream= $this->firstElement($this->fixture)->getInputStream()); {
-      $this->assertInstanceOf('io.streams.InputStream', $stream);
+      $this->assertInstanceOf(InputStream::class, $stream);
       $this->assertNotEquals(0, $stream->available());
       $this->assertEquals('File contents', $stream->read(13));
     }
@@ -136,7 +139,7 @@ class IOCollectionTest extends AbstractCollectionTest {
   #[@test]
   public function get_elements_output_stream() {
     with ($stream= $this->firstElement($this->fixture)->getOutputStream()); {
-      $this->assertInstanceOf('io.streams.OutputStream', $stream);
+      $this->assertInstanceOf(OutputStream::class, $stream);
       $stream->write('File contents');
     }
   }

--- a/src/test/php/net/xp_framework/unittest/io/collections/IOCollectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/IOCollectionTest.class.php
@@ -1,6 +1,10 @@
 <?php namespace net\xp_framework\unittest\io\collections;
 
 use io\collections\IOCollection;
+use io\IOException;
+use lang\IllegalStateException;
+use lang\IllegalArgumentException;
+use util\NoSuchElementException;
 
 /**
  * Unit tests for IOCollection class (basic functionality)
@@ -52,13 +56,13 @@ class IOCollectionTest extends AbstractCollectionTest {
     $empty->close();
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function calling_next_before_opening_collection_raises_exception() {
     $c= new MockCollection('~');
     $c->next();
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function calling_next_after_closing_collection_raises_exception() {
     $c= new MockCollection('~');
     $c->open();
@@ -124,7 +128,7 @@ class IOCollectionTest extends AbstractCollectionTest {
     }
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function get_collections_input_stream() {
     $this->firstElement($this->newCollection('/', [$this->newCollection('/root')]))->getInputStream();
   }
@@ -137,7 +141,7 @@ class IOCollectionTest extends AbstractCollectionTest {
     }
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function get_collections_output_stream() {
     $this->firstElement($this->newCollection('/', [$this->newCollection('/root')]))->getOutputStream();
   }
@@ -159,7 +163,7 @@ class IOCollectionTest extends AbstractCollectionTest {
     $this->assertEquals($created, $this->fixture->getElement('new.txt'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function create_existing_element() {
     $this->fixture->newElement('first.txt');
   }
@@ -169,7 +173,7 @@ class IOCollectionTest extends AbstractCollectionTest {
     $this->assertEquals(new MockElement('./first.txt'), $this->fixture->getElement('first.txt'));
   }
 
-  #[@test, @expect('util.NoSuchElementException')]
+  #[@test, @expect(NoSuchElementException::class)]
   public function get_nonexistant_element() {
     $this->fixture->getElement('doesnotexist.txt');
   }
@@ -189,7 +193,7 @@ class IOCollectionTest extends AbstractCollectionTest {
     $this->assertEquals(new MockCollection('./sub'), $this->fixture->getCollection('sub'));
   }
 
-  #[@test, @expect('util.NoSuchElementException')]
+  #[@test, @expect(NoSuchElementException::class)]
   public function get_nonexistant_collection() {
     $this->fixture->getCollection('doesnotexist');
   }
@@ -201,7 +205,7 @@ class IOCollectionTest extends AbstractCollectionTest {
     $this->assertEquals($created, $this->fixture->getCollection('newdir'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function new_existing_collection() {
     $this->fixture->newCollection('sub');
   }

--- a/src/test/php/net/xp_framework/unittest/io/streams/ChannelStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/ChannelStreamTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
-use unittest\TestCase;
 use io\streams\ChannelOutputStream;
 use io\streams\ChannelInputStream;
+use io\IOException;
 use lang\Runnable;
 
 /**
@@ -11,76 +11,44 @@ use lang\Runnable;
  * @see      xp://io.streams.ChannelOutputStream
  * @see      xp://io.streams.ChannelInputStream
  */
-class ChannelStreamTest extends TestCase {
+class ChannelStreamTest extends \unittest\TestCase {
 
-  /**
-   * Test ChannelOutputStream constructed with an invalid channel name
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function invalidOutputChannelName() {
     new ChannelOutputStream('@@invalid@@');
   }
 
-  /**
-   * Test ChannelInputStream constructed with an invalid channel name
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function invalidInputChannelName() {
     new ChannelInputStream('@@invalid@@');
   }
   
-  /**
-   * Test "stdin" channel cannot be written to
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function stdinIsNotAnOutputStream() {
     new ChannelOutputStream('stdin');
   }
 
-  /**
-   * Test "input" channel cannot be written to
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function inputIsNotAnOutputStream() {
     new ChannelOutputStream('input');
   }
 
-  /**
-   * Test "stdout" channel cannot be read from
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function stdoutIsNotAnInputStream() {
     new ChannelInputStream('stdout');
   }
 
-  /**
-   * Test "stderr" channel cannot be read from
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function stderrIsNotAnInputStream() {
     new ChannelInputStream('stderr');
   }
 
-  /**
-   * Test "output" channel cannot be read from
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function outputIsNotAnInputStream() {
     new ChannelInputStream('outpit');
   }
 
-  /**
-   * Test writing to a closed channel results in an IOException
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function writeToClosedChannel() {
     ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
@@ -91,11 +59,7 @@ class ChannelStreamTest extends TestCase {
     ]));
   }
 
-  /**
-   * Test readin from a closed channel results in an IOException
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function readingFromClosedChannel() {
     ChannelWrapper::capture(newinstance(Runnable::class, [], [
       'run' => function() {
@@ -106,10 +70,6 @@ class ChannelStreamTest extends TestCase {
     ]));
   }
 
-  /**
-   * Test "output" channel
-   *
-   */
   #[@test]
   public function output() {
     $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
@@ -121,10 +81,6 @@ class ChannelStreamTest extends TestCase {
     $this->assertEquals('+OK Hello', $r['output']);
   }
 
-  /**
-   * Test "stdout" channel
-   *
-   */
   #[@test]
   public function stdout() {
     $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
@@ -136,10 +92,6 @@ class ChannelStreamTest extends TestCase {
     $this->assertEquals('+OK Hello', $r['stdout']);
   }
 
-  /**
-   * Test "stderr" channel
-   *
-   */
   #[@test]
   public function stderr() {
     $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
@@ -151,10 +103,6 @@ class ChannelStreamTest extends TestCase {
     $this->assertEquals('+OK Hello', $r['stderr']);
   }
 
-  /**
-   * Test "stdin" channel
-   *
-   */
   #[@test]
   public function stdin() {
     $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [
@@ -169,10 +117,6 @@ class ChannelStreamTest extends TestCase {
     $this->assertEquals('+OK Piped input', $r['stdout']);
   }
 
-  /**
-   * Test "input" channel
-   *
-   */
   #[@test]
   public function input() {
     $r= ChannelWrapper::capture(newinstance(Runnable::class, [], [

--- a/src/test/php/net/xp_framework/unittest/io/streams/FileInputStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/FileInputStreamTest.class.php
@@ -4,46 +4,41 @@ use unittest\TestCase;
 use io\streams\FileInputStream;
 use io\FileUtil;
 use io\TempFile;
+use io\IOException;
+use io\FileNotFoundException;
+use unittest\PrerequisitesNotMetError;
 
-/**
- * TestCase
- *
- * @see      xp://io.streams.FileInputStream
- */
 class FileInputStreamTest extends TestCase {
-  protected 
-    $file = null;
+  private $file;
 
   /**
    * Sets up test case - creates temporary file
    *
+   * @return void
    */
   public function setUp() {
     try {
       $this->file= new TempFile();
       FileUtil::setContents($this->file, 'Created by FileInputStreamTest');
-    } catch (\io\IOException $e) {
-      throw new \unittest\PrerequisitesNotMetError('Cannot write temporary file', $e, [$this->file]);
+    } catch (IOException $e) {
+      throw new PrerequisitesNotMetError('Cannot write temporary file', $e, [$this->file]);
     }
   }
   
   /**
    * Tear down this test case - removes temporary file
    *
+   * @return void
    */
   public function tearDown() {
     try {
       $this->file->isOpen() && $this->file->close();
       $this->file->unlink();
-    } catch (\io\IOException $ignored) {
+    } catch (IOException $ignored) {
       // Can't really do anything about it...
     }
   }
   
-  /**
-   * Test read() method
-   *
-   */
   #[@test]
   public function reading() {
     with ($stream= new FileInputStream($this->file)); {
@@ -53,10 +48,6 @@ class FileInputStreamTest extends TestCase {
     }
   }
 
-  /**
-   * Test seek() and tell() methods
-   *
-   */
   #[@test]
   public function seeking() {
     with ($stream= new FileInputStream($this->file)); {
@@ -67,10 +58,6 @@ class FileInputStreamTest extends TestCase {
     }
   }
 
-  /**
-   * Test available() method
-   *
-   */
   #[@test]
   public function availability() {
     with ($stream= new FileInputStream($this->file)); {
@@ -80,10 +67,6 @@ class FileInputStreamTest extends TestCase {
     }
   }
 
-  /**
-   * Test file remains open when FileInputStream instance is deleted
-   *
-   */
   #[@test]
   public function delete() {
     with ($stream= new FileInputStream($this->file)); {
@@ -93,20 +76,12 @@ class FileInputStreamTest extends TestCase {
     }
   }
 
-  /**
-   * Test opening a file input stream with a non-existant file name
-   *
-   */
-  #[@test, @expect('io.FileNotFoundException')]
+  #[@test, @expect(FileNotFoundException::class)]
   public function nonExistantFile() {
     new FileInputStream('::NON-EXISTANT::');
   }
 
-  /**
-   * Test reading after stream has been closed
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function readingAfterClose() {
     with ($stream= new FileInputStream($this->file)); {
       $stream->close();
@@ -114,11 +89,7 @@ class FileInputStreamTest extends TestCase {
     }
   }
 
-  /**
-   * Test availability after stream has been closed
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function availableAfterClose() {
     with ($stream= new FileInputStream($this->file)); {
       $stream->close();
@@ -126,10 +97,6 @@ class FileInputStreamTest extends TestCase {
     }
   }
 
-  /**
-   * Test closig an already closed stream
-   *
-   */
   #[@test]
   public function doubleClose() {
     with ($stream= new FileInputStream($this->file)); {

--- a/src/test/php/net/xp_framework/unittest/io/streams/FileOutputStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/FileOutputStreamTest.class.php
@@ -1,38 +1,39 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
-use unittest\TestCase;
 use io\streams\FileOutputStream;
 use io\FileUtil;
 use io\TempFile;
+use io\IOException;
+use unittest\PrerequisitesNotMetError;
+use lang\IllegalArgumentException;
 
-/**
- * TestCase
- *
- * @see      xp://io.streams.FileOutputStream
- */
-class FileOutputStreamTest extends TestCase {
-  protected $file;
+class FileOutputStreamTest extends \unittest\TestCase {
+  private $file;
 
   /**
    * Sets up test case - creates temporary file
+   *
+   * @return void
    */
   public function setUp() {
     try {
       $this->file= new TempFile();
       FileUtil::setContents($this->file, 'Created by FileOutputStreamTest');
-    } catch (\io\IOException $e) {
-      throw new \unittest\PrerequisitesNotMetError('Cannot write temporary file', $e, [$this->file]);
+    } catch (IOException $e) {
+      throw new PrerequisitesNotMetError('Cannot write temporary file', $e, [$this->file]);
     }
   }
   
   /**
    * Tear down this test case - removes temporary file
+   *
+   * @return void
    */
   public function tearDown() {
     try {
       $this->file->isOpen() && $this->file->close();
       $this->file->unlink();
-    } catch (\io\IOException $ignored) {
+    } catch (IOException $ignored) {
       // Can't really do anything about it...
     }
   }
@@ -64,12 +65,12 @@ class FileOutputStreamTest extends TestCase {
     }
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function given_an_invalid_file_an_exception_is_raised() {
     new FileOutputStream('');
   }
 
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function cannot_write_after_closing() {
     with ($stream= new FileOutputStream($this->file)); {
       $stream->close();

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -1,11 +1,13 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
 use io\Channel;
+use io\IOException;
 use io\streams\TextReader;
 use io\streams\InputStream;
 use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
 use lang\IllegalArgumentException;
+use lang\FormatException;
 
 /**
  * TestCase
@@ -90,12 +92,12 @@ class TextReaderTest extends \unittest\TestCase {
     $this->assertEquals('Übercoder', $this->newReader('Übercoder', 'utf-8')->read(9));
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function readBrokenUtf8() {
     $this->newReader("Hello \334|", 'utf-8')->read(0x1000);
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function readMalformedUtf8() {
     $this->newReader("Hello \334bercoder", 'utf-8')->read(0x1000);
   }
@@ -106,7 +108,7 @@ class TextReaderTest extends \unittest\TestCase {
     try {
       $r->read(10);
       $this->fail('No exception caught', null, 'lang.FormatException');
-    } catch (\lang\FormatException $expected) {
+    } catch (FormatException $expected) {
       // OK
     }
     $this->assertNull($r->read(512));
@@ -343,7 +345,7 @@ class TextReaderTest extends \unittest\TestCase {
     $this->assertEquals('ABC', $r->read(3));
   }
 
-  #[@test, @expect(class= 'io.IOException', withMessage= 'Underlying stream does not support seeking')]
+  #[@test, @expect(class= IOException::class, withMessage= 'Underlying stream does not support seeking')]
   public function resetUnseekable() {
     $r= new TextReader($this->unseekableStream());
     $r->reset();

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -2,6 +2,7 @@
 
 use io\Channel;
 use io\IOException;
+use io\streams\LinesIn;
 use io\streams\TextReader;
 use io\streams\InputStream;
 use io\streams\MemoryInputStream;
@@ -408,7 +409,7 @@ class TextReaderTest extends \unittest\TestCase {
 
   #[@test]
   public function lines() {
-    $this->assertInstanceOf('io.streams.LinesIn', $this->newReader('')->lines());
+    $this->assertInstanceOf(LinesIn::class, $this->newReader('')->lines());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/math/BigFloatTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/math/BigFloatTest.class.php
@@ -1,15 +1,10 @@
 <?php namespace net\xp_framework\unittest\math;
 
-use unittest\TestCase;
 use math\BigFloat;
 use math\BigInt;
+use lang\IllegalArgumentException;
 
-/**
- * TestCase
- *
- * @see     xp://math.BigFloat
- */
-class BigFloatTest extends TestCase {
+class BigFloatTest extends \unittest\TestCase {
 
   #[@test]
   public function floatFromInt() {
@@ -163,7 +158,7 @@ class BigFloatTest extends TestCase {
     $this->assertEquals(new BigFloat(6100.0), (new BigFloat(37210000.0))->divide(6100.0));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function divisionByZero() {
     (new BigFloat(5.0))->divide(new BigFloat(0.0));
   }

--- a/src/test/php/net/xp_framework/unittest/math/BigIntAndFloatTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/math/BigIntAndFloatTest.class.php
@@ -1,16 +1,10 @@
 <?php namespace net\xp_framework\unittest\math;
 
-use unittest\TestCase;
 use math\BigInt;
 use math\BigFloat;
+use lang\IllegalArgumentException;
 
-/**
- * TestCase
- *
- * @see     xp://math.BigFloat
- * @see     xp://math.BigInt
- */
-class BigIntAndFloatTest extends TestCase {
+class BigIntAndFloatTest extends \unittest\TestCase {
   
   #[@test]
   public function addFloatToInt() {
@@ -52,12 +46,12 @@ class BigIntAndFloatTest extends TestCase {
     $this->assertEquals(new BigInt(4), (new BigInt(2))->divide0(new BigFloat(0.5)));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function divideIntByFloatZero() {
     (new BigInt(2))->divide(new BigFloat(0.0));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function divideIntByFloatZero0() {
     (new BigInt(2))->divide0(new BigFloat(0.0));
   }
@@ -67,7 +61,7 @@ class BigIntAndFloatTest extends TestCase {
     $this->assertEquals(new BigFloat(0.5), (new BigInt(2))->power(new BigFloat(-1)));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function powerOneHalf() {
     (new BigInt(2))->power(new BigFloat(0.5));
   }

--- a/src/test/php/net/xp_framework/unittest/math/BigIntTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/math/BigIntTest.class.php
@@ -1,15 +1,10 @@
 <?php namespace net\xp_framework\unittest\math;
 
-use unittest\TestCase;
 use math\BigInt;
 use math\BigFloat;
+use lang\IllegalArgumentException;
 
-/**
- * TestCase
- *
- * @see     xp://math.BigInt
- */
-class BigIntTest extends TestCase {
+class BigIntTest extends \unittest\TestCase {
 
   #[@test]
   public function intFromFloat() {
@@ -198,7 +193,7 @@ class BigIntTest extends TestCase {
     $this->assertEquals(new BigInt(6100), (new BigInt(37210000))->divide(6100));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function divisionByZero() {
     (new BigInt(5))->divide(new BigInt(0));
   }
@@ -213,7 +208,7 @@ class BigIntTest extends TestCase {
     $this->assertEquals(new BigInt(1), (new BigInt(5))->modulo(new BigInt(2)));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function moduloZero() {
     (new BigInt(5))->modulo(new BigInt(0));
   }

--- a/src/test/php/net/xp_framework/unittest/peer/URLTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/URLTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace net\xp_framework\unittest\peer;
 
-use unittest\TestCase;
 use peer\URL;
+use lang\IllegalArgumentException;
+use lang\FormatException;
 
 /**
  * TestCase
@@ -11,7 +12,7 @@ use peer\URL;
  * @see   rfc://rfc1738
  * @see   http://bugs.php.net/54180
  */
-class URLTest extends TestCase {
+class URLTest extends \unittest\TestCase {
 
   #[@test]
   public function scheme() {
@@ -214,91 +215,51 @@ class URLTest extends TestCase {
     $this->assertTrue((new URL('http://localhost/?1549'))->hasParam('1549'));
   }
 
-  /**
-   * Test getFragment() method
-   *
-   */
   #[@test]
   public function fragment() {
     $this->assertEquals('top', (new URL('http://localhost#top'))->getFragment());
   }
 
-  /**
-   * Test getFragment() method
-   *
-   */
   #[@test]
   public function fragmentWithSlash() {
     $this->assertEquals('top', (new URL('http://localhost/#top'))->getFragment());
   }
 
-  /**
-   * Test getFragment() method
-   *
-   */
   #[@test]
   public function fragmentWithSlashAndQuestionMark() {
     $this->assertEquals('top', (new URL('http://localhost/?#top'))->getFragment());
   }
 
-  /**
-   * Test getFragment() method
-   *
-   */
   #[@test]
   public function fragmentWithQuery() {
     $this->assertEquals('top', (new URL('http://localhost/?query#top'))->getFragment());
   }
 
-  /**
-   * Test getFragment() method
-   *
-   */
   #[@test]
   public function emptyFragment() {
     $this->assertEquals(null, (new URL('http://localhost'))->getFragment());
   }
 
-  /**
-   * Test getFragment() method
-   *
-   */
   #[@test]
   public function hashOnly() {
     $this->assertEquals(null, (new URL('http://localhost#'))->getFragment());
   }
 
-  /**
-   * Test getFragment() method
-   *
-   */
   #[@test]
   public function hashAtEnd() {
     $this->assertEquals(null, (new URL('http://localhost?#'))->getFragment());
   }
 
-  /**
-   * Test getFragment() method
-   *
-   */
   #[@test]
   public function hashAtEndWithQuery() {
     $this->assertEquals(null, (new URL('http://localhost?query#'))->getFragment());
   }
 
-  /**
-   * Test getFragment() method when invoked with a default value
-   *
-   */
   #[@test]
   public function fragmentDefault() {
     $this->assertEquals('top', (new URL('http://localhost'))->getFragment('top'));
   }
 
-  /**
-   * Test setFragment()
-   *
-   */
   #[@test]
   public function fragmentMutability() {
     $this->assertEquals(
@@ -307,37 +268,21 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getPort() method
-   *
-   */
   #[@test]
   public function port() {
     $this->assertEquals(8080, (new URL('http://localhost:8080'))->getPort());
   }
 
-  /**
-   * Test getPort() method
-   *
-   */
   #[@test]
   public function emptyPort() {
     $this->assertEquals(null, (new URL('http://localhost'))->getPort());
   }
 
-  /**
-   * Test getPort() method when invoked with a default value
-   *
-   */
   #[@test]
   public function portDefault() {
     $this->assertEquals(80, (new URL('http://localhost'))->getPort(80));
   }
 
-  /**
-   * Test setPort()
-   *
-   */
   #[@test]
   public function portMutability() {
     $this->assertEquals(
@@ -351,37 +296,21 @@ class URLTest extends TestCase {
     $this->assertEquals('b', (new URL('http://localhost?a=b'))->getParam('a'));
   }
 
-  /**
-   * Test getParam() method with an array parameter
-   *
-   */
   #[@test]
   public function getArrayParameter() {
     $this->assertEquals(['b'], (new URL('http://localhost?a[]=b'))->getParam('a'));
   }
 
-  /**
-   * Test getParam() method with an array parameter
-   *
-   */
   #[@test]
   public function getEncodedArrayParameter() {
     $this->assertEquals(['='], (new URL('http://localhost?a[]=%3D'))->getParam('a'));
   }
 
-  /**
-   * Test getParam() method with array parameters
-   *
-   */
   #[@test]
   public function getArrayParameters() {
     $this->assertEquals(['b', 'c'], (new URL('http://localhost?a[]=b&a[]=c'))->getParam('a'));
   }
 
-  /**
-   * Test getParam() method with array parameters
-   *
-   */
   #[@test]
   public function getArrayParametersAsHash() {
     $this->assertEquals(
@@ -390,10 +319,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() method with array parameters
-   *
-   */
   #[@test]
   public function getArrayParametersAsHashWithEncodedNames() {
     $this->assertEquals(
@@ -402,10 +327,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParams() with array parameters
-   *
-   */
   #[@test]
   public function arrayOffsetsInDifferentArrays() {
     $this->assertEquals(
@@ -414,10 +335,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function duplicateOffsetsOverwriteEachother() {
     $this->assertEquals(
@@ -426,10 +343,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function duplicateNamesOverwriteEachother() {
     $this->assertEquals(
@@ -438,10 +351,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function twoDimensionalArray() {
     $this->assertEquals(
@@ -450,10 +359,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function threeDimensionalArray() {
     $this->assertEquals(
@@ -462,10 +367,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function arrayOfHash() {
     $this->assertEquals(
@@ -474,10 +375,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function hashOfArray() {
     $this->assertEquals(
@@ -486,10 +383,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function hashOfArrayOfHash() {
     $this->assertEquals(
@@ -498,10 +391,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function hashNotationWithoutValues() {
     $this->assertEquals(
@@ -510,10 +399,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function arrayNotationWithoutValues() {
     $this->assertEquals(
@@ -522,10 +407,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParams() method with array parameters
-   *
-   */
   #[@test]
   public function getArrayParams() {
     $this->assertEquals(
@@ -534,10 +415,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParam() with array parameters
-   *
-   */
   #[@test]
   public function mixedOffsetsAndKeys() {
     $this->assertEquals(
@@ -546,10 +423,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParams() with array parameters
-   *
-   */
   #[@test]
   public function nestedBraces() {
     $this->assertEquals(
@@ -558,10 +431,6 @@ class URLTest extends TestCase {
     );
   }
  
-  /**
-   * Test getParams() with array parameters
-   *
-   */
   #[@test]
   public function nestedBracesTwice() {
     $this->assertEquals(
@@ -570,10 +439,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParams() with array parameters
-   *
-   */
   #[@test]
   public function nestedBracesChained() {
     $this->assertEquals(
@@ -582,10 +447,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test getParams() with array parameters
-   *
-   */
   #[@test]
   public function unnamedArrayParameterDoesNotArray() {
     $this->assertEquals(
@@ -604,19 +465,11 @@ class URLTest extends TestCase {
     $this->assertEquals('', (new URL('http://localhost?x='))->getParam('x'));
   }
 
-  /**
-   * Test getParam() method when invoked with a default value
-   *
-   */
   #[@test]
   public function paramDefault() {
     $this->assertEquals('x', (new URL('http://localhost?a=b'))->getParam('c', 'x'));
   }
  
-  /**
-   * Test addParam()
-   *
-   */
   #[@test]
   public function addNewParam() {
     $this->assertEquals(
@@ -625,10 +478,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test setParam()
-   *
-   */
   #[@test]
   public function setNewParam() {
     $this->assertEquals(
@@ -637,10 +486,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test addParam()
-   *
-   */
   #[@test]
   public function addAdditionalParam() {
     $this->assertEquals(
@@ -649,10 +494,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test setParam()
-   *
-   */
   #[@test]
   public function setAdditionalParam() {
     $this->assertEquals(
@@ -661,10 +502,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test addParam()
-   *
-   */
   #[@test]
   public function addAdditionalParamChained() {
     $this->assertEquals(
@@ -673,10 +510,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test setParam()
-   *
-   */
   #[@test]
   public function setAdditionalParamChained() {
     $this->assertEquals(
@@ -685,19 +518,11 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test addParam()
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function addExistingParam() {
     (new URL('http://localhost?a=b'))->addParam('a', 'b');
   }
 
-  /**
-   * Test setParam()
-   *
-   */
   #[@test]
   public function setExistingParam() {
     $this->assertEquals(
@@ -706,34 +531,22 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test addParams()
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function addExistingParams() {
     (new URL('http://localhost?a=b'))->addParams(['a' => 'b']);
   }
 
-  /**
-   * Test addParams()
-   *
-   */
   #[@test]
   public function addExistingParamsDoesNotPartiallyModify() {
     $original= 'http://localhost?a=b';
     $u= new URL($original);
     try {
       $u->addParams(['c' => 'd', 'a' => 'b']);
-      $this->fail('Existing parameter "a" not detected', null, 'lang.IllegalArgumentException');
+      $this->fail('Existing parameter "a" not detected', null, IllegalArgumentException::class);
     } catch (\lang\IllegalArgumentException $expected) { }
     $this->assertEquals($original, $u->getURL());
   }
 
-  /**
-   * Test setParams()
-   *
-   */
   #[@test]
   public function setExistingParams() {
     $this->assertEquals(
@@ -742,10 +555,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test addParams()
-   *
-   */
   #[@test]
   public function addNewParams() {
     $this->assertEquals(
@@ -754,10 +563,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test setParams()
-   *
-   */
   #[@test]
   public function setNewParams() {
     $this->assertEquals(
@@ -766,10 +571,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test addParams()
-   *
-   */
   #[@test]
   public function addAdditionalParams() {
     $this->assertEquals(
@@ -778,10 +579,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test setParams()
-   *
-   */
   #[@test]
   public function setAdditionalParams() {
     $this->assertEquals(
@@ -790,10 +587,6 @@ class URLTest extends TestCase {
     );
   }
 
-  /**
-   * Test addParam()
-   *
-   */
   #[@test]
   public function addArrayParam() {
     $u= new URL('http://localhost/');
@@ -801,10 +594,6 @@ class URLTest extends TestCase {
     $this->assertEquals('http://localhost/?x[]=y&x[]=z', $u->getURL());
   }
 
-  /**
-   * Test setParam()
-   *
-   */
   #[@test]
   public function setArrayParam() {
     $u= new URL('http://localhost/');
@@ -812,10 +601,6 @@ class URLTest extends TestCase {
     $this->assertEquals('http://localhost/?x[]=y&x[]=z', $u->getURL());
   }
 
-  /**
-   * Test getParams() method
-   *
-   */
   #[@test]
   public function params() {
     $this->assertEquals(['a' => 'b', 'c' => 'd'], (new URL('http://localhost?a=b&c=d'))->getParams());
@@ -928,37 +713,37 @@ class URLTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function insideAText() {
     new URL('this is the url http://url/ and nothing else');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function doesNotSupportMailto() {
     new URL('mailto:user@example.com');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function whiteSpaceInSchemeNotAllowed() {
     new URL('scheme ://host');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function minusInSchemeNotAllowed() {
     new URL('scheme-minus://host');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function underscoreInSchemeNotAllowed() {
     new URL('scheme_underscore://host');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function numericSchemeNotAllowed() {
     new URL('123://host');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function plusAsFirstSignInSchemeNotAllowed() {
     new URL('+v2://host');
   }
@@ -973,199 +758,167 @@ class URLTest extends TestCase {
     $this->assertEquals('f', (new URL('f://host'))->getScheme());
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function schemeOnlyUnparseable() {
     new URL('http:');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function schemeAndSeparatorOnlyUnparseable() {
     new URL('http://');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function schemeSeparatorOnlyUnparseable() {
     new URL('://');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function colonOnlyUnparseable() {
     new URL(':');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function slashSlashOnlyUnparseable() {
     new URL('//');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function missingSchemeUnparseable() {
     new URL(':///path/to/file');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function emptyUnparseable() {
     new URL('');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function withoutSchemeUnparseable() {
     new URL('/path/to/file');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function slashOnlyUnparseable() {
     new URL('/');
   }
 
-  /**
-   * Test malformed query string parsing
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function missingClosingBracket() {
     new URL('http://example.com/?a[=c');
   }
 
-  /**
-   * Test malformed query string parsing
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function missingOpeningBracket() {
     new URL('http://example.com/?a]=c');
   }
 
-  /**
-   * Test malformed query string parsing
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function unbalancedOpeningBrackets() {
     new URL('http://example.com/?a[[[]]=c');
   }
 
-  /**
-   * Test malformed query string parsing
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function unbalancedClosingBrackets() {
     new URL('http://example.com/?a[[]]]=c');
   }
 
-  /**
-   * Test malformed query string parsing
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function missingClosingBracketAfterClosed() {
     new URL('http://example.com/?a[][=c');
   }
 
-  /**
-   * Test getParams() with array parameters
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function missingClosingBracketInNested() {
     new URL('http://localhost/?a[nested[a]=c');
   }
 
-  /**
-   * Test getParams() with array parameters
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function missingClosingBracketInNestedAfterClosed() {
     new URL('http://localhost/?a[][nested[a]=c');
   }
 
-  /**
-   * Test getParams() with array parameters
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function missingClosingBracketInNestedBeforeClosed() {
     new URL('http://localhost/?a[nested[a][]=c');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function singleSlash() {
     new URL('http:/blah.com');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function portOnlyNoHost() {
     new URL('http://:80');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function userAndPortOnlyNoHost() {
     new URL('http://user@:80');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function atSignOnlyNoHost() {
     new URL('http://@');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function userOnlyNoHost() {
     new URL('http://user@');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function doubleDoubleColon() {
     new URL('http://::');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function questionMarkOnlyNoHost() {
     new URL('http://?');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function hashSignOnlyNoHost() {
     new URL('http://#');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function colonAndQuestionMarkOnlyNoHost() {
     new URL('http://:?');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function questionMarkAndColonAndOnlyNoHost() {
     new URL('http://?:');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function nonNumericPort() {
     new URL('http://example.com:ABCDEF');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function duplicatePort() {
     new URL('http://example.com:443:443');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function unclosedIPV6Brackets() {
     new URL('http://[::1');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function colonInDomainNameNotAllowed() {
     new URL('http://a:o.com/');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function percentSignInDomainNameNotAllowed() {
     new URL('http://a%o.com/');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function spaceInDomainNameNotAllowed() {
     new URL('http://a o.com/');
   }

--- a/src/test/php/net/xp_framework/unittest/peer/net/Inet4AddressTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/net/Inet4AddressTest.class.php
@@ -1,142 +1,81 @@
 <?php namespace net\xp_framework\unittest\peer\net;
 
-use unittest\TestCase;
 use peer\net\Inet4Address;
 use peer\net\Network;
+use lang\FormatException;
 
-class Inet4AddressTest extends TestCase {
+class Inet4AddressTest extends \unittest\TestCase {
 
-  /**
-   * Test creation of address
-   *
-   */
   #[@test]
   public function createAddress() {
     $this->assertEquals('127.0.0.1', (new Inet4Address('127.0.0.1'))->asString());
   }
 
-  /**
-   * Test creation of IP from some string raises exception
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function createInvalidAddressRaisesException() {
     new Inet4Address('Who am I');
   }
 
-  /**
-   * Test creation of invalid formatted IP raises exception
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function createInvalidAddressThatLooksLikeAddressRaisesException() {
     new Inet4Address('10.0.0.355');
   }
   
-  /**
-   * Test creation of ip from string with too many dot blocks
-   * raises an exception
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function createInvalidAddressWithTooManyBlocksRaisesException() {
     new Inet4Address('10.0.0.255.5');
   }
 
-  /**
-   * 127.0.0.1 should be detected as loopback
-   *
-   */
   #[@test]
   public function loopbackAddress() {
     $this->assertTrue((new Inet4Address('127.0.0.1'))->isLoopback());
   }
   
-  /**
-   * 127.0.0.x should be detected as loopback
-   *
-   */
   #[@test]
   public function alternativeLoopbackAddress() {
     $this->assertTrue((new Inet4Address('127.0.0.200'))->isLoopback());
   }
   
-  /**
-   * Test subnet determination works
-   *
-   */
   #[@test]
   public function inSubnet() {
     $this->assertTrue((new Inet4Address('192.168.2.1'))->inSubnet(new Network(new Inet4Address('192.168.2'), 24)));
   }
   
-  /**
-   * Test ip is not part of subnet
-   *
-   */
   #[@test]
   public function notInSubnet() {
     $this->assertFalse((new Inet4Address('192.168.2.1'))->inSubnet(new Network(new Inet4Address('172.17.0.0'), 12)));
   }
   
-  /**
-   * Test that a host is in his own host-subnet
-   *
-   */
   #[@test]
   public function hostInOwnHostSubnet() {
     $this->assertTrue((new Inet4Address('172.17.29.6'))->inSubnet(new Network(new Inet4Address('172.17.29.6'), 32)));
   }
   
-  /**
-   * Test invalid formatted net raises exception
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function illegalSubnet() {
     (new Inet4Address('172.17.29.6'))->inSubnet(new Network(new Inet4Address('172.17.29.6'), 33));
   }
 
-  /**
-   * The same IPs should be equal
-   *
-   */
   #[@test]
   public function sameIPsShouldBeEqual() {
     $this->assertEquals(new Inet4Address('127.0.0.1'), new Inet4Address('127.0.0.1'));
   }
 
-  /**
-   * Different IPs should not be equal
-   *
-   */
   #[@test]
   public function differentIPsShouldBeDifferent() {
     $this->assertNotEquals(new Inet4Address('127.0.0.5'), new Inet4Address('192.168.1.1'));
   }
 
-  /**
-   * Check casting to string works
-   *
-   */
   #[@test]
   public function castToString() {
     $this->assertEquals('192.168.1.1', (string)new Inet4Address('192.168.1.1'));
   }
 
-  /**
-   * Test reverse address being built
-   *
-   */
   #[@test]
   public function reverseNotationLocalhost() {
     $this->assertEquals('1.0.0.127.in-addr.arpa', (new Inet4Address('127.0.0.1'))->reversedNotation());
   }
   
-  /**
-   * Test reverse address being built
-   *
-   */
   #[@test]
   public function createSubnet_creates_subnet_with_trailing_zeros() {
     $addr= new Inet4Address('192.168.1.1');

--- a/src/test/php/net/xp_framework/unittest/peer/net/Inet6AddressTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/net/Inet6AddressTest.class.php
@@ -1,15 +1,16 @@
 <?php namespace net\xp_framework\unittest\peer\net;
 
-use unittest\TestCase;
 use peer\net\Inet6Address;
 use peer\net\Network;
+use lang\FormatException;
 
-class Inet6AddressTest extends TestCase {
+/**
+ * IPv6 addresses test 
+ *
+ * @see   http://en.wikipedia.org/wiki/Reverse_DNS_lookup#IPv6_reverse_resolution
+ */
+class Inet6AddressTest extends \unittest\TestCase {
 
-  /**
-   * Test creation of address
-   *
-   */
   #[@test]
   public function createAddress() {
     $this->assertEquals(
@@ -18,10 +19,6 @@ class Inet6AddressTest extends TestCase {
     );
   }
 
-  /**
-   * Test creation of address
-   *
-   */
   #[@test]
   public function createAddressFromUpperCase() {
     $this->assertEquals(
@@ -30,28 +27,22 @@ class Inet6AddressTest extends TestCase {
     );
   }
 
-  /**
-   * Test creation of address from its packed form
-   *
-   */
   #[@test]
   public function createAddressFromPackedForm() {
     $this->assertEquals(
       '::1',
       (new Inet6Address("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1", true))->asString()
     );
-    
-    //special case when a colon is part of the packed address string
+  }
+
+  #[@test]
+  public function createAddressFromPackedFormWithColonSpecialCase() {
     $this->assertEquals(
       '::3a',
       (new Inet6Address("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0:", true))->asString() // ord(':')==0x32
     );
   }
 
-  /**
-   * Test getAddress() shortens address
-   *
-   */
   #[@test]
   public function addressIsShortened() {
     $this->assertEquals(
@@ -60,10 +51,6 @@ class Inet6AddressTest extends TestCase {
     );
   }
   
-  /**
-   * Test shortening only takes place once
-   *
-   */
   #[@test]
   public function addressShorteningOnlyTakesPlaceOnce() {
     $this->assertEquals(
@@ -72,11 +59,6 @@ class Inet6AddressTest extends TestCase {
     );
   }
   
-  
-  /**
-   * Test hexquads become shortened if first digits are zero
-   *
-   */
   #[@test]
   public function hexquadsAreShortenedWhenStartingWithZero() {
     $this->assertEquals(
@@ -85,10 +67,6 @@ class Inet6AddressTest extends TestCase {
     );
   }
   
-  /**
-   * Test prefix is shortened
-   *
-   */
   #[@test]
   public function addressPrefixIsShortened() {
     $this->assertEquals(
@@ -97,10 +75,6 @@ class Inet6AddressTest extends TestCase {
     );
   }
   
-  /**
-   * Test postfix is shortened
-   *
-   */
   #[@test]
   public function addressPostfixIsShortened() {
     $this->assertEquals(
@@ -109,156 +83,86 @@ class Inet6AddressTest extends TestCase {
     );
   }
   
-  
-  /**
-   * Test loopback address is formatted correctly
-   *
-   */
   #[@test]
   public function loopbackAddress() {
     $this->assertEquals('::1', (new Inet6Address('::1'))->asString());
   }
   
-  /**
-   * Test loopback address is detected
-   *
-   */
   #[@test]
   public function isLoopbackAddress() {
     $this->assertTrue((new Inet6Address('::1'))->isLoopback());
   }
   
-  /**
-   * Test alternative loopback address is detected
-   *
-   */
   #[@test]
   public function isNotLoopbackAddress() {
     $this->assertFalse((new Inet6Address('::2'))->isLoopback());
   }
   
-  /**
-   * Test subnet detection for loopback
-   *
-   */
   #[@test]
   public function inSubnet() {
     $this->assertTrue((new Inet6Address('::1'))->inSubnet(new Network(new Inet6Address('::1'), 120)));
   }
   
-  /**
-   * Test smallest possible subnet contains loopback
-   *
-   */
   #[@test]
   public function inSmallestPossibleSubnet() {
     $this->assertTrue((new Inet6Address('::1'))->inSubnet(new Network(new Inet6Address('::0'), 127)));
   }
   
-  /**
-   * Test address not being detected in subnet when its not
-   *
-   */
   #[@test]
   public function notInSubnet() {
     $this->assertFalse((new Inet6Address('::1'))->inSubnet(new Network(new Inet6Address('::0101'), 120)));
   }
 
-  /**
-   * Test invalid address is caught
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function illegalAddress() {
     new Inet6Address('::ffffff:::::a');
   }
 
-  /**
-   * Test invalid address is caught
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function anotherIllegalAddress() {
     new Inet6Address('');
   }
 
-  /**
-   * Test creation of address from an invalid input string
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function invalidInputOfNumbers() {
     new Inet6Address('12345678901234567');
   }
 
-  /**
-   * Test creation of address from an invalid input string
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function invalidHexQuadBeginning() {
     new Inet6Address('XXXX::a574:382b:23c1:aa49:4592:4efe:9982');
   }
 
-  /**
-   * Test creation of address from an invalid input string
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function invalidHexQuadEnd() {
     new Inet6Address('9982::a574:382b:23c1:aa49:4592:4efe:XXXX');
   }
 
-  /**
-   * Test creation of address from an invalid input string
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function invalidHexQuad() {
     new Inet6Address('a574::XXXX:382b:23c1:aa49:4592:4efe:9982');
   }
   
-  /**
-   * Test creation of address from an invalid input string
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function invalidHexDigit() {
     new Inet6Address('a574::382X:382b:23c1:aa49:4592:4efe:9982');
   }
 
-  /**
-   * The same IPs should be equal
-   *
-   */
   #[@test]
   public function sameIPsShouldBeEqual() {
     $this->assertEquals(new Inet6Address('::1'), new Inet6Address('::1'));
   }
 
-  /**
-   * Different IPs should not be equal
-   *
-   */
   #[@test]
   public function differentIPsShouldBeDifferent() {
     $this->assertNotEquals(new Inet6Address('::1'), new Inet6Address('::fe08'));
   }
 
-  /**
-   * Check casting to string works
-   *
-   */
   #[@test]
   public function castToString() {
     $this->assertEquals('[::1]', (string)new Inet6Address('::1'));
   }
 
-  /**
-   * Test
-   *
-   * @see   http://en.wikipedia.org/wiki/Reverse_DNS_lookup#IPv6_reverse_resolution
-   */
   #[@test]
   public function reversedNotation() {
     $this->assertEquals(
@@ -267,10 +171,6 @@ class Inet6AddressTest extends TestCase {
     );
   }
   
-      /**
-   * Test reverse address being built
-   *
-   */
   #[@test]
   public function createSubnet_creates_subnet_with_trailing_zeros() {
     $addr= new Inet6Address('febc:a574:382b:23c1:aa49:4592:4efe:9982');

--- a/src/test/php/net/xp_framework/unittest/peer/net/InetAddressFactoryTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/net/InetAddressFactoryTest.class.php
@@ -2,93 +2,54 @@
 
 use unittest\TestCase;
 use peer\net\InetAddressFactory;
+use peer\net\Inet4Address;
+use peer\net\Inet6Address;
+use lang\FormatException;
 
-
-/**
- * Test class
- *
- * 
- */
 class InetAddressFactoryTest extends TestCase {
-  protected
-    $cut  = null;
+  private $cut;
 
-  /**
-   * SetUp
-   *
-   */
+  /** @return void */
   public function setUp() {
     $this->cut= new InetAddressFactory();
   }
 
-  /**
-   * Parse 127.0.0.1
-   *
-   */
   #[@test]
   public function createLocalhostV4() {
-    $this->assertInstanceOf('peer.net.Inet4Address', $this->cut->parse('127.0.0.1'));
+    $this->assertInstanceOf(Inet4Address::class, $this->cut->parse('127.0.0.1'));
   }
 
-  /**
-   * Parse invalid address that matches a valid one
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function parseInvalidAddressThatLooksLikeV4() {
     $this->cut->parse('3.33.333.333');
   }
 
-  /**
-   * Parse invalid address that matches a valid one
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function parseInvalidAddressThatAlsoLooksLikeV4() {
     $this->cut->parse('10..3.3');
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function tryParse() {
-    $this->assertEquals(new \peer\net\Inet4Address('172.17.29.6'), $this->cut->tryParse('172.17.29.6'));
+    $this->assertEquals(new Inet4Address('172.17.29.6'), $this->cut->tryParse('172.17.29.6'));
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function tryParseReturnsNullOnFailure() {
     $this->assertEquals(null, $this->cut->tryParse('not an ip address'));
   }
 
-  /**
-   * Parse localhost address
-   * 
-   */
   #[@test]
   public function parseLocalhostV6() {
-    $this->assertInstanceOf('peer.net.Inet6Address', $this->cut->parse('::1'));
+    $this->assertInstanceOf(Inet6Address::class, $this->cut->parse('::1'));
   }
 
-  /**
-   * Parse address
-   *
-   */
   #[@test]
   public function parseV6() {
-    $this->assertInstanceOf('peer.net.Inet6Address', $this->cut->parse('fe80::a6ba:dbff:fefe:7755'));
+    $this->assertInstanceOf(Inet6Address::class, $this->cut->parse('fe80::a6ba:dbff:fefe:7755'));
   }
 
-  /**
-   * Parse address
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function parseThatLooksLikeV6() {
     $this->cut->parse('::ffffff:::::a');
   }

--- a/src/test/php/net/xp_framework/unittest/peer/net/NameserverLookupTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/net/NameserverLookupTest.class.php
@@ -3,6 +3,7 @@
 use peer\net\Inet4Address;
 use peer\net\Inet6Address;
 use peer\net\NameserverLookup;
+use lang\ElementNotFoundException;
 
 /**
  * Test nameserver lookup API
@@ -10,7 +11,7 @@ use peer\net\NameserverLookup;
  * @see   xp://peer.net.NameserverLookup'
  */
 class NameserverLookupTest extends \unittest\TestCase {
-  private $cut= null;
+  private $cut;
 
   /**
    * Sets up test case and defines dummy nameserver lookup fixture
@@ -76,7 +77,7 @@ class NameserverLookupTest extends \unittest\TestCase {
     $this->assertEquals([], $this->cut->lookupAll('localhost'));
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function lookupNonexistantThrowsException() {
     $this->cut->lookup('localhost');
   }
@@ -87,7 +88,7 @@ class NameserverLookupTest extends \unittest\TestCase {
     $this->assertEquals('localhost', $this->cut->reverseLookup(new Inet4Address('127.0.0.1')));
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function nonexistingReverseLookupCausesException() {
     $this->cut->reverseLookup(new Inet4Address('192.168.1.1'));
   }

--- a/src/test/php/net/xp_framework/unittest/peer/net/NetworkParserTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/net/NetworkParserTest.class.php
@@ -1,68 +1,48 @@
 <?php namespace net\xp_framework\unittest\peer\net;
 
-use unittest\TestCase;
 use peer\net\NetworkParser;
+use peer\net\Network;
+use peer\net\Inet4Address;
+use peer\net\Inet6Address;
+use lang\FormatException;
 
-class NetworkParserTest extends TestCase {
-  protected
-    $cut  = null;
+class NetworkParserTest extends \unittest\TestCase {
+  private $cut;
 
-  /**
-   * Set up test fixture
-   *
-   */
+  /** @return void */
   public function setUp() {
     $this->cut= new NetworkParser();
   }
 
-  /**
-   * Test parsing ipv4 network string
-   * 
-   */
   #[@test]
   public function parseV4Network() {
     $this->assertEquals(
-      new \peer\net\Network(new \peer\net\Inet4Address('192.168.1.1'), 24),
+      new Network(new Inet4Address('192.168.1.1'), 24),
       $this->cut->parse('192.168.1.1/24')
     );
   }
 
-  /**
-   * Test parsing illegal network fails
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function parseV4NetworkThrowsExceptionOnIllegalNetworkString() {
     $this->cut->parse('192.168.1.1 b24');
   }
 
-  /**
-   * Test parsing ipv6 network string
-   */
   #[@test]
   public function parseV6Network() {
     $this->assertEquals(
-      new \peer\net\Network(new \peer\net\Inet6Address('fc00::'), 7),
+      new Network(new Inet6Address('fc00::'), 7),
       $this->cut->parse('fc00::/7')
     );
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function tryParse() {
     $this->assertEquals(
-      new \peer\net\Network(new \peer\net\Inet4Address('172.16.0.0'), 12),
+      new Network(new Inet4Address('172.16.0.0'), 12),
       $this->cut->tryParse('172.16.0.0/12')
     );
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function tryParseReturnsNullOnFailure() {
     $this->assertEquals(null, $this->cut->tryParse('not a network'));

--- a/src/test/php/net/xp_framework/unittest/peer/net/NetworkTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/net/NetworkTest.class.php
@@ -1,35 +1,23 @@
 <?php namespace net\xp_framework\unittest\peer\net;
 
-use unittest\TestCase;
 use peer\net\Network;
 use peer\net\Inet4Address;
 use peer\net\Inet6Address;
+use lang\FormatException;
 
-class NetworkTest extends TestCase {
+class NetworkTest extends \unittest\TestCase {
 
-  /**
-   * Create network
-   * 
-   */
   #[@test]
   public function createNetwork() {
     $net= new Network(new Inet4Address("127.0.0.1"), 24);
     $this->assertEquals('127.0.0.1/24', $net->asString());
   }
 
-  /**
-   * Create network fails
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function createNetworkFailsIfTooLargeNetmaskGiven() {
     new Network(new Inet4Address("127.0.0.1"), 33);
   }
 
-  /**
-   * Create v6 network
-   *
-   */
   #[@test]
   public function createNetworkV6() {
     $this->assertEquals(
@@ -38,10 +26,6 @@ class NetworkTest extends TestCase {
     );
   }
 
-  /**
-   * Create v6 network
-   *
-   */
   #[@test]
   public function createNetworkV6WorkAlsoWithNetmaskTooBigInV4() {
     $this->assertEquals(
@@ -50,56 +34,32 @@ class NetworkTest extends TestCase {
     );
   }
 
-  /**
-   * Create v6 network
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function createNetworkV6FailsIfTooLargeNetmaskGiven() {
     new Network(new Inet6Address('fe00::'), 763);
   }
 
-  /**
-   * Create network fails
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function createNetworkFailsIfTooSmallNetmaskGiven() {
     new Network(new Inet4Address("127.0.0.1"), -1);
   }
 
-  /**
-   * Create network fails
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function createNetworkFailsIfNonIntegerNetmaskGiven() {
     new Network(new Inet4Address("127.0.0.1"), 0.5);
   }
 
-  /**
-   * Create network fails
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function createNetworkFailsIfStringGiven() {
     new Network(new Inet4Address("127.0.0.1"), "Hello");
   }
 
-  /**
-   * Retrieve network ip
-   *
-   */
   #[@test]
   public function networkAddress() {
     $net= new Network(new Inet4Address("127.0.0.0"), 24);
     $this->assertEquals(new Inet4Address("127.0.0.0"), $net->getNetworkAddress());
   }
 
-  /**
-   * Check if given IP is part of net
-   *
-   */
   #[@test]
   public function loopbackNetworkContainsLoopbackAddressV4() {
     $this->assertTrue((new Network(new Inet4Address('127.0.0.5'), 24))->contains(new Inet4Address('127.0.0.1')));

--- a/src/test/php/net/xp_framework/unittest/peer/sockets/AbstractSocketTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/sockets/AbstractSocketTest.class.php
@@ -2,6 +2,9 @@
 
 use unittest\TestCase;
 use peer\Socket;
+use peer\SocketException;
+use peer\ConnectException;
+use peer\SocketTimeoutException;
 use lang\Runtime;
 
 /**
@@ -17,6 +20,7 @@ abstract class AbstractSocketTest extends TestCase {
    * Callback for when server is connected
    *
    * @param  string $bindAddress
+   * @return vid
    */
   public static function connected($bindAddress) {
     self::$bindAddress= explode(':', $bindAddress);
@@ -24,6 +28,8 @@ abstract class AbstractSocketTest extends TestCase {
 
   /**
    * Callback for when server should be shut down
+   *
+   * @return vid
    */
   public static function shutdown() {
     $c= new Socket(self::$bindAddress[0], self::$bindAddress[1]);
@@ -42,70 +48,56 @@ abstract class AbstractSocketTest extends TestCase {
   protected abstract function newSocket($addr, $port);
 
   /**
-   * Setup this test case
+   * Read exactly the specific amount of bytes.
+   *
+   * @param   int num
+   * @return  string
    */
+  protected function readBytes($num) {
+    $bytes= '';
+    do {
+      $bytes.= $this->fixture->readBinary($num- strlen($bytes));
+    } while (strlen($bytes) < $num);
+    return $bytes;
+  }
+
+
+  /** @return void */
   public function setUp() {
     $this->fixture= $this->newSocket(self::$bindAddress[0], self::$bindAddress[1]);
   }
 
-  /**
-   * Tears down this test case
-   */
+  /** @return void */
   public function tearDown() {
     $this->fixture->isConnected() && $this->fixture->close();
   }
   
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function initiallyNotConnected() {
     $this->assertFalse($this->fixture->isConnected());
   }
 
-  /**
-   * Test connecting
-   *
-   */
   #[@test]
   public function connect() {
     $this->assertTrue($this->fixture->connect());
     $this->assertTrue($this->fixture->isConnected());
   }
 
-  /**
-   * Test connecting
-   *
-   */
-  #[@test, @expect('peer.ConnectException')]
+  #[@test, @expect(ConnectException::class)]
   public function connectInvalidPort() {
     $this->newSocket(self::$bindAddress[0], -1)->connect(0.1);
   }
 
-  /**
-   * Test connecting
-   *
-   */
-  #[@test, @expect('peer.ConnectException')]
+  #[@test, @expect(ConnectException::class)]
   public function connectInvalidHost() {
     $this->newSocket('@invalid', self::$bindAddress[1])->connect(0.1);
   }
 
-  /**
-   * Test connecting to port 49151 (IANA Reserved)
-   *
-   * @see   http://www.iana.org/assignments/port-numbers
-   */
-  #[@test, @expect('peer.ConnectException')]
-  public function connectUnConnected() {
+  #[@test, @expect(ConnectException::class)]
+  public function connectIANAReserved49151() {
     $this->newSocket(self::$bindAddress[0], 49151)->connect(0.1);
   }
 
-  /**
-   * Test closing
-   *
-   */
   #[@test]
   public function closing() {
     $this->assertTrue($this->fixture->connect());
@@ -113,19 +105,11 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertFalse($this->fixture->isConnected());
   }
 
-  /**
-   * Test closing
-   *
-   */
   #[@test]
   public function closingNotConnected() {
     $this->assertFalse($this->fixture->close());
   }
   
-  /**
-   * Test EOF after closing
-   *
-   */
   #[@test]
   public function eofAfterClosing() {
     $this->assertTrue($this->fixture->connect());
@@ -141,29 +125,17 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertFalse($this->fixture->eof());
   }
 
-  /**
-   * Test writing data
-   *
-   */
   #[@test]
   public function write() {
     $this->fixture->connect();
     $this->assertEquals(10, $this->fixture->write("ECHO data\n"));
   }
 
-  /**
-   * Test writing data
-   *
-   */
-  #[@test, @expect('peer.SocketException')]
+  #[@test, @expect(SocketException::class)]
   public function writeUnConnected() {
     $this->fixture->write('Anything');
   }
 
-  /**
-   * Test writing data after EOF
-   *
-   */
   #[@test, @ignore('Writes still succeed after close - no idea why...')]
   public function writeAfterEof() {
     $this->fixture->connect();
@@ -171,15 +143,11 @@ abstract class AbstractSocketTest extends TestCase {
     try {
       $this->fixture->write('Anything');
       $this->fail('No exception raised', null, 'peer.SocketException');
-    } catch (\peer\SocketException $expected) {
+    } catch (SocketException $expected) {
       // OK
     }
   }
 
-  /**
-   * Test reading data w/ readLine()
-   *
-   */
   #[@test]
   public function readLine() {
     $this->fixture->connect();
@@ -187,19 +155,11 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals("+ECHO data", $this->fixture->readLine());
   }
 
-  /**
-   * Test readLine()
-   *
-   */
-  #[@test, @expect('peer.SocketException')]
+  #[@test, @expect(SocketException::class)]
   public function readLineUnConnected() {
     $this->fixture->readLine();
   }
 
-  /**
-   * Test reading after eof w/ readLine()
-   *
-   */
   #[@test]
   public function readLineOnEof() {
     $this->fixture->connect();
@@ -208,10 +168,6 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertTrue($this->fixture->eof(), '<EOF>');
   }
 
-  /**
-   * Test reading multiple lines separated by \n
-   *
-   */
   #[@test]
   public function readLinesWithLineFeed() {
     $this->fixture->connect();
@@ -222,10 +178,6 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals('+LINE .', $this->fixture->readLine());
   }
 
-  /**
-   * Test reading multiple lines separated by \r
-   *
-   */
   #[@test, @ignore('readLine() only works for \n or \r\n at the moment')]
   public function readLinesWithCarriageReturn() {
     $this->fixture->connect();
@@ -236,10 +188,6 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals('+LINE .', $this->fixture->readLine());
   }
 
-  /**
-   * Test reading multiple lines separated by \r\n
-   *
-   */
   #[@test]
   public function readLinesWithCarriageReturnLineFeed() {
     $this->fixture->connect();
@@ -250,24 +198,6 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals('+LINE .', $this->fixture->readLine());
   }
   
-  /**
-   * Read exactly the specific amount of bytes.
-   *
-   * @param   int num
-   * @return  string
-   */
-  protected function readBytes($num) {
-    $bytes= '';
-    do {
-      $bytes.= $this->fixture->readBinary($num- strlen($bytes));
-    } while (strlen($bytes) < $num);
-    return $bytes;
-  }
-
-  /**
-   * Test readLine() and readBinary() in conjunction
-   *
-   */
   #[@test]
   public function readLineAndBinary() {
     $this->fixture->connect();
@@ -276,10 +206,6 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals("+LINE 1\r\n+LINE 2\r\n+LINE .\n", $this->readBytes(26));
   }
 
-  /**
-   * Test readLine() and readBinary() in conjunction
-   *
-   */
   #[@test]
   public function readLineAndBinaryWithMaxLen() {
     $this->fixture->connect();
@@ -290,10 +216,6 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals('+LINE .', $this->fixture->readLine());
   }
 
-  /**
-   * Test reading data w/ read()
-   *
-   */
   #[@test]
   public function read() {
     $this->fixture->connect();
@@ -301,19 +223,11 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals("+ECHO data\n", $this->fixture->read());
   }
 
-  /**
-   * Test read()
-   *
-   */
-  #[@test, @expect('peer.SocketException')]
+  #[@test, @expect(SocketException::class)]
   public function readUnConnected() {
     $this->fixture->read();
   }
 
-  /**
-   * Test reading after eof w/ read()
-   *
-   */
   #[@test]
   public function readOnEof() {
     $this->fixture->connect();
@@ -322,10 +236,6 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertTrue($this->fixture->eof(), '<EOF>');
   }
 
-  /**
-   * Test reading data w/ readBinary()
-   *
-   */
   #[@test]
   public function readBinary() {
     $this->fixture->connect();
@@ -333,19 +243,11 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals("+ECHO data\n", $this->fixture->read());
   }
 
-  /**
-   * Test readBinary()
-   *
-   */
-  #[@test, @expect('peer.SocketException')]
+  #[@test, @expect(SocketException::class)]
   public function readBinaryUnConnected() {
     $this->fixture->readBinary();
   }
 
-  /**
-   * Test reading after eof w/ readBinary()
-   *
-   */
   #[@test]
   public function readBinaryOnEof() {
     $this->fixture->connect();
@@ -354,29 +256,17 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertTrue($this->fixture->eof(), '<EOF>');
   }
 
-  /**
-   * Test canRead()
-   *
-   */
   #[@test]
   public function canRead() {
     $this->fixture->connect();
     $this->assertFalse($this->fixture->canRead(0.1));
   }
 
-  /**
-   * Test canRead()
-   *
-   */
-  #[@test, @expect('peer.SocketException')]
+  #[@test, @expect(SocketException::class)]
   public function canReadUnConnected() {
     $this->fixture->canRead(0.1);
   }
 
-  /**
-   * Test canRead()
-   *
-   */
   #[@test]
   public function canReadWithData() {
     $this->fixture->connect();
@@ -384,20 +274,12 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertTrue($this->fixture->canRead(0.1));
   }
 
-  /**
-   * Test getHandle()
-   *
-   */
   #[@test]
   public function getHandle() {
     $this->fixture->connect();
     $this->assertTrue(is_resource($this->fixture->getHandle()));
   }
 
-  /**
-   * Test getHandle()
-   *
-   */
   #[@test]
   public function getHandleAfterClose() {
     $this->fixture->connect();
@@ -405,52 +287,32 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertNull($this->fixture->getHandle());
   }
 
-  /**
-   * Test getHandle()
-   *
-   */
   #[@test]
   public function getHandleUnConnected() {
     $this->assertNull($this->fixture->getHandle());
   }
 
-  /**
-   * Test setTimeout()
-   *
-   */
-  #[@test, @expect('peer.SocketTimeoutException')]
+  #[@test, @expect(SocketTimeoutException::class)]
   public function readTimeout() {
     $this->fixture->connect();
     $this->fixture->setTimeout(0.1);
     $this->fixture->read();
   }
 
-  /**
-   * Test setTimeout()
-   *
-   */
-  #[@test, @expect('peer.SocketTimeoutException')]
+  #[@test, @expect(SocketTimeoutException::class)]
   public function readBinaryTimeout() {
     $this->fixture->connect();
     $this->fixture->setTimeout(0.1);
     $this->fixture->readBinary();
   }
 
-  /**
-   * Test setTimeout()
-   *
-   */
-  #[@test, @expect('peer.SocketTimeoutException')]
+  #[@test, @expect(SocketTimeoutException::class)]
   public function readLineTimeout() {
     $this->fixture->connect();
     $this->fixture->setTimeout(0.1);
     $this->fixture->readLine();
   }
 
-  /**
-   * Test getInputStream() method
-   *
-   */
   #[@test]
   public function inputStream() {
     $expect= '<response><type>status</type><payload><bool>true</bool></payload></response>';
@@ -462,9 +324,6 @@ abstract class AbstractSocketTest extends TestCase {
     $this->assertEquals('+ECHO '.$expect, $si->read(strlen($expect)+ strlen('+ECHO ')));
   }
 
-  /**
-   * Test remoteEndpoint() method
-   */
   #[@test]
   public function remoteEndpoint() {
     $this->assertEquals(
@@ -473,17 +332,11 @@ abstract class AbstractSocketTest extends TestCase {
     );
   }
 
-  /**
-   * Test localEndpoint() method
-   */
   #[@test]
   public function localEndpointForUnconnectedSocket() {
     $this->assertNull($this->fixture->localEndpoint());
   }
 
-  /**
-   * Test localEndpoint() method
-   */
   #[@test]
   public function localEndpointForConnectedSocket() {
     $this->fixture->connect();

--- a/src/test/php/net/xp_framework/unittest/peer/sockets/AbstractSocketTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/sockets/AbstractSocketTest.class.php
@@ -1,18 +1,13 @@
 <?php namespace net\xp_framework\unittest\peer\sockets;
 
-use unittest\TestCase;
 use peer\Socket;
+use peer\SocketEndpoint;
 use peer\SocketException;
 use peer\ConnectException;
 use peer\SocketTimeoutException;
 use lang\Runtime;
 
-/**
- * TestCase
- *
- * @see      xp://peer.Socket
- */
-abstract class AbstractSocketTest extends TestCase {
+abstract class AbstractSocketTest extends \unittest\TestCase {
   protected static $bindAddress= [null, -1];
   protected $fixture= null;
 
@@ -327,7 +322,7 @@ abstract class AbstractSocketTest extends TestCase {
   #[@test]
   public function remoteEndpoint() {
     $this->assertEquals(
-      new \peer\SocketEndpoint(self::$bindAddress[0], self::$bindAddress[1]),
+      new SocketEndpoint(self::$bindAddress[0], self::$bindAddress[1]),
       $this->fixture->remoteEndpoint()
     );
   }
@@ -340,6 +335,6 @@ abstract class AbstractSocketTest extends TestCase {
   #[@test]
   public function localEndpointForConnectedSocket() {
     $this->fixture->connect();
-    $this->assertInstanceOf('peer.SocketEndpoint', $this->fixture->localEndpoint());
+    $this->assertInstanceOf(SocketEndpoint::class, $this->fixture->localEndpoint());
   }
 }

--- a/src/test/php/net/xp_framework/unittest/peer/sockets/BSDSocketTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/sockets/BSDSocketTest.class.php
@@ -4,6 +4,7 @@ use unittest\actions\ExtensionAvailable;
 use unittest\actions\Actions;
 use net\xp_framework\unittest\StartServer;
 use peer\BSDSocket;
+use lang\IllegalStateException;
 
 /**
  * TestCase
@@ -28,91 +29,55 @@ class BSDSocketTest extends AbstractSocketTest {
     return new BSDSocket($addr, $port);
   }
   
-  /**
-   * Test setDomain() and getDomain() with AF_INET
-   *
-   */
   #[@test]
   public function inetDomain() {
     $this->fixture->setDomain(AF_INET);
     $this->assertEquals(AF_INET, $this->fixture->getDomain());
   }
 
-  /**
-   * Test setDomain() and getDomain() with AF_UNIX
-   *
-   */
   #[@test]
   public function unixDomain() {
     $this->fixture->setDomain(AF_UNIX);
     $this->assertEquals(AF_UNIX, $this->fixture->getDomain());
   }
 
-  /**
-   * Test setDomain()
-   *
-   */
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function setDomainOnConnected() {
     $this->fixture->connect();
     $this->fixture->setDomain(AF_UNIX);
   }
 
-  /**
-   * Test setType() and getType() with SOCK_STREAM
-   *
-   */
   #[@test]
   public function streamType() {
     $this->fixture->setType(SOCK_STREAM);
     $this->assertEquals(SOCK_STREAM, $this->fixture->getType());
   }
 
-  /**
-   * Test setType() and getType() with SOCK_DGRAM
-   *
-   */
   #[@test]
   public function dgramType() {
     $this->fixture->setType(SOCK_DGRAM);
     $this->assertEquals(SOCK_DGRAM, $this->fixture->getType());
   }
 
-  /**
-   * Test setType()
-   *
-   */
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function setTypeOnConnected() {
     $this->fixture->connect();
     $this->fixture->setType(SOCK_STREAM);
   }
 
-  /**
-   * Test setProtocol() and getProtocol() with SOL_TCP
-   *
-   */
   #[@test]
   public function tcpProtocol() {
     $this->fixture->setProtocol(SOL_TCP);
     $this->assertEquals(SOL_TCP, $this->fixture->getProtocol());
   }
 
-  /**
-   * Test setProtocol() and getProtocol() with SOL_UDP
-   *
-   */
   #[@test]
   public function udpProtocol() {
     $this->fixture->setProtocol(SOL_UDP);
     $this->assertEquals(SOL_UDP, $this->fixture->getProtocol());
   }
 
-  /**
-   * Test setProtocol()
-   *
-   */
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function setProtocolOnConnected() {
     $this->fixture->connect();
     $this->fixture->setProtocol(SOL_TCP);

--- a/src/test/php/net/xp_framework/unittest/peer/sockets/SocketEndpointTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/peer/sockets/SocketEndpointTest.class.php
@@ -1,17 +1,16 @@
 <?php namespace net\xp_framework\unittest\peer\sockets;
 
-use unittest\TestCase;
 use peer\SocketEndpoint;
 use peer\net\Inet4Address;
 use peer\net\Inet6Address;
-
+use lang\FormatException;
 
 /**
  * TestCase
  *
  * @see      xp://peer.SocketEndpoint
  */
-class SocketEndpointTest extends TestCase {
+class SocketEndpointTest extends \unittest\TestCase {
 
   #[@test]
   public function v4_string_passed_to_constructor() {
@@ -93,17 +92,17 @@ class SocketEndpointTest extends TestCase {
     $this->assertEquals(new SocketEndpoint('fe80::1', 6100), SocketEndpoint::valueOf('[fe80::1]:6100'));
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function value_of_empty_string() {
     SocketEndpoint::valueOf('');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function value_of_without_colon() {
     SocketEndpoint::valueOf('127.0.0.1');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function value_of_without_port() {
     SocketEndpoint::valueOf('127.0.0.1:');
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassCastingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassCastingTest.class.php
@@ -4,6 +4,7 @@ use unittest\TestCase;
 use lang\XPClass;
 use lang\Object;
 use lang\Type;
+use lang\ClassCastException;
 
 /**
  * TestCase
@@ -27,12 +28,12 @@ class ClassCastingTest extends TestCase {
     $this->assertEquals($this, XPClass::forName('lang.Object')->cast($this));
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function thisClassCastingAnObject() {
     $this->getClass()->cast(new Object());
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function thisClassCastingAnUnrelatedClass() {
     $this->getClass()->cast(Type::$VOID);
   }
@@ -42,7 +43,7 @@ class ClassCastingTest extends TestCase {
     $this->assertNull($this->getClass()->cast(null));
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function castPrimitive() {
     $this->getClass()->cast(0);
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use unittest\TestCase;
 use lang\reflect\ClassParser;
+use lang\Object;
 
 define('APIDOC_TAG',        0x0001);
 define('APIDOC_VALUE',      0x0002);
@@ -13,7 +13,7 @@ define('APIDOC_VALUE',      0x0002);
  * @see  https://github.com/xp-framework/xp-framework/issues/230
  * @see  https://github.com/xp-framework/xp-framework/issues/270
  */
-class ClassDetailsTest extends TestCase {
+class ClassDetailsTest extends \unittest\TestCase {
 
   /**
    * Helper method that parses an apidoc comment and returns the matches
@@ -262,7 +262,7 @@ class ClassDetailsTest extends TestCase {
       class Test extends Object {
       }
     ');
-    $this->assertInstanceOf('lang.Object', $actual['class'][DETAIL_ANNOTATIONS]['value']);
+    $this->assertInstanceOf(Object::class, $actual['class'][DETAIL_ANNOTATIONS]['value']);
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassFromUriTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassFromUriTest.class.php
@@ -1,14 +1,14 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use unittest\TestCase;
 use lang\MethodNotImplementedException;
+use lang\ClassNotFoundException;
 
 /**
  * TestCase for resolving classes from URIs using the `loadUri()` method.
  *
  * @see  xp://net.xp_framework.unittest.reflection.ClassFromFileSystemTest
  */
-abstract class ClassFromUriTest extends TestCase {
+abstract class ClassFromUriTest extends \unittest\TestCase {
   protected static $base;
   protected $fixture;
 
@@ -133,22 +133,22 @@ abstract class ClassFromUriTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function from_an_absolute_path_not_inside_cl_base() {
     $this->fixture->loadUri($this->compose(null, 'CLT1.class.php'));
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function from_non_class_file() {
     $this->fixture->loadUri('CLT1.txt');
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function from_directory() {
     $this->fixture->loadUri($this->compose(self::$base, 'net', 'xp_framework'));
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function from_non_existant_file() {
     $this->fixture->loadUri($this->compose(self::$base, 'NonExistant.File'));
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
@@ -2,6 +2,11 @@
 
 use lang\XPClass;
 use lang\ClassLoader;
+use lang\ClassFormatException;
+use lang\ClassNotFoundException;
+use lang\ClassDependencyException;
+use lang\ClassCastException;
+use lang\IllegalStateException;
 use lang\reflect\Package;
 use lang\archive\Archive;
 use lang\archive\ArchiveClassLoader;
@@ -133,22 +138,22 @@ class ClassLoaderTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function loadNonExistantClass() {
     ClassLoader::getDefault()->loadClass('@@NON-EXISTANT@@');
   }
 
-  #[@test, @expect('lang.ClassFormatException')]
+  #[@test, @expect(ClassFormatException::class)]
   public function loadClassFileWithoutDeclaration() {
     XPClass::forName('net.xp_framework.unittest.reflection.classes.broken.NoClass');
   }
 
-  #[@test, @expect('lang.ClassFormatException')]
+  #[@test, @expect(ClassFormatException::class)]
   public function loadClassFileWithIncorrectDeclaration() {
     XPClass::forName('net.xp_framework.unittest.reflection.classes.broken.FalseClass');
   }
 
-  #[@test, @expect('lang.ClassDependencyException')]
+  #[@test, @expect(ClassDependencyException::class)]
   public function loadClassWithBrokenDependency() {
     XPClass::forName('net.xp_framework.unittest.reflection.classes.broken.BrokenDependencyClass');
   }
@@ -162,12 +167,12 @@ class ClassLoaderTest extends \unittest\TestCase {
     }
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function newInstance() {
     (new XPClass('DoesNotExist'))->reflect();
   }
 
-  #[@test, @expect('lang.ClassCastException')]
+  #[@test, @expect(ClassCastException::class)]
   public function newInstance__PHP_Incomplete_Class() {
     new XPClass(unserialize('O:12:"DoesNotExist":0:{}'));
   }
@@ -197,7 +202,7 @@ class ClassLoaderTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function loadingClassoneFails() {
     ClassLoader::getDefault()
       ->loadClass('net.xp_framework.unittest.reflection.classes.Classone')
@@ -240,7 +245,7 @@ class ClassLoaderTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function loadNonExistantUri() {
     ClassLoader::getDefault()->loadUri('non/existant/Class.class.php');
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
@@ -85,16 +85,16 @@ class ClassLoaderTest extends \unittest\TestCase {
   #[@test]
   public function archiveClassLoader() {
     $this->assertInstanceOf(
-      'lang.archive.ArchiveClassLoader',
-       XPClass::forName('net.xp_framework.unittest.reflection.classes.ClassThree')->getClassLoader()
+      ArchiveClassLoader::class,
+      XPClass::forName('net.xp_framework.unittest.reflection.classes.ClassThree')->getClassLoader()
     );
   }
 
   #[@test]
   public function containedArchiveClassLoader() {
     $this->assertInstanceOf(
-      'lang.archive.ArchiveClassLoader',
-       XPClass::forName('net.xp_framework.unittest.reflection.classes.ClassFive')->getClassLoader()
+      ArchiveClassLoader::class,
+      XPClass::forName('net.xp_framework.unittest.reflection.classes.ClassFive')->getClassLoader()
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassPathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassPathTest.class.php
@@ -1,14 +1,14 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use unittest\TestCase;
-
+use lang\ClassLoader;
+use lang\ElementNotFoundException;
 
 /**
  * TestCase for classloading
  *
  * @see    xp://lang.ClassLoader#registerPath
  */
-class ClassPathTest extends TestCase {
+class ClassPathTest extends \unittest\TestCase {
   protected $registered= [];
 
   /**
@@ -25,74 +25,51 @@ class ClassPathTest extends TestCase {
   /**
    * Removes all registered paths
    *
+   * @return void
    */
   public function tearDown() {
     foreach ($this->registered as $l) {
-      \lang\ClassLoader::removeLoader($l);
+      ClassLoader::removeLoader($l);
     }
   }
 
-  /**
-   * Test registering a path before all others
-   *
-   */
   #[@test]
   public function before() {
-    $loader= $this->track(\lang\ClassLoader::registerPath('.', true));
-    $loaders= \lang\ClassLoader::getLoaders();
+    $loader= $this->track(ClassLoader::registerPath('.', true));
+    $loaders= ClassLoader::getLoaders();
     $this->assertEquals($loader, $loaders[0]);
   } 
 
-  /**
-   * Test registering a path after all others
-   *
-   */
   #[@test]
   public function after() {
-    $loader= $this->track(\lang\ClassLoader::registerPath('.', false));
-    $loaders= \lang\ClassLoader::getLoaders();
+    $loader= $this->track(ClassLoader::registerPath('.', false));
+    $loaders= ClassLoader::getLoaders();
     $this->assertEquals($loader, $loaders[sizeof($loaders)- 1]);
   }
 
-  /**
-   * Test registering a path after all others is the default
-   *
-   */
   #[@test]
   public function after_is_default() {
-    $loader= $this->track(\lang\ClassLoader::registerPath('.'));
-    $loaders= \lang\ClassLoader::getLoaders();
+    $loader= $this->track(ClassLoader::registerPath('.'));
+    $loaders= ClassLoader::getLoaders();
     $this->assertEquals($loader, $loaders[sizeof($loaders)- 1]);
   }
 
-  /**
-   * Inspect path: it begins with !, so it is loaded first
-   *
-   */
   #[@test]
   public function before_via_inspect() {
-    $loader= $this->track(\lang\ClassLoader::registerPath('!.', null));
-    $loaders= \lang\ClassLoader::getLoaders();
+    $loader= $this->track(ClassLoader::registerPath('!.', null));
+    $loaders= ClassLoader::getLoaders();
     $this->assertEquals($loader, $loaders[0]);
   }
 
-  /**
-   * Inspect path: it does not begin with !, so it is loaded last
-   *
-   */
   #[@test]
   public function after_via_inspect() {
-    $loader= $this->track(\lang\ClassLoader::registerPath('.', null));
-    $loaders= \lang\ClassLoader::getLoaders();
+    $loader= $this->track(ClassLoader::registerPath('.', null));
+    $loaders= ClassLoader::getLoaders();
     $this->assertEquals($loader, $loaders[sizeof($loaders)- 1]);
   }
 
-  /**
-   * Test registering a non-existant path
-   *
-   */
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function non_existant() {
-    \lang\ClassLoader::registerPath('@@non-existant@@');
+    ClassLoader::registerPath('@@non-existant@@');
   } 
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/FieldsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/FieldsTest.class.php
@@ -1,5 +1,10 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
+use lang\XPClass;
+use lang\ElementNotFoundException;
+use lang\IllegalArgumentException;
+use lang\IllegalAccessException;
+
 class FieldsTest extends \unittest\TestCase {
   private $fixture;
 
@@ -9,7 +14,7 @@ class FieldsTest extends \unittest\TestCase {
    * @return void
    */
   public function setUp() {
-    $this->fixture= \lang\XPClass::forName('net.xp_framework.unittest.reflection.TestClass');
+    $this->fixture= XPClass::forName('net.xp_framework.unittest.reflection.TestClass');
   }
 
   /**
@@ -104,7 +109,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.XPClass#getField
    */
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function getNonExistantField() {
     $this->fixture->getField('@@nonexistant@@');
   }
@@ -124,7 +129,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.XPClass#getField
    */
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function getSpecialIdField() {
     $this->fixture->getField('__id');
   }
@@ -202,7 +207,7 @@ class FieldsTest extends \unittest\TestCase {
     with ($field= $this->fixture->getField('date')); {
       $this->assertInstanceOf('lang.reflect.Field', $field);
       $this->assertEquals('date', $field->getName());
-      $this->assertEquals(\lang\XPClass::forName('util.Date'), $field->getType());
+      $this->assertEquals(XPClass::forName('util.Date'), $field->getType());
       $this->assertTrue($this->fixture->equals($field->getDeclaringClass()));
     }
   }
@@ -237,7 +242,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.reflect.Field#get
    */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function getDateFieldValueOnWrongObject() {
     $this->fixture->getField('date')->get(new \lang\Object());
   }
@@ -247,7 +252,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.reflect.Field#set
    */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function setDateFieldValueOnWrongObject() {
     $this->fixture->getField('date')->set(new \lang\Object(), \util\Date::now());
   }
@@ -283,7 +288,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.reflect.Field#get
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function getCacheFieldValue() {
     $this->fixture->getField('cache')->get(null);
   }
@@ -293,7 +298,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.reflect.Field#set
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function setCacheFieldValue() {
     $this->fixture->getField('cache')->set(null, []);
   }
@@ -303,7 +308,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.reflect.Field#get
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function getSizeFieldValue() {
     $this->fixture->getField('size')->get($this->fixture->newInstance());
   }
@@ -313,7 +318,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.reflect.Field#set
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function setSizeFieldValue() {
     $this->fixture->getField('size')->set($this->fixture->newInstance(), 1);
   }
@@ -323,7 +328,7 @@ class FieldsTest extends \unittest\TestCase {
    *
    * @see     xp://lang.reflect.Field#get
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function factorFieldValue() {
     $this->fixture->getField('factor')->get($this->fixture->newInstance());
   }
@@ -361,7 +366,7 @@ class FieldsTest extends \unittest\TestCase {
    */
   #[@test]
   public function dateFieldType() {
-    $this->assertEquals(\lang\XPClass::forName('util.Date'), $this->fixture->getField('date')->getType());
+    $this->assertEquals(XPClass::forName('util.Date'), $this->fixture->getField('date')->getType());
   }
 
   /**
@@ -440,7 +445,7 @@ class FieldsTest extends \unittest\TestCase {
    */
   #[@test]
   public function fieldTypeForInheritedField() {
-    $this->assertEquals(\lang\XPClass::forName('lang.Object'), $this->fixture->getField('inherited')->getType());
+    $this->assertEquals(XPClass::forName('lang.Object'), $this->fixture->getField('inherited')->getType());
   }
 
   /**

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -3,6 +3,9 @@
 use lang\Generic;
 use lang\XPClass;
 use lang\Type;
+use lang\ClassFormatException;
+use lang\IllegalStateException;
+use lang\ElementNotFoundException;
 
 class MethodParametersTest extends \unittest\TestCase {
 
@@ -126,7 +129,7 @@ class MethodParametersTest extends \unittest\TestCase {
     $this->assertNull($this->method('fixture')->getParameter(6)->getTypeRestriction());
   }
 
-  #[@test, @expect('lang.ClassFormatException')]
+  #[@test, @expect(ClassFormatException::class)]
   public function nonexistant_restriction_class_parameter() {
     $this->method('fixturex')->getParameter(0)->getTypeRestriction();
   }
@@ -187,7 +190,7 @@ class MethodParametersTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.ClassFormatException')]
+  #[@test, @expect(ClassFormatException::class)]
   public function nonexistant_typed_class_parameter() {
     $this->method('fixturex')->getParameter(0)->getType();
   }
@@ -266,7 +269,7 @@ class MethodParametersTest extends \unittest\TestCase {
     $this->assertTrue($this->method('fixture')->getParameter(6)->isOptional());
   }
 
-  #[@test, @expect(class= 'lang.IllegalStateException', withMessage= 'Parameter "a" has no default value')]
+  #[@test, @expect(class= IllegalStateException::class, withMessage= 'Parameter "a" has no default value')]
   public function required_parameter_does_not_have_default_value() {
     $this->method('fixture')->getParameter(0)->getDefaultValue();
   }
@@ -311,7 +314,7 @@ class MethodParametersTest extends \unittest\TestCase {
     $this->assertEquals([], $this->method('fixture')->getParameter(0)->getAnnotations());
   }
 
-  #[@test, @expect(class= 'lang.ElementNotFoundException', withMessage= 'Annotation "test" does not exist')]
+  #[@test, @expect(class= ElementNotFoundException::class, withMessage= 'Annotation "test" does not exist')]
   public function cannot_get_test_annotation_for_un_annotated_parameter() {
     $this->method('fixture')->getParameter(0)->getAnnotation('test');
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodsTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\XPClass;
 use lang\Object;
+use lang\Error;
 use lang\Type;
 use lang\MapType;
 use lang\Primitive;
@@ -17,13 +18,9 @@ use unittest\actions\RuntimeVersion;
  * @see    xp://lang.reflect.Method
  */
 class MethodsTest extends \unittest\TestCase {
-  protected $fixture;
+  private $fixture;
 
-  /**
-   * Sets up test case
-   *
-   * @return void
-   */
+  /** @return void */
   public function setUp() {
     $this->fixture= XPClass::forName('net.xp_framework.unittest.reflection.TestClass');
   }
@@ -44,8 +41,8 @@ class MethodsTest extends \unittest\TestCase {
   /**
    * Assertion helper
    *
-   * @param   lang.Generic var
-   * @param   lang.Generic[] list
+   * @param   lang.Generic $var
+   * @param   lang.Generic[] $list
    * @throws  unittest.AssertionFailedError
    */
   protected function assertContained($var, $list) {
@@ -401,7 +398,7 @@ class MethodsTest extends \unittest\TestCase {
     $this->assertEquals(XPClass::forName('lang.Object'), $o->getClass()->getMethod('fixture')->getReturnType());
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0'))]
   public function violatingReturnType() {
     $o= newinstance(Object::class, [], '{
       public function fixture(): Object { return "Test"; }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodsTest.class.php
@@ -5,6 +5,10 @@ use lang\Object;
 use lang\Type;
 use lang\MapType;
 use lang\Primitive;
+use lang\ElementNotFoundException;
+use lang\IllegalAccessException;
+use lang\IllegalArgumentException;
+use lang\reflect\TargetInvocationException;
 use unittest\actions\RuntimeVersion;
 
 /**
@@ -27,8 +31,8 @@ class MethodsTest extends \unittest\TestCase {
   /**
    * Assertion helper
    *
-   * @param   lang.Generic var
-   * @param   lang.Generic[] list
+   * @param   lang.Generic $var
+   * @param   lang.Generic[] $list
    * @throws  unittest.AssertionFailedError
    */
   protected function assertNotContained($var, $list) {
@@ -97,7 +101,7 @@ class MethodsTest extends \unittest\TestCase {
     $this->assertFalse($this->fixture->hasMethod('@@nonexistant@@'));
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function getNonExistantMethod() {
     $this->fixture->getMethod('@@nonexistant@@');
   }
@@ -107,7 +111,7 @@ class MethodsTest extends \unittest\TestCase {
     $this->assertFalse($this->fixture->hasMethod('__construct'));
   }
   
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function constructorIsNotAMethod() {
     $this->fixture->getMethod('__construct');
   }
@@ -117,7 +121,7 @@ class MethodsTest extends \unittest\TestCase {
     $this->assertFalse($this->fixture->hasMethod('__static'));
   }
   
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function staticInitializerIsNotAMethod() {
     $this->fixture->getMethod('__static');
   }
@@ -175,12 +179,12 @@ class MethodsTest extends \unittest\TestCase {
     }
   }
 
-  #[@test, @expect('lang.reflect.TargetInvocationException')]
+  #[@test, @expect(TargetInvocationException::class)]
   public function invokeSetTrace() {
     $this->fixture->getMethod('setTrace')->invoke($this->fixture->newInstance(), [null]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function invokeSetTraceOnWrongObject() {
     $this->fixture->getMethod('setTrace')->invoke(new \lang\Object(), [null]);
   }
@@ -190,17 +194,17 @@ class MethodsTest extends \unittest\TestCase {
     $this->assertTrue($this->fixture->getMethod('initializerCalled')->invoke(null));
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokePrivateMethod() {
     $this->fixture->getMethod('defaultMap')->invoke($this->fixture->newInstance());
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokeProtectedMethod() {
     $this->fixture->getMethod('clearMap')->invoke($this->fixture->newInstance());
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokeAbstractMethod() {
     XPClass::forName('net.xp_framework.unittest.reflection.AbstractTestClass')
       ->getMethod('getDate')

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodsTest.class.php
@@ -9,6 +9,7 @@ use lang\Primitive;
 use lang\ElementNotFoundException;
 use lang\IllegalAccessException;
 use lang\IllegalArgumentException;
+use lang\reflect\Method;
 use lang\reflect\TargetInvocationException;
 use unittest\actions\RuntimeVersion;
 
@@ -169,7 +170,7 @@ class MethodsTest extends \unittest\TestCase {
   public function getDateMethod() {
     $this->assertTrue($this->fixture->hasMethod('getDate'));
     with ($method= $this->fixture->getMethod('getDate')); {
-      $this->assertInstanceOf('lang.reflect.Method', $method);
+      $this->assertInstanceOf(Method::class, $method);
       $this->assertEquals('getDate', $method->getName(true));
       $this->assertTrue($this->fixture->equals($method->getDeclaringClass()));
       $this->assertEquals('util.Date', $method->getReturnTypeName());

--- a/src/test/php/net/xp_framework/unittest/reflection/ModuleLoadingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ModuleLoadingTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\ClassLoader;
 use lang\reflect\Module;
+use lang\ElementNotFoundException;
 
 /**
  * TestCase for modules
@@ -57,12 +58,12 @@ class ModuleLoadingTest extends \unittest\TestCase {
     }']));
   }
 
-  #[@test, @expect(class= 'lang.ElementNotFoundException', withMessage= '/Missing or malformed module-info/')]
+  #[@test, @expect(class= ElementNotFoundException::class, withMessage= '/Missing or malformed module-info/')]
   public function empty_module_file() {
     $this->register(new LoaderProviding(['module.xp' => '']));
   }
 
-  #[@test, @expect(class= 'lang.ElementNotFoundException', withMessage= '/Missing or malformed module-info/')]
+  #[@test, @expect(class= ElementNotFoundException::class, withMessage= '/Missing or malformed module-info/')]
   public function module_without_name() {
     $this->register(new LoaderProviding(['module.xp' => 'module { }']));
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ModuleLoadingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ModuleLoadingTest.class.php
@@ -107,7 +107,7 @@ class ModuleLoadingTest extends \unittest\TestCase {
 
   #[@test]
   public function module_inheritance() {
-    $cl= ClassLoader::defineClass('net.xp_framework.unittest.reflection.BaseModule', 'lang.reflect.Module', []);
+    $cl= ClassLoader::defineClass('net.xp_framework.unittest.reflection.BaseModule', Module::class, []);
     $this->register(new LoaderProviding([
       'module.xp' => '<?php module xp-framework/child extends net\xp_framework\unittest\reflection\BaseModule { }'
     ]));

--- a/src/test/php/net/xp_framework/unittest/reflection/ModuleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ModuleTest.class.php
@@ -10,30 +10,26 @@ use lang\ElementNotFoundException;
  * @see   xp://lang.ClassLoader
  */
 class ModuleTest extends \unittest\TestCase {
-  protected $cl;
-  protected $registered= [];
+  private $cl;
+  private $registered= [];
 
   /**
    * Register a loader with the CL
    *
    * @param  lang.reflect.Module $module
    */
-  protected function register($module) {
+  private function register($module) {
     $this->registered[]= Module::register($module);
   }
 
-  /**
-   * Tears down test, removing all modules registered
-   */
+  /** @return void */
   public function tearDown() {
     foreach ($this->registered as $module) {
       Module::remove($module);
     }
   }
 
-  /**
-   * Sets up test.
-   */
+  /** @return void */
   public function setUp() {
     $this->cl= ClassLoader::getDefault();
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ModuleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ModuleTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\reflect\Module;
 use lang\ClassLoader;
+use lang\ElementNotFoundException;
 
 /**
  * TestCase for modules
@@ -90,7 +91,7 @@ class ModuleTest extends \unittest\TestCase {
   }
 
   #[@test, @expect(
-  #  class= 'lang.ElementNotFoundException',
+  #  class= ElementNotFoundException::class,
   #  withMessage= 'No module "@@non-existant@@" declared'
   #)]
   public function forName_throws_exception_when_no_module_registered() {

--- a/src/test/php/net/xp_framework/unittest/reflection/PackageTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PackageTest.class.php
@@ -6,6 +6,7 @@ use lang\reflect\Package;
 use lang\ClassLoader;
 use lang\XPClass;
 use lang\IllegalArgumentException;
+use lang\ElementNotFoundException;
 
 /**
  * TestCase
@@ -26,6 +27,8 @@ class PackageTest extends \unittest\TestCase {
   /**
    * Setup this test. Registeres class loaders deleates for the 
    * afforementioned XARs
+   *
+   * @return void
    */
   public function setUp() {
     $this->libraryLoader= ClassLoader::registerLoader(new ArchiveClassLoader(new Archive((new XPClass(__CLASS__))
@@ -38,6 +41,8 @@ class PackageTest extends \unittest\TestCase {
   /**
    * Tear down this test. Removes classloader delegates registered 
    * during setUp()
+   *
+   * @return void
    */
   public function tearDown() {
     ClassLoader::removeLoader($this->libraryLoader);
@@ -51,7 +56,7 @@ class PackageTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function nonExistantPackage() {
     Package::forName('@@non-existant-package@@');
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/PackageTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PackageTest.class.php
@@ -5,6 +5,7 @@ use lang\archive\ArchiveClassLoader;
 use lang\reflect\Package;
 use lang\ClassLoader;
 use lang\XPClass;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
@@ -79,7 +80,7 @@ class PackageTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function loadClassFromDifferentPackage() {
     Package::forName('net.xp_framework.unittest.reflection.classes')->loadClass('lang.reflect.Method');
   }
@@ -183,7 +184,7 @@ class PackageTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function loadPackageByDifferentName() {
     Package::forName('net.xp_framework.unittest.reflection')->getPackage('lang.reflect');
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/PrimitiveAndWrappersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrimitiveAndWrappersTest.class.php
@@ -9,6 +9,7 @@ use lang\types\Short;
 use lang\types\Float;
 use lang\types\Boolean;
 use lang\types\ArrayList;
+use lang\IllegalArgumentException;
 use io\streams\Streams;
 use io\streams\MemoryInputStream;
 use unittest\actions\RuntimeVersion;
@@ -63,7 +64,7 @@ class PrimitiveAndWrappersTest extends TestCase {
     $fd= Streams::readableFd(new MemoryInputStream('test'));
     try {
       Primitive::boxed($fd);
-    } catch (\lang\IllegalArgumentException $expected) {
+    } catch (IllegalArgumentException $expected) {
       return;
     } finally {
       fclose($fd);    // Necessary, PHP will segfault otherwise
@@ -97,7 +98,7 @@ class PrimitiveAndWrappersTest extends TestCase {
     $this->assertEquals([1, 2, 3], Primitive::unboxed(new ArrayList(1, 2, 3)));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]]
+  #[@test, @expect(IllegalArgumentException::class)]]
   public function unboxObject() {
     Primitive::unboxed(new \lang\Object());
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
@@ -2,6 +2,7 @@
 
 use unittest\TestCase;
 use lang\Primitive;
+use lang\ClassCastException;
 use lang\IllegalArgumentException;
 use io\streams\Streams;
 use io\streams\MemoryInputStream;
@@ -244,12 +245,12 @@ class PrimitiveTest extends TestCase {
     Primitive::forName($name)->newInstance(['one' => 'two']);
   }
 
-  #[@test, @expect('lang.ClassCastException'), @values(['int', 'double', 'bool', 'string'])]
+  #[@test, @expect(ClassCastException::class), @values(['int', 'double', 'bool', 'string'])]
   public function cannot_cast_arrays_to_primitives($name) {
     Primitive::forName($name)->cast([1, 2, 3]);
   }
 
-  #[@test, @expect('lang.ClassCastException'), @values(['int', 'double', 'bool', 'string'])]
+  #[@test, @expect(ClassCastException::class), @values(['int', 'double', 'bool', 'string'])]
   public function cannot_cast_maps_to_primitives($name) {
     Primitive::forName($name)->cast(['one' => 'two']);
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
@@ -2,6 +2,7 @@
 
 use unittest\TestCase;
 use lang\Primitive;
+use lang\IllegalArgumentException;
 use io\streams\Streams;
 use io\streams\MemoryInputStream;
 use unittest\actions\RuntimeVersion;
@@ -33,12 +34,12 @@ class PrimitiveTest extends TestCase {
     $this->assertEquals(Primitive::$BOOL, Primitive::forName('bool'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function arrayPrimitive() {
     Primitive::forName('array');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function nonPrimitive() {
     Primitive::forName('lang.Object');
   }
@@ -233,12 +234,12 @@ class PrimitiveTest extends TestCase {
     $this->assertEquals($expected, Primitive::$BOOL->cast($value));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values(['int', 'double', 'bool', 'string'])]
+  #[@test, @expect(IllegalArgumentException::class), @values(['int', 'double', 'bool', 'string'])]
   public function cannot_create_instances_of_primitives_from_arrays($name) {
     Primitive::forName($name)->newInstance([1, 2, 3]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @values(['int', 'double', 'bool', 'string'])]
+  #[@test, @expect(IllegalArgumentException::class), @values(['int', 'double', 'bool', 'string'])]
   public function cannot_create_instances_of_primitives_from_maps($name) {
     Primitive::forName($name)->newInstance(['one' => 'two']);
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/PrivateAccessibilityTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrivateAccessibilityTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use unittest\TestCase;
 use lang\ClassLoader;
+use lang\XPClass;
 use lang\IllegalAccessException;
 
 /**
@@ -11,20 +11,17 @@ use lang\IllegalAccessException;
  * @see      xp://lang.reflect.Method
  * @see      xp://lang.reflect.Field
  */
-class PrivateAccessibilityTest extends TestCase {
-  private static 
-    $fixture          = null, 
-    $fixtureChild     = null,
-    $fixtureCtorChild = null;
+class PrivateAccessibilityTest extends \unittest\TestCase {
+  private static $fixture, $fixtureChild, $fixtureCtorChild;
   
   /**
    * Initialize fixture, fixtureChild and fixtureCtorChild members
    */
   #[@beforeClass]
   public static function initializeClasses() {
-    self::$fixture= \lang\XPClass::forName('net.xp_framework.unittest.reflection.PrivateAccessibilityFixture');
-    self::$fixtureChild= \lang\XPClass::forName('net.xp_framework.unittest.reflection.PrivateAccessibilityFixtureChild');
-    self::$fixtureCtorChild= \lang\XPClass::forName('net.xp_framework.unittest.reflection.PrivateAccessibilityFixtureCtorChild');
+    self::$fixture= XPClass::forName('net.xp_framework.unittest.reflection.PrivateAccessibilityFixture');
+    self::$fixtureChild= XPClass::forName('net.xp_framework.unittest.reflection.PrivateAccessibilityFixtureChild');
+    self::$fixtureCtorChild= XPClass::forName('net.xp_framework.unittest.reflection.PrivateAccessibilityFixtureCtorChild');
   }
 
   #[@test, @expect(IllegalAccessException::class)]

--- a/src/test/php/net/xp_framework/unittest/reflection/PrivateAccessibilityTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrivateAccessibilityTest.class.php
@@ -2,6 +2,7 @@
 
 use unittest\TestCase;
 use lang\ClassLoader;
+use lang\IllegalAccessException;
 
 /**
  * TestCase
@@ -26,7 +27,7 @@ class PrivateAccessibilityTest extends TestCase {
     self::$fixtureCtorChild= \lang\XPClass::forName('net.xp_framework.unittest.reflection.PrivateAccessibilityFixtureCtorChild');
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateConstructor() {
     self::$fixture->getConstructor()->newInstance([]);
   }
@@ -36,12 +37,12 @@ class PrivateAccessibilityTest extends TestCase {
     $this->assertInstanceOf(self::$fixture, PrivateAccessibilityFixture::construct(self::$fixture));
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateConstructorFromParentClass() {
     PrivateAccessibilityFixtureCtorChild::construct(self::$fixture);
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateConstructorFromChildClass() {
     PrivateAccessibilityFixtureCtorChild::construct(self::$fixtureChild);
   }
@@ -55,7 +56,7 @@ class PrivateAccessibilityTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateMethod() {
     self::$fixture->getMethod('target')->invoke(PrivateAccessibilityFixture::construct(self::$fixture));
   }
@@ -65,12 +66,12 @@ class PrivateAccessibilityTest extends TestCase {
     $this->assertEquals('Invoked', PrivateAccessibilityFixture::invoke(self::$fixture));
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateMethodFromParentClass() {
     PrivateAccessibilityFixtureChild::invoke(self::$fixture);
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateMethodFromChildClass() {
     PrivateAccessibilityFixtureChild::invoke(self::$fixtureChild);
   }
@@ -84,7 +85,7 @@ class PrivateAccessibilityTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateStaticMethod() {
     self::$fixture->getMethod('staticTarget')->invoke(null);
   }
@@ -94,12 +95,12 @@ class PrivateAccessibilityTest extends TestCase {
     $this->assertEquals('Invoked', PrivateAccessibilityFixture::invokeStatic(self::$fixture));
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateStaticMethodFromParentClass() {
     PrivateAccessibilityFixtureChild::invokeStatic(self::$fixture);
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingPrivateStaticMethodFromChildClass() {
     PrivateAccessibilityFixtureChild::invokeStatic(self::$fixtureChild);
   }
@@ -113,7 +114,7 @@ class PrivateAccessibilityTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function readingPrivateMember() {
     self::$fixture->getField('target')->get(PrivateAccessibilityFixture::construct(self::$fixture));
   }
@@ -123,7 +124,7 @@ class PrivateAccessibilityTest extends TestCase {
     $this->assertEquals('Target', PrivateAccessibilityFixture::read(self::$fixture));
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function readingPrivateMemberFromParentClass() {
     PrivateAccessibilityFixtureChild::read(self::$fixture);
   }
@@ -142,7 +143,7 @@ class PrivateAccessibilityTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function readingPrivateStaticMember() {
     self::$fixture->getField('staticTarget')->get(null);
   }
@@ -152,7 +153,7 @@ class PrivateAccessibilityTest extends TestCase {
     $this->assertEquals('Target', PrivateAccessibilityFixture::readStatic(self::$fixture));
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function readingPrivateStaticMemberFromParentClass() {
     PrivateAccessibilityFixtureChild::readStatic(self::$fixture);
   }
@@ -171,7 +172,7 @@ class PrivateAccessibilityTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function writingPrivateMember() {
     self::$fixture->getField('target')->set(PrivateAccessibilityFixture::construct(self::$fixture), null);
   }
@@ -181,7 +182,7 @@ class PrivateAccessibilityTest extends TestCase {
     $this->assertEquals('Modified', PrivateAccessibilityFixture::write(self::$fixture));
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function writingPrivateMemberFromParentClass() {
     PrivateAccessibilityFixtureChild::write(self::$fixture);
   }
@@ -200,7 +201,7 @@ class PrivateAccessibilityTest extends TestCase {
     }
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function writingPrivateStaticMember() {
     self::$fixture->getField('staticTarget')->set(null, 'Modified');
   }
@@ -210,7 +211,7 @@ class PrivateAccessibilityTest extends TestCase {
     $this->assertEquals('Modified', PrivateAccessibilityFixture::writeStatic(self::$fixture));
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function writingPrivateStaticMemberFromParentClass() {
     PrivateAccessibilityFixtureChild::writeStatic(self::$fixture);
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ProtectedAccessibilityTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ProtectedAccessibilityTest.class.php
@@ -2,7 +2,7 @@
 
 use unittest\TestCase;
 use lang\ClassLoader;
-
+use lang\IllegalAccessException;
 
 /**
  * TestCase
@@ -30,7 +30,7 @@ class ProtectedAccessibilityTest extends TestCase {
    * Invoke protected constructor from here should not work
    *
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingProtectedConstructor() {
     self::$fixture->getConstructor()->newInstance([]);
   }
@@ -79,7 +79,7 @@ class ProtectedAccessibilityTest extends TestCase {
    * Invoke protected method from here should not work
    *
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingProtectedMethod() {
     self::$fixture->getMethod('target')->invoke(ProtectedAccessibilityFixture::construct(self::$fixture));
   }
@@ -128,7 +128,7 @@ class ProtectedAccessibilityTest extends TestCase {
    * Invoke protected method from here should not work
    *
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function invokingProtectedStaticMethod() {
     self::$fixture->getMethod('staticTarget')->invoke(null);
   }
@@ -177,7 +177,7 @@ class ProtectedAccessibilityTest extends TestCase {
    * Read protected member from here should not work
    *
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function readingProtectedMember() {
     self::$fixture->getField('target')->get(ProtectedAccessibilityFixture::construct(self::$fixture));
   }
@@ -226,7 +226,7 @@ class ProtectedAccessibilityTest extends TestCase {
    * Read protected member from here should not work
    *
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function readingProtectedStaticMember() {
     self::$fixture->getField('staticTarget')->get(null);
   }
@@ -275,7 +275,7 @@ class ProtectedAccessibilityTest extends TestCase {
    * Write protected member from here should not work
    *
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function writingProtectedMember() {
     self::$fixture->getField('target')->set(ProtectedAccessibilityFixture::construct(self::$fixture), null);
   }
@@ -324,7 +324,7 @@ class ProtectedAccessibilityTest extends TestCase {
    * Write protected static member from same class
    *
    */
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function writingProtectedStaticMember() {
     self::$fixture->getField('staticTarget')->set(null, 'Modified');
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ProtectedAccessibilityTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ProtectedAccessibilityTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use unittest\TestCase;
+use lang\XPClass;
 use lang\ClassLoader;
 use lang\IllegalAccessException;
 
@@ -11,61 +11,45 @@ use lang\IllegalAccessException;
  * @see      xp://lang.reflect.Method
  * @see      xp://lang.reflect.Field
  */
-class ProtectedAccessibilityTest extends TestCase {
-  protected static 
-    $fixture        = null, 
-    $fixtureChild   = null;
+class ProtectedAccessibilityTest extends \unittest\TestCase {
+  protected static $fixture, $fixtureChild;
   
   /**
    * Initialize fixture and fixtureChild members
    *
+   * @return void
    */
   #[@beforeClass]
   public static function initializeClasses() {
-    self::$fixture= \lang\XPClass::forName('net.xp_framework.unittest.reflection.ProtectedAccessibilityFixture');
-    self::$fixtureChild= \lang\XPClass::forName('net.xp_framework.unittest.reflection.ProtectedAccessibilityFixtureChild');
+    self::$fixture= XPClass::forName('net.xp_framework.unittest.reflection.ProtectedAccessibilityFixture');
+    self::$fixtureChild= XPClass::forName('net.xp_framework.unittest.reflection.ProtectedAccessibilityFixtureChild');
   }
 
   /**
    * Invoke protected constructor from here should not work
    *
+   * @return void
    */
   #[@test, @expect(IllegalAccessException::class)]
   public function invokingProtectedConstructor() {
     self::$fixture->getConstructor()->newInstance([]);
   }
 
-  /**
-   * Invoke protected constructor from same class
-   *
-   */
   #[@test]
   public function invokingProtectedConstructorFromSameClass() {
     $this->assertInstanceOf(self::$fixture, ProtectedAccessibilityFixture::construct(self::$fixture));
   }
 
-  /**
-   * Invoke protected constructor from parent class
-   *
-   */
   #[@test]
   public function invokingProtectedConstructorFromParentClass() {
     $this->assertInstanceOf(self::$fixture, ProtectedAccessibilityFixtureChild::construct(self::$fixture));
   }
 
-  /**
-   * Invoke protected constructor from child class
-   *
-   */
   #[@test]
   public function invokingProtectedConstructorFromChildClass() {
     $this->assertInstanceOf(self::$fixtureChild, ProtectedAccessibilityFixtureChild::construct(self::$fixtureChild));
   }
 
-  /**
-   * Invoke protected constructor from here should work if it's accessible
-   *
-   */
   #[@test]
   public function invokingProtectedConstructorMadeAccessible() {
     $this->assertInstanceOf(self::$fixture, self::$fixture
@@ -75,46 +59,26 @@ class ProtectedAccessibilityTest extends TestCase {
     );
   }
 
-  /**
-   * Invoke protected method from here should not work
-   *
-   */
   #[@test, @expect(IllegalAccessException::class)]
   public function invokingProtectedMethod() {
     self::$fixture->getMethod('target')->invoke(ProtectedAccessibilityFixture::construct(self::$fixture));
   }
 
-  /**
-   * Invoke protected method from same class
-   *
-   */
   #[@test]
   public function invokingProtectedMethodFromSameClass() {
     $this->assertEquals('Invoked', ProtectedAccessibilityFixture::invoke(self::$fixture));
   }
 
-  /**
-   * Invoke protected method from parent class
-   *
-   */
   #[@test]
   public function invokingProtectedMethodFromParentClass() {
     $this->assertEquals('Invoked', ProtectedAccessibilityFixtureChild::invoke(self::$fixture));
   }
 
-  /**
-   * Invoke protected method from child class
-   *
-   */
   #[@test]
   public function invokingProtectedMethodFromChildClass() {
     $this->assertEquals('Invoked', ProtectedAccessibilityFixtureChild::invoke(self::$fixtureChild));
   }
 
-  /**
-   * Invoke protected method from here should work if it's accessible
-   *
-   */
   #[@test]
   public function invokingProtectedMethodMadeAccessible() {
     $this->assertEquals('Invoked', self::$fixture
@@ -124,46 +88,26 @@ class ProtectedAccessibilityTest extends TestCase {
     );
   }
 
-  /**
-   * Invoke protected method from here should not work
-   *
-   */
   #[@test, @expect(IllegalAccessException::class)]
   public function invokingProtectedStaticMethod() {
     self::$fixture->getMethod('staticTarget')->invoke(null);
   }
 
-  /**
-   * Invoke protected method from same class
-   *
-   */
   #[@test]
   public function invokingProtectedStaticMethodFromSameClass() {
     $this->assertEquals('Invoked', ProtectedAccessibilityFixture::invokeStatic(self::$fixture));
   }
 
-  /**
-   * Invoke protected method from same class
-   *
-   */
   #[@test]
   public function invokingProtectedStaticMethodFromParentClass() {
     $this->assertEquals('Invoked', ProtectedAccessibilityFixtureChild::invokeStatic(self::$fixture));
   }
 
-  /**
-   * Invoke protected method from same class
-   *
-   */
   #[@test]
   public function invokingProtectedStaticMethodFromChildClass() {
     $this->assertEquals('Invoked', ProtectedAccessibilityFixtureChild::invokeStatic(self::$fixtureChild));
   }
 
-  /**
-   * Invoke protected method from here should work if it's accessible
-   *
-   */
   #[@test]
   public function invokingProtectedStaticMethodMadeAccessible() {
     $this->assertEquals('Invoked', self::$fixture
@@ -173,46 +117,26 @@ class ProtectedAccessibilityTest extends TestCase {
     );
   }
 
-  /**
-   * Read protected member from here should not work
-   *
-   */
   #[@test, @expect(IllegalAccessException::class)]
   public function readingProtectedMember() {
     self::$fixture->getField('target')->get(ProtectedAccessibilityFixture::construct(self::$fixture));
   }
 
-  /**
-   * Read protected member from same class
-   *
-   */
   #[@test]
   public function readingProtectedMemberFromSameClass() {
     $this->assertEquals('Target', ProtectedAccessibilityFixture::read(self::$fixture));
   }
 
-  /**
-   * Read protected member from same class
-   *
-   */
   #[@test]
   public function readingProtectedMemberFromParentClass() {
     $this->assertEquals('Target', ProtectedAccessibilityFixtureChild::read(self::$fixture));
   }
 
-  /**
-   * Read protected member from same class
-   *
-   */
   #[@test]
   public function readingProtectedMemberFromChildClass() {
     $this->assertEquals('Target', ProtectedAccessibilityFixtureChild::read(self::$fixtureChild));
   }
 
-  /**
-   * Read protected member from here should work if it's accessible
-   *
-   */
   #[@test]
   public function readingProtectedMemberMadeAccessible() {
     $this->assertEquals('Target', self::$fixture
@@ -222,46 +146,26 @@ class ProtectedAccessibilityTest extends TestCase {
     );
   }
 
-  /**
-   * Read protected member from here should not work
-   *
-   */
   #[@test, @expect(IllegalAccessException::class)]
   public function readingProtectedStaticMember() {
     self::$fixture->getField('staticTarget')->get(null);
   }
 
-  /**
-   * Read protected static member from same class
-   *
-   */
   #[@test]
   public function readingProtectedStaticMemberFromSameClass() {
     $this->assertEquals('Target', ProtectedAccessibilityFixture::readStatic(self::$fixture));
   }
 
-  /**
-   * Read protected static member from same class
-   *
-   */
   #[@test]
   public function readingProtectedStaticMemberFromParentClass() {
     $this->assertEquals('Target', ProtectedAccessibilityFixtureChild::readStatic(self::$fixture));
   }
 
-  /**
-   * Read protected static member from same class
-   *
-   */
   #[@test]
   public function readingProtectedStaticMemberFromChildClass() {
     $this->assertEquals('Target', ProtectedAccessibilityFixtureChild::readStatic(self::$fixtureChild));
   }
 
-  /**
-   * Read protected member from here should work if it's accessible
-   *
-   */
   #[@test]
   public function readingProtectedStaticMemberMadeAccessible() {
     $this->assertEquals('Target', self::$fixture
@@ -271,46 +175,26 @@ class ProtectedAccessibilityTest extends TestCase {
     );
   }
 
-  /**
-   * Write protected member from here should not work
-   *
-   */
   #[@test, @expect(IllegalAccessException::class)]
   public function writingProtectedMember() {
     self::$fixture->getField('target')->set(ProtectedAccessibilityFixture::construct(self::$fixture), null);
   }
 
-  /**
-   * Write protected member from same class
-   *
-   */
   #[@test]
   public function writingProtectedMemberFromSameClass() {
     $this->assertEquals('Modified', ProtectedAccessibilityFixture::write(self::$fixture));
   }
 
-  /**
-   * Write protected member from same class
-   *
-   */
   #[@test]
   public function writingProtectedMemberFromParentClass() {
     $this->assertEquals('Modified', ProtectedAccessibilityFixtureChild::write(self::$fixture));
   }
 
-  /**
-   * Write protected member from same class
-   *
-   */
   #[@test]
   public function writingProtectedMemberFromChildClass() {
     $this->assertEquals('Modified', ProtectedAccessibilityFixtureChild::write(self::$fixtureChild));
   }
 
-  /**
-   * Write protected member from here should work if it's accessible
-   *
-   */
   #[@test]
   public function writingProtectedMemberMadeAccessible() {
     with ($f= self::$fixture->getField('target'), $i= ProtectedAccessibilityFixture::construct(self::$fixture)); {
@@ -320,46 +204,26 @@ class ProtectedAccessibilityTest extends TestCase {
     }
   }
 
-  /**
-   * Write protected static member from same class
-   *
-   */
   #[@test, @expect(IllegalAccessException::class)]
   public function writingProtectedStaticMember() {
     self::$fixture->getField('staticTarget')->set(null, 'Modified');
   }
 
-  /**
-   * Write protected static member from same class
-   *
-   */
   #[@test]
   public function writingProtectedStaticMemberFromSameClass() {
     $this->assertEquals('Modified', ProtectedAccessibilityFixture::writeStatic(self::$fixture));
   }
 
-  /**
-   * Write protected static member from same class
-   *
-   */
   #[@test]
   public function writingProtectedStaticMemberFromParentClass() {
     $this->assertEquals('Modified', ProtectedAccessibilityFixtureChild::writeStatic(self::$fixture));
   }
 
-  /**
-   * Write protected static member from same class
-   *
-   */
   #[@test]
   public function writingProtectedStaticMemberFromChildClass() {
     $this->assertEquals('Modified', ProtectedAccessibilityFixtureChild::writeStatic(self::$fixtureChild));
   }
 
-  /**
-   * Write protected member from here should work if it's accessible
-   *
-   */
   #[@test]
   public function writingProtectedStaticMemberMadeAccessible() {
     with ($f= self::$fixture->getField('staticTarget')); {

--- a/src/test/php/net/xp_framework/unittest/reflection/ProxyTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ProxyTest.class.php
@@ -3,6 +3,8 @@
 use lang\reflect\Proxy;
 use lang\XPClass;
 use lang\ClassLoader;
+use lang\IllegalArgumentException;
+use lang\Error;
 use lang\reflect\InvocationHandler;
 use util\XPIterator;
 use util\Observer;
@@ -71,27 +73,27 @@ class ProxyTest extends \unittest\TestCase {
     )]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function nullClassLoader() {
     Proxy::getProxyClass(null, [$this->iteratorClass]);
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function nullClassLoader7() {
     Proxy::getProxyClass(null, [$this->iteratorClass]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function emptyInterfaces() {
     Proxy::getProxyClass(ClassLoader::getDefault(), []);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function nullInterfaces() {
     Proxy::getProxyClass(ClassLoader::getDefault(), null);
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function nullInterfaces7() {
     Proxy::getProxyClass(ClassLoader::getDefault(), null);
   }
@@ -162,12 +164,12 @@ class ProxyTest extends \unittest\TestCase {
     $this->assertEquals([], $this->handler->invocations['next_0']);
   }
   
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function cannotCreateProxiesForClasses() {
     $this->proxyInstanceFor([XPClass::forName('lang.Object')]);
   }
   
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function cannotCreateProxiesForClassesAsSecondArg() {
     $this->proxyInstanceFor([
       XPClass::forName('util.XPIterator'),

--- a/src/test/php/net/xp_framework/unittest/reflection/ProxyTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ProxyTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\reflect\Proxy;
 use lang\XPClass;
+use lang\Type;
 use lang\ClassLoader;
 use lang\IllegalArgumentException;
 use lang\Error;
@@ -16,13 +17,9 @@ use unittest\actions\RuntimeVersion;
  * @see   xp://lang.reflect.Proxy
  */
 class ProxyTest extends \unittest\TestCase {
-  protected $handler       = null;
-  protected $iteratorClass = null;
-  protected $observerClass = null;
+  protected $handler, $iteratorClass, $observerClass;
 
-  /**
-   * Setup method 
-   */
+  /** @return void */
   public function setUp() {
     $this->handler= newinstance(InvocationHandler::class, [], [
       'invocations' => [],
@@ -30,8 +27,8 @@ class ProxyTest extends \unittest\TestCase {
         $this->invocations[$method.'_'.sizeof($args)]= $args;
       }
     ]);
-    $this->iteratorClass= XPClass::forName('util.XPIterator');
-    $this->observerClass= XPClass::forName('util.Observer');
+    $this->iteratorClass= XPClass::forName(XPIterator::class);
+    $this->observerClass= XPClass::forName(Observer::class);
   }
 
   /**
@@ -172,7 +169,7 @@ class ProxyTest extends \unittest\TestCase {
   #[@test, @expect(IllegalArgumentException::class)]
   public function cannotCreateProxiesForClassesAsSecondArg() {
     $this->proxyInstanceFor([
-      XPClass::forName('util.XPIterator'),
+      $this->iteratorClass,
       XPClass::forName('lang.Object')
     ]);
   }
@@ -180,14 +177,14 @@ class ProxyTest extends \unittest\TestCase {
   #[@test]
   public function allowDoubledInterfaceMethod() {
     $this->proxyInstanceFor([
-      XPClass::forName('util.XPIterator'),
-      ClassLoader::defineInterface('util.NewIterator', 'util.XPIterator')
+      $this->iteratorClass,
+      ClassLoader::defineInterface('util.NewIterator', XPIterator::class)
     ]);
   }
   
   #[@test]
   public function overloadedMethod() {
-    $proxy= $this->proxyInstanceFor([XPClass::forName('net.xp_framework.unittest.reflection.OverloadedInterface')]);
+    $proxy= $this->proxyInstanceFor([XPClass::forName(OverloadedInterface::class)]);
     $proxy->overloaded('foo');
     $proxy->overloaded('foo', 'bar');
     $this->assertEquals(['foo'], $this->handler->invocations['overloaded_1']);
@@ -216,7 +213,7 @@ class ProxyTest extends \unittest\TestCase {
   public function builtin_array_parameters_handled_correctly() {
     $proxy= $this->newProxyWith('{ public function fixture(array $param); }');
     $this->assertEquals(
-      \lang\Type::$ARRAY,
+      Type::$ARRAY,
       $proxy->getMethod('fixture')->getParameters()[0]->getTypeRestriction()
     );
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ResourcesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ResourcesTest.class.php
@@ -1,13 +1,12 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use unittest\TestCase;
 use lang\ClassLoader;
 use lang\archive\Archive;
 use lang\archive\ArchiveClassLoader;
 use lang\ElementNotFoundException;
 use io\File;
 
-class ResourcesTest extends TestCase {
+class ResourcesTest extends \unittest\TestCase {
   private $cl;
 
   /** @return void */
@@ -41,7 +40,7 @@ class ResourcesTest extends TestCase {
   #[@test]
   public function findResource() {
     $this->assertInstanceOf(
-      'lang.archive.ArchiveClassLoader',
+      ArchiveClassLoader::class,
       ClassLoader::getDefault()->findResource('META-INF/manifest.ini')
     );
   }
@@ -54,7 +53,7 @@ class ResourcesTest extends TestCase {
   #[@test]
   public function getResourceAsStream() {
     $stream= ClassLoader::getDefault()->getResourceAsStream('META-INF/manifest.ini');
-    $this->assertInstanceOf('io.File', $stream);
+    $this->assertInstanceOf(File::class, $stream);
     $stream->open(File::READ);
     $this->assertManifestFile($stream->read($stream->size()));
     $stream->close();

--- a/src/test/php/net/xp_framework/unittest/reflection/ResourcesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ResourcesTest.class.php
@@ -1,17 +1,18 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use unittest\TestCase;
+use lang\ClassLoader;
 use lang\archive\Archive;
+use lang\archive\ArchiveClassLoader;
+use lang\ElementNotFoundException;
 use io\File;
 
 class ResourcesTest extends TestCase {
-  private $cl= null;
+  private $cl;
 
-  /**
-   * Sets up class loader
-   */
+  /** @return void */
   public function setUp() {
-    $this->cl= \lang\ClassLoader::registerLoader(new \lang\archive\ArchiveClassLoader(new Archive($this
+    $this->cl= ClassLoader::registerLoader(new ArchiveClassLoader(new Archive($this
       ->getClass()
       ->getPackage()
       ->getPackage('lib')
@@ -19,19 +20,18 @@ class ResourcesTest extends TestCase {
     ));
   }
 
-  /**
-   * Removes class loader
-   */
+  /** @return void */
   public function tearDown() {
-    \lang\ClassLoader::removeLoader($this->cl);
+    ClassLoader::removeLoader($this->cl);
   }
 
   /**
    * Helper method for getResource() and getResourceAsStream()
    *
-   * @param   string contents
+   * @param  string $contents
+   * @throws unittest.AssertionFailedError
    */
-  protected function assertManifestFile($contents) {
+  private function assertManifestFile($contents) {
     $this->assertEquals(
       "[runnable]\nmain-class=\"remote.server.impl.ApplicationServer\"",
       trim($contents)
@@ -42,31 +42,31 @@ class ResourcesTest extends TestCase {
   public function findResource() {
     $this->assertInstanceOf(
       'lang.archive.ArchiveClassLoader',
-      \lang\ClassLoader::getDefault()->findResource('META-INF/manifest.ini')
+      ClassLoader::getDefault()->findResource('META-INF/manifest.ini')
     );
   }
 
   #[@test]
   public function getResource() {
-    $this->assertManifestFile(\lang\ClassLoader::getDefault()->getResource('META-INF/manifest.ini'));
+    $this->assertManifestFile(ClassLoader::getDefault()->getResource('META-INF/manifest.ini'));
   }
 
   #[@test]
   public function getResourceAsStream() {
-    $stream= \lang\ClassLoader::getDefault()->getResourceAsStream('META-INF/manifest.ini');
+    $stream= ClassLoader::getDefault()->getResourceAsStream('META-INF/manifest.ini');
     $this->assertInstanceOf('io.File', $stream);
     $stream->open(File::READ);
     $this->assertManifestFile($stream->read($stream->size()));
     $stream->close();
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function nonExistantResource() {
-    \lang\ClassLoader::getDefault()->getResource('::DOES-NOT-EXIST::');
+    ClassLoader::getDefault()->getResource('::DOES-NOT-EXIST::');
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function nonExistantResourceStream() {
-    \lang\ClassLoader::getDefault()->getResourceAsStream('::DOES-NOT-EXIST::');
+    ClassLoader::getDefault()->getResourceAsStream('::DOES-NOT-EXIST::');
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/RuntimeClassDefinitionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/RuntimeClassDefinitionTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\XPClass;
 use lang\ClassLoader;
+use lang\ClassNotFoundException;
 
 /**
  * TestCase for lang.ClassLoader::defineClass()
@@ -89,17 +90,17 @@ class RuntimeClassDefinitionTest extends RuntimeTypeDefinitionTest {
     $this->assertTrue($class->getField('initializerCalled')->get(null));
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function cannot_define_class_with_non_existant_parent() {
     $this->define(['parent' => '@@nonexistant@@']);
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function cannot_define_class_with_null_parent() {
     $this->define(['parent' => null]);
   }
 
-  #[@test, @expect('lang.ClassNotFoundException'), @values([
+  #[@test, @expect(ClassNotFoundException::class), @values([
   #  [['@@nonexistant@@']],
   #  [['lang.Runnable', '@@nonexistant@@']],
   #  [['@@nonexistant@@', 'lang.Runnable']]
@@ -108,7 +109,7 @@ class RuntimeClassDefinitionTest extends RuntimeTypeDefinitionTest {
     $this->define(['interfaces' => $list]);
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function cannot_define_class_with_null_interface() {
     $this->define(['interfaces' => [null]]);
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/RuntimeClassDefinitionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/RuntimeClassDefinitionTest.class.php
@@ -1,6 +1,8 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use lang\XPClass;
+use lang\Throwable;
+use lang\Runnable;
 use lang\ClassLoader;
 use lang\ClassNotFoundException;
 
@@ -33,30 +35,30 @@ class RuntimeClassDefinitionTest extends RuntimeTypeDefinitionTest {
 
   #[@test]
   public function given_parent_is_inherited() {
-    $this->assertTrue($this->define(['parent' => 'lang.Throwable'])->isSubclassOf('lang.Throwable'));
+    $this->assertTrue($this->define(['parent' => Throwable::class])->isSubclassOf(Throwable::class));
   }
 
   #[@test]
   public function given_parent_class_is_inherited() {
-    $this->assertTrue($this->define(['parent' => XPClass::forName('lang.Throwable')])->isSubclassOf('lang.Throwable'));
+    $this->assertTrue($this->define(['parent' => XPClass::forName(Throwable::class)])->isSubclassOf(Throwable::class));
   }
 
   #[@test]
   public function given_interface_is_implemented() {
-    $class= $this->define(['interfaces' => ['lang.Runnable']], '{
+    $class= $this->define(['interfaces' => [Runnable::class]], '{
       public function run() { } 
     }');
 
-    $this->assertTrue($class->isSubclassOf('lang.Runnable'));
+    $this->assertTrue($class->isSubclassOf(Runnable::class));
   }
 
   #[@test]
   public function given_interface_class_is_implemented() {
-    $class= $this->define(['interfaces' => [XPClass::forName('lang.Runnable')]], '{
+    $class= $this->define(['interfaces' => [XPClass::forName(Runnable::class)]], '{
       public function run() { } 
     }');
 
-    $this->assertTrue($class->isSubclassOf('lang.Runnable'));
+    $this->assertTrue($class->isSubclassOf(Runnable::class));
   }
 
   #[@test]
@@ -78,7 +80,7 @@ class RuntimeClassDefinitionTest extends RuntimeTypeDefinitionTest {
 
   #[@test]
   public function parents_field_exists() {
-    $this->assertTrue($this->define(['parent' => 'lang.Throwable'])->hasField('message'));
+    $this->assertTrue($this->define(['parent' => Throwable::class])->hasField('message'));
   }
 
   #[@test]
@@ -102,8 +104,8 @@ class RuntimeClassDefinitionTest extends RuntimeTypeDefinitionTest {
 
   #[@test, @expect(ClassNotFoundException::class), @values([
   #  [['@@nonexistant@@']],
-  #  [['lang.Runnable', '@@nonexistant@@']],
-  #  [['@@nonexistant@@', 'lang.Runnable']]
+  #  [[Runnable::class, '@@nonexistant@@']],
+  #  [['@@nonexistant@@', Runnable::class]]
   #])]
   public function cannot_define_class_with_non_existant_interface($list) {
     $this->define(['interfaces' => $list]);

--- a/src/test/php/net/xp_framework/unittest/reflection/RuntimeInterfaceDefinitionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/RuntimeInterfaceDefinitionTest.class.php
@@ -1,6 +1,8 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use lang\XPClass;
+use lang\Runnable;
+use lang\Closeable;
 use lang\ClassLoader;
 use lang\ClassNotFoundException;
 
@@ -33,43 +35,43 @@ class RuntimeInterfaceDefinitionTest extends RuntimeTypeDefinitionTest {
   #[@test]
   public function given_parent_is_inherited() {
     $this->assertEquals(
-      [XPClass::forName('lang.Runnable')],
-      $this->define(['parents' => ['lang.Runnable']])->getInterfaces()
+      [XPClass::forName(Runnable::class)],
+      $this->define(['parents' => [Runnable::class]])->getInterfaces()
     );
   }
 
   #[@test]
   public function given_parent_class_is_inherited() {
     $this->assertEquals(
-      [XPClass::forName('lang.Runnable')],
-      $this->define(['parents' => [XPClass::forName('lang.Runnable')]])->getInterfaces()
+      [XPClass::forName(Runnable::class)],
+      $this->define(['parents' => [XPClass::forName(Runnable::class)]])->getInterfaces()
     );
   }
 
   #[@test]
   public function given_parents_are_inherited() {
     $this->assertEquals(
-      [XPClass::forName('lang.Runnable'), XPClass::forName('lang.Closeable')],
-      $this->define(['parents' => ['lang.Runnable', 'lang.Closeable']])->getInterfaces()
+      [XPClass::forName(Runnable::class), XPClass::forName(Closeable::class)],
+      $this->define(['parents' => [Runnable::class, Closeable::class]])->getInterfaces()
     );
   }
 
   #[@test]
   public function given_parent_classes_are_inherited() {
     $this->assertEquals(
-      [XPClass::forName('lang.Runnable'), XPClass::forName('lang.Closeable')],
-      $this->define(['parents' => [XPClass::forName('lang.Runnable'), XPClass::forName('lang.Closeable')]])->getInterfaces()
+      [XPClass::forName(Runnable::class), XPClass::forName(Closeable::class)],
+      $this->define(['parents' => [XPClass::forName(Runnable::class), XPClass::forName(Closeable::class)]])->getInterfaces()
     );
   }
 
   #[@test]
   public function parents_method_exists() {
-    $this->assertTrue($this->define(['parents' => ['lang.Runnable']])->hasMethod('run'));
+    $this->assertTrue($this->define(['parents' => [Runnable::class]])->hasMethod('run'));
   }
 
   #[@test]
   public function method_exists() {
-    $class= $this->define(['parents' => ['lang.Runnable']], '{ public function runAs($user); }');
+    $class= $this->define(['parents' => [Runnable::class]], '{ public function runAs($user); }');
     $this->assertTrue($class->hasMethod('runAs'));
   }
 
@@ -85,7 +87,7 @@ class RuntimeInterfaceDefinitionTest extends RuntimeTypeDefinitionTest {
 
   #[@test]
   public function closure_map_style_declaring_method() {
-    $class= $this->define(['parents' => ['lang.Runnable']], ['fixture' => function() { }]);
+    $class= $this->define(['parents' => [Runnable::class]], ['fixture' => function() { }]);
     $this->assertTrue($class->hasMethod('fixture'));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/RuntimeInterfaceDefinitionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/RuntimeInterfaceDefinitionTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\XPClass;
 use lang\ClassLoader;
+use lang\ClassNotFoundException;
 
 /**
  * TestCase for lang.ClassLoader::defineInterface()
@@ -72,12 +73,12 @@ class RuntimeInterfaceDefinitionTest extends RuntimeTypeDefinitionTest {
     $this->assertTrue($class->hasMethod('runAs'));
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function cannot_define_interface_with_non_existant_parent() {
     $this->define(['parents' => ['@@nonexistant@@']]);
   }
 
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function cannot_define_interface_with_null_parent() {
     $this->define(['parents' => [null]]);
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/RuntimeTypeDefinitionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/RuntimeTypeDefinitionTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use unittest\TestCase;
 use lang\ClassLoader;
+use lang\DynamicClassLoader;
+use lang\XPClass;
 
 /**
  * Base class for runtime type definitions
@@ -9,7 +10,7 @@ use lang\ClassLoader;
  * @see   xp://lang.ClassLoader
  * @see   https://github.com/xp-framework/xp-framework/issues/94
  */
-abstract class RuntimeTypeDefinitionTest extends TestCase {
+abstract class RuntimeTypeDefinitionTest extends \unittest\TestCase {
 
   /**
    * Wraps around a function which defines types, giving it unique names and
@@ -41,12 +42,12 @@ abstract class RuntimeTypeDefinitionTest extends TestCase {
 
   #[@test]
   public function returns_XPClass_instances() {
-    $this->assertInstanceOf('lang.XPClass', $this->define());
+    $this->assertInstanceOf(XPClass::class, $this->define());
   }
 
   #[@test]
   public function classloader_of_defined_type_is_DynamicClassLoader() {
-    $this->assertInstanceOf('lang.DynamicClassLoader', $this->define()->getClassLoader());
+    $this->assertInstanceOf(DynamicClassLoader::class, $this->define()->getClassLoader());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -9,12 +9,10 @@ use lang\MapType;
 use lang\XPClass;
 use util\collections\Vector;
 use util\collections\HashTable;
+use lang\IllegalStateException;
+use lang\IllegalAccessException;
+use lang\ClassCastException;
 
-/**
- * TestCase
- *
- * @see      xp://lang.Type
- */
 class TypeTest extends \unittest\TestCase {
 
   #[@test]
@@ -174,7 +172,7 @@ class TypeTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalStateException'), @values([null, ''])]
+  #[@test, @expect(IllegalStateException::class), @values([null, ''])]
   public function forName_raises_exception_when_given_empty($value) {
     Type::forName($value);
   }
@@ -230,7 +228,7 @@ class TypeTest extends \unittest\TestCase {
     $this->assertEquals($value, Type::$VAR->newInstance($value));
   }
 
-  #[@test, @expect('lang.IllegalAccessException'), @values('instances')]
+  #[@test, @expect(IllegalAccessException::class), @values('instances')]
   public function newInstance_of_void($value) {
     Type::$VOID->newInstance($value);
   }
@@ -240,7 +238,7 @@ class TypeTest extends \unittest\TestCase {
     $this->assertEquals($value, Type::$VAR->cast($value));
   }
 
-  #[@test, @expect('lang.ClassCastException'), @values('instances')]
+  #[@test, @expect(ClassCastException::class), @values('instances')]
   public function cast_to_void($value) {
     Type::$VOID->cast($value);
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -117,7 +117,7 @@ class TypeTest extends \unittest\TestCase {
   #[@test]
   public function genericObjectType() {
     with ($t= Type::forName('util.collections.HashTable<string, lang.Object>')); {
-      $this->assertInstanceOf('lang.XPClass', $t);
+      $this->assertInstanceOf(XPClass::class, $t);
       $this->assertTrue($t->isGeneric());
       $this->assertEquals(XPClass::forName('util.collections.HashTable'), $t->genericDefinition());
       $this->assertEquals(

--- a/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
@@ -257,7 +257,7 @@ class XPClassTest extends \unittest\TestCase {
 
   #[@test, @expect(IllegalAccessException::class)]
   public function newInstance_raises_exception_if_class_is_abstract() {
-    XPClass::forName('net.xp_framework.unittest.reflection.AbstractTestClass')->newInstance();
+    XPClass::forName(AbstractTestClass::class)->newInstance();
   }
 
   #[@test, @expect(TargetInvocationException::class)]
@@ -267,19 +267,15 @@ class XPClassTest extends \unittest\TestCase {
 
   #[@test, @expect(IllegalAccessException::class)]
   public function constructors_newInstance_method_raises_exception_if_class_is_abstract() {
-    XPClass::forName('net.xp_framework.unittest.reflection.AbstractTestClass')
-      ->getConstructor()
-      ->newInstance()
-    ;
+    XPClass::forName(AbstractTestClass::class)->getConstructor()->newInstance();
   }
   
   #[@test]
   public function implementedConstructorInvocation() {
-    $parent= 'net.xp_framework.unittest.reflection.AbstractTestClass';
-    $i= ClassLoader::defineClass('ANonAbstractClass', $parent, [], '{
+    $i= ClassLoader::defineClass('ANonAbstractClass', AbstractTestClass::class, [], '{
       public function getDate() {}
     }');    
-    $this->assertInstanceOf($parent, $i->getConstructor()->newInstance());
+    $this->assertInstanceOf(AbstractTestClass::class, $i->getConstructor()->newInstance());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
@@ -8,6 +8,7 @@ use lang\ElementNotFoundException;
 use lang\ClassNotFoundException;
 use lang\IllegalAccessException;
 use lang\reflect\Package;
+use lang\reflect\Constructor;
 use lang\reflect\TargetInvocationException;
 
 /**
@@ -223,7 +224,7 @@ class XPClassTest extends \unittest\TestCase {
 
   #[@test]
   public function fixture_classes_constructor() {
-    $this->assertInstanceOf('lang.reflect.Constructor', $this->fixture->getConstructor());
+    $this->assertInstanceOf(Constructor::class, $this->fixture->getConstructor());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
@@ -2,6 +2,13 @@
 
 use lang\XPClass;
 use lang\Primitive;
+use lang\ClassLoader;
+use lang\IllegalStateException;
+use lang\ElementNotFoundException;
+use lang\ClassNotFoundException;
+use lang\IllegalAccessException;
+use lang\reflect\Package;
+use lang\reflect\TargetInvocationException;
 
 /**
  * Test the XPClass class, the entry point to the XP Framework's class reflection API.
@@ -11,9 +18,7 @@ use lang\Primitive;
 class XPClassTest extends \unittest\TestCase {
   protected $fixture;
 
-  /**
-   * Setup method
-   */
+  /** @return void */
   public function setUp() {
     $this->fixture= XPClass::forName('net.xp_framework.unittest.reflection.TestClass');
   }
@@ -36,7 +41,7 @@ class XPClassTest extends \unittest\TestCase {
   #[@test]
   public function getPackage_returns_package_class_resides_in() {
     $this->assertEquals(
-      \lang\reflect\Package::forName('net.xp_framework.unittest.reflection'),
+      Package::forName('net.xp_framework.unittest.reflection'),
       $this->fixture->getPackage()
     );
   }
@@ -94,7 +99,7 @@ class XPClassTest extends \unittest\TestCase {
     $this->assertFalse($this->fixture->isAssignableFrom($name));
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function illegal_argument_given_to_isAssignableFrom() {
     $this->fixture->isAssignableFrom('@not-a-type@');
   }
@@ -226,7 +231,7 @@ class XPClassTest extends \unittest\TestCase {
     $this->assertFalse(XPClass::forName('lang.Object')->hasConstructor());
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function getting_object_classes_constructor_raises_an_exception() {
     XPClass::forName('lang.Object')->getConstructor();
   }
@@ -239,27 +244,27 @@ class XPClassTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function newInstance_raises_exception_if_class_is_an_interface() {
     XPClass::forName('util.log.Traceable')->newInstance();
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function newInstance_raises_exception_if_class_is_a_trait() {
     XPClass::forName('net.xp_framework.unittest.reflection.classes.TraitOne')->newInstance();
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function newInstance_raises_exception_if_class_is_abstract() {
     XPClass::forName('net.xp_framework.unittest.reflection.AbstractTestClass')->newInstance();
   }
 
-  #[@test, @expect('lang.reflect.TargetInvocationException')]
+  #[@test, @expect(TargetInvocationException::class)]
   public function constructors_newInstance_method_wraps_exceptions() {
     $this->fixture->getConstructor()->newInstance(['@@not-a-valid-date-string@@']);
   }
 
-  #[@test, @expect('lang.IllegalAccessException')]
+  #[@test, @expect(IllegalAccessException::class)]
   public function constructors_newInstance_method_raises_exception_if_class_is_abstract() {
     XPClass::forName('net.xp_framework.unittest.reflection.AbstractTestClass')
       ->getConstructor()
@@ -270,7 +275,7 @@ class XPClassTest extends \unittest\TestCase {
   #[@test]
   public function implementedConstructorInvocation() {
     $parent= 'net.xp_framework.unittest.reflection.AbstractTestClass';
-    $i= \lang\ClassLoader::defineClass('ANonAbstractClass', $parent, [], '{
+    $i= ClassLoader::defineClass('ANonAbstractClass', $parent, [], '{
       public function getDate() {}
     }');    
     $this->assertInstanceOf($parent, $i->getConstructor()->newInstance());
@@ -296,22 +301,19 @@ class XPClassTest extends \unittest\TestCase {
     $this->assertEquals('Annotation', $this->fixture->getAnnotation('test'));
   }
   
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function getting_non_existant_annotation_raises_exception() {
     $this->fixture->getAnnotation('non-existant');
   }
   
-  #[@test, @expect('lang.ClassNotFoundException')]
+  #[@test, @expect(ClassNotFoundException::class)]
   public function forName_raises_exceptions_for_nonexistant_classes() {
     XPClass::forName('class.does.not.Exist');
   }
 
   #[@test]
   public function forName_supports_class_literals() {
-    $this->assertEquals(
-      $this->fixture,
-      XPClass::forName('net\\xp_framework\\unittest\\reflection\\TestClass')
-    );
+    $this->assertEquals($this->fixture, XPClass::forName(TestClass::class));
   }
 
   #[@test]
@@ -346,7 +348,7 @@ class XPClassTest extends \unittest\TestCase {
     $this->assertEquals('XP Framework', $this->fixture->getConstant('CONSTANT_STRING'));
   }
 
-  #[@test, @expect('lang.ElementNotFoundException'), @values(['DOES_NOT_EXIST', '', null])]
+  #[@test, @expect(ElementNotFoundException::class), @values(['DOES_NOT_EXIST', '', null])]
   public function getConstant_throws_exception_if_constant_doesnt_exist($name) {
     $this->fixture->getConstant($name);
   }

--- a/src/test/php/net/xp_framework/unittest/security/BlowFishUnixCryptTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/BlowFishUnixCryptTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace net\xp_framework\unittest\security;
 
+use security\crypto\UnixCrypt;
+use security\crypto\CryptoException;
+
 /**
  * TestCase
  *
@@ -7,14 +10,8 @@
  */
 class BlowFishUnixCryptTest extends UnixCryptTest {
 
-  /**
-   * Returns fixture
-   *
-   * @return  security.crypto.CryptImpl
-   */
-  protected function fixture() {
-    return \security\crypto\UnixCrypt::$BLOWFISH;
-  }
+  /** @return security.crypto.CryptImpl */
+  protected function fixture() { return UnixCrypt::$BLOWFISH; }
 
   #[@test]
   public function blowfishPhpNetExample() {
@@ -31,33 +28,32 @@ class BlowFishUnixCryptTest extends UnixCryptTest {
     $this->assertCryptedMatches('$2a$07$usesomesillystringforsal', '$2a$07$usesomesillystringforeHbE8dX9jg7DlVE.rTNXDHM0HKhUj402');
   }
 
-
   #[@test]
   public function blowfishSaltDoesNotEndWithDollar() {
     $this->assertCryptedMatches('$2a$07$usesomesillystringforsalt_', '$2a$07$usesomesillystringforeHbE8dX9jg7DlVE.rTNXDHM0HKhUj402');
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function blowfishCostParameterTooShort() {
     $this->fixture()->crypt('irrelevant', '$2a$_');
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function blowfishCostParameterZero() {
     $this->fixture()->crypt('irrelevant', '$2a$00$');
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function blowfishCostParameterTooLow() {
     $this->fixture()->crypt('irrelevant', '$2a$03$');
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function blowfishCostParameterTooHigh() {
     $this->fixture()->crypt('irrelevant', '$2a$32$');
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function blowfishCostParameterMalFormed() {
     $this->fixture()->crypt('irrelevant', '$2a$__$');
   }

--- a/src/test/php/net/xp_framework/unittest/security/ExtendedDESUnixCryptTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/ExtendedDESUnixCryptTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\security;
 
-
+use security\crypto\UnixCrypt;
+use security\crypto\CryptoException;
 
 /**
  * TestCase
@@ -15,7 +16,7 @@ class ExtendedDESUnixCryptTest extends UnixCryptTest {
    * @return  security.crypto.CryptImpl
    */
   protected function fixture() {
-    return \security\crypto\UnixCrypt::$EXTENDED;
+    return UnixCrypt::$EXTENDED;
   }
 
   #[@test]
@@ -28,17 +29,17 @@ class ExtendedDESUnixCryptTest extends UnixCryptTest {
     $this->assertCryptedMatches('_J9..rasm', '_J9..rasmBYk8r9AiWNc', 'rasmuslerdorf');
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function extendedDES1CharSalt() {
     $this->fixture()->crypt('plain', '_');
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function extendedDES2CharSalt() {
     $this->fixture()->crypt('plain', '_1');
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function extendedDES7CharSalt() {
     $this->fixture()->crypt('plain', '_1234567');
   }

--- a/src/test/php/net/xp_framework/unittest/security/PasswordStrengthTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/PasswordStrengthTest.class.php
@@ -3,6 +3,8 @@
 use security\password\PasswordStrength;
 use security\password\StandardAlgorithm;
 use security\password\Algorithm;
+use util\NoSuchElementException;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase for PasswordStrength entry point class
@@ -26,12 +28,12 @@ class PasswordStrengthTest extends \unittest\TestCase {
     $this->assertInstanceOf(nameof($algorithm), PasswordStrength::getAlgorithm('test'));
   }
 
-  #[@test, @expect('util.NoSuchElementException')]
+  #[@test, @expect(NoSuchElementException::class)]
   public function getAlgorithm_throws_an_exception_for_non_existant_algorithm() {
     PasswordStrength::getAlgorithm('@@NON_EXISTANT@@');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function setAlgorithm_throws_an_exception_for_non_algorithms() {
     PasswordStrength::setAlgorithm('object', typeof($this));
   }

--- a/src/test/php/net/xp_framework/unittest/security/RandomCodeGeneratorTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/RandomCodeGeneratorTest.class.php
@@ -2,6 +2,7 @@
 
 use unittest\TestCase;
 use security\password\RandomCodeGenerator;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
@@ -29,12 +30,12 @@ class RandomCodeGeneratorTest extends TestCase {
     $this->assertTrue((bool)preg_match('/^[a-z0-9]{16}$/', $this->fixture->generate()));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function zeroLength() {
     new RandomCodeGenerator(0);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function negativeLength() {
     new RandomCodeGenerator(-1);
   }

--- a/src/test/php/net/xp_framework/unittest/security/SecureStringTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/SecureStringTest.class.php
@@ -1,6 +1,11 @@
 <?php namespace net\xp_framework\unittest\security;
 
 use security\SecureString;
+use security\SecurityException;
+use lang\IllegalStateException;
+use lang\IllegalArgumentException;
+use lang\XPException;
+use lang\Throwable;
 
 /**
  * Baseclass for test cases for security.SecureString
@@ -24,7 +29,7 @@ abstract class SecureStringTest extends \unittest\TestCase {
     new SecureString($this->getValue());
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function not_serializable() {
     serialize(new SecureString('payload'));
   }
@@ -82,24 +87,24 @@ abstract class SecureStringTest extends \unittest\TestCase {
     $called= false;
     SecureString::setBacking(function($value) use (&$called) {
       $called= true;
-      throw new \lang\XPException('Something went wrong - intentionally.');
+      throw new XPException('Something went wrong - intentionally.');
     }, function($value) { return null; });
 
     new SecureString('foo');
     $this->assertTrue($called);
   }
 
-  #[@test, @expect(class= 'security.SecurityException', withMessage= '/An error occurred during storing the encrypted password./')]
+  #[@test, @expect(class= SecurityException::class, withMessage= '/An error occurred during storing the encrypted password./')]
   public function decryption_throws_exception_if_creation_has_failed() {
     $called= false;
     SecureString::setBacking(function($value) {
-      throw new \lang\XPException('Something went wrong - intentionally.');
+      throw new XPException('Something went wrong - intentionally.');
     }, function($value) { return null; });
 
     // Creation may never throw exception
     try {
       $s= new SecureString('foo');
-    } catch (\lang\Throwable $t) {
+    } catch (\Throwable $t) {
       $this->fail('Exception thrown where no exception may be thrown', $t, null);
     }
 
@@ -107,7 +112,7 @@ abstract class SecureStringTest extends \unittest\TestCase {
     $s->getCharacters();
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function useBacking_with_invalid_backing_throws_exception() {
     SecureString::useBacking(77);
   }

--- a/src/test/php/net/xp_framework/unittest/security/StandardDESUnixCryptTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/StandardDESUnixCryptTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace net\xp_framework\unittest\security;
 
+use security\crypto\UnixCrypt;
+use security\crypto\CryptoException;
+
 /**
  * TestCase
  *
@@ -15,7 +18,7 @@ class StandardDESUnixCryptTest extends UnixCryptTest {
    * @return  security.crypto.CryptImpl
    */
   protected function fixture() {
-    return \security\crypto\UnixCrypt::$STANDARD;
+    return UnixCrypt::$STANDARD;
   }
 
   #[@test]
@@ -32,7 +35,7 @@ class StandardDESUnixCryptTest extends UnixCryptTest {
   public function saltTooShort() {
     try {
       $this->assertCryptedMatches('a', 'a$Xz1wsurHC5M');
-    } catch (\security\crypto\CryptoException $ignored) { }
+    } catch (CryptoException $ignored) { }
   }
 
   #[@test]
@@ -44,29 +47,29 @@ class StandardDESUnixCryptTest extends UnixCryptTest {
   public function oneDollar() {
     try {
       $this->assertCryptedMatches('1$', '1$SyvOllpoCvg');
-    } catch (\security\crypto\CryptoException $ignored) { }
+    } catch (CryptoException $ignored) { }
   }
 
   #[@test]
   public function dollarTwo() {
     try {
       $this->assertCryptedMatches('$2', '$26WPvCItMuNE');
-    } catch (\security\crypto\CryptoException $ignored) { }
+    } catch (CryptoException $ignored) { }
   }
 
   #[@test]
   public function dollarDollar() {
     try {
       $this->assertCryptedMatches('$$', '$$oLnFl.kOCXI');
-    } catch (\security\crypto\CryptoException $ignored) { }
+    } catch (CryptoException $ignored) { }
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function unsafeLineFeed() {
     $this->fixture()->crypt('irrelevant', "\n_");
   }
 
-  #[@test, @expect('security.crypto.CryptoException')]
+  #[@test, @expect(CryptoException::class)]
   public function unsafeColon() {
     $this->fixture()->crypt('irrelevant', ':_');
   }

--- a/src/test/php/net/xp_framework/unittest/security/checksum/AbstractDigestTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/checksum/AbstractDigestTest.class.php
@@ -2,106 +2,62 @@
 
 use unittest\TestCase;
 use security\checksum\MessageDigest;
+use lang\IllegalStateException;
 
-
-/**
- * TestCase for MD5 digest
- *
- * @see      xp://security.checksum.MD5Digest
- */
 abstract class AbstractDigestTest extends TestCase {
   protected $fixture;
   
   /**
    * Creates a new message digest object
    *
-   * @return  security.checksum.MessageDigest
+   * @return security.checksum.MessageDigest
    */
   protected abstract function newDigest();
 
   /**
    * Returns a checksum for a given input string
    *
-   * @param   string data
-   * @return  security.checksum.Checksum
+   * @param  string $input
+   * @return security.checksum.Checksum
    */
-  protected abstract function checksumOf($data);
+  protected abstract function checksumOf($input);
 
-  /**
-   * Sets up test case
-   *
-   */
+  /** @return void */
   public function setUp() {
     $this->fixture= $this->newDigest();
   }
   
-  /**
-   * Test calling update once
-   *
-   */
   #[@test]
   public function singleUpdate() {
     $this->fixture->update('Hello');
-    $this->assertEquals(
-      $this->checksumOf('Hello'),
-      $this->fixture->digest()
-    );
+    $this->assertEquals($this->checksumOf('Hello'), $this->fixture->digest());
   }
 
-  /**
-   * Test calling update() multiple times
-   *
-   */
   #[@test]
   public function multipleUpdates() {
     $this->fixture->update('Hello');
     $this->fixture->update('World');
-    $this->assertEquals(
-      $this->checksumOf('HelloWorld'),
-      $this->fixture->digest()
-    );
+    $this->assertEquals($this->checksumOf('HelloWorld'), $this->fixture->digest());
   }
 
-  /**
-   * Test not calling update() results in the MD5 of an empty string
-   *
-   */
   #[@test]
   public function noUpdate() {
-    $this->assertEquals(
-      $this->checksumOf(''),
-      $this->fixture->digest()
-    );
+    $this->assertEquals($this->checksumOf(''), $this->fixture->digest());
   }
 
-  /**
-   * Test not calling update() but instead digest with optional parameter
-   *
-   */
   #[@test]
   public function digestOnly() {
-    $this->assertEquals(
-      $this->checksumOf('Hello'),
-      $this->fixture->digest('Hello')
-    );
+    $this->assertEquals($this->checksumOf('Hello'), $this->fixture->digest('Hello'));
   }
 
-  /**
-   * Test not calling update() results in the MD5 of an empty string
-   *
-   */
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function callingUpdateAfterFinalization() {
     $this->fixture->update('...');
     $this->fixture->digest();
     $this->fixture->update('...');
   }
 
-  /**
-   * Test not calling update() results in the MD5 of an empty string
-   *
-   */
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function callingDigestAfterFinalization() {
     $this->fixture->update('...');
     $this->fixture->digest();

--- a/src/test/php/net/xp_framework/unittest/security/checksum/MessageDigestTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/security/checksum/MessageDigestTest.class.php
@@ -1,41 +1,23 @@
 <?php namespace net\xp_framework\unittest\security\checksum;
 
-use unittest\TestCase;
 use security\checksum\MessageDigest;
+use security\NoSuchAlgorithmException;
+use lang\IllegalArgumentException;
 
+class MessageDigestTest extends \unittest\TestCase {
 
-/**
- * TestCase
- *
- * @see      xp://security.checksum.MessageDigest
- */
-class MessageDigestTest extends TestCase {
-
-  /**
-   * Test register() method
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
-  public function registerTestClassAsImplementation() {
-    MessageDigest::register('irrelevant', $this->getClass());
-  }
-
-  /**
-   * Test supportedAlgorithms() method
-   *
-   */
   #[@test]
-  public function supportedAlgorithms() {
-    $a= MessageDigest::supportedAlgorithms();
-    $this->assertTrue(is_array($a), 'Expected an array but have '.\xp::typeOf($a));
+  public function supported_algorithms() {
+    $this->assertInstanceOf('string[]', MessageDigest::supportedAlgorithms());
   }
 
-  /**
-   * Test newInstance() method
-   *
-   */
-  #[@test, @expect('security.NoSuchAlgorithmException')]
-  public function unsupportedAlgorithm() {
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function register_this_as_implementation() {
+    MessageDigest::register('irrelevant', typeof($this));
+  }
+
+  #[@test, @expect(NoSuchAlgorithmException::class)]
+  public function unsupported_algorithm() {
     MessageDigest::newInstance('unsupported');
   }
 }

--- a/src/test/php/net/xp_framework/unittest/text/DateFormatTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/text/DateFormatTest.class.php
@@ -1,250 +1,166 @@
 <?php namespace net\xp_framework\unittest\text;
 
-use unittest\TestCase;
 use text\DateFormat;
-
+use util\Date;
+use lang\FormatException;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
  *
  * @see      xp://text.DateFormat
  */
-class DateFormatTest extends TestCase {
+class DateFormatTest extends \unittest\TestCase {
 
-  /**
-   * Test US-format (YYYY-MM-DD)
-   *
-   */
   #[@test]
   public function parseUsFormat() {
     $this->assertEquals(
-      new \util\Date('2009-01-01'),
+      new Date('2009-01-01'),
       (new DateFormat('%Y-%m-%d'))->parse('2009-01-01')
     );
   }
 
-  /**
-   * Test US-format (YYYY-MM-DD)
-   *
-   */
   #[@test]
   public function formatUsFormat() {
     $this->assertEquals(
       '2009-12-14',
-      (new DateFormat('%Y-%m-%d'))->format(new \util\Date('2009-12-14'))
+      (new DateFormat('%Y-%m-%d'))->format(new Date('2009-12-14'))
     );
   }
 
-  /**
-   * Test US-format (YYYY-MM-DD HH:MM:SS (AM|PM))
-   *
-   */
   #[@test]
   public function parseUsFormatWithTime() {
     $this->assertEquals(
-      new \util\Date('2009-12-14 14:24:36'),
+      new Date('2009-12-14 14:24:36'),
       (new DateFormat('%Y-%m-%d %I:%M:%S %p'))->parse('2009-12-14 02:24:36 PM')
     );
   }
 
-  /**
-   * Test US-format (YYYY-MM-DD HH:MM:SS (AM|PM))
-   *
-   */
   #[@test]
   public function formatUsFormatWithTime() {
     $this->assertEquals(
       '2009-12-14 02:24:36 PM',
-      (new DateFormat('%Y-%m-%d %I:%M:%S %p'))->format(new \util\Date('2009-12-14 14:24:36'))
+      (new DateFormat('%Y-%m-%d %I:%M:%S %p'))->format(new Date('2009-12-14 14:24:36'))
     );
   }
 
-  /**
-   * Test US-format (YYYY-MM-DD HH:MM:SS (AM|PM))
-   *
-   */
   #[@test]
   public function parseUsFormatWith24HourTime() {
     $this->assertEquals(
-      new \util\Date('2009-12-14 14:00:01'),
+      new Date('2009-12-14 14:00:01'),
       (new DateFormat('%Y-%m-%d %H:%M:%S'))->parse('2009-12-14 14:00:01')
     );
   }
 
-  /**
-   * Test US-format (YYYY-MM-DD HH:MM:SS)
-   *
-   */
   #[@test]
   public function formatUsFormatWith24HourTime() {
     $this->assertEquals(
       '2009-12-14 14:24:36',
-      (new DateFormat('%Y-%m-%d %H:%M:%S'))->format(new \util\Date('2009-12-14 14:24:36'))
+      (new DateFormat('%Y-%m-%d %H:%M:%S'))->format(new Date('2009-12-14 14:24:36'))
     );
   }
 
-  /**
-   * Test EU-format (DD.MM.YYYY)
-   *
-   */
   #[@test]
   public function parseEuFormat() {
     $this->assertEquals(
-      new \util\Date('2009-12-14'),
+      new Date('2009-12-14'),
       (new DateFormat('%d.%m.%Y'))->parse('14.12.2009')
     );
   }
 
-  /**
-   * Test EU-format (DD.MM.YYYY)
-   *
-   */
   #[@test]
   public function formatEuFormat() {
     $this->assertEquals(
       '09.01.2009',
-      (new DateFormat('%d.%m.%Y'))->format(new \util\Date('2009-01-09'))
+      (new DateFormat('%d.%m.%Y'))->format(new Date('2009-01-09'))
     );
   }
 
-  /**
-   * Test EU-format (DD.MM.YYYY HH:II:SS)
-   *
-   */
   #[@test]
   public function parseEuFormatWithTime() {
     $this->assertEquals(
-      new \util\Date('2009-12-14 11:45:00'),
+      new Date('2009-12-14 11:45:00'),
       (new DateFormat('%d.%m.%Y %H:%M:%S'))->parse('14.12.2009 11:45:00')
     );
   }
 
-  /**
-   * Test EU-format (DD.MM.YYYY HH:II:SS)
-   *
-   */
   #[@test]
   public function formatEuFormatWithTime() {
     $this->assertEquals(
       '14.12.2009 11:45:00',
-      (new DateFormat('%d.%m.%Y %H:%M:%S'))->format(new \util\Date('2009-12-14 11:45:00'))
+      (new DateFormat('%d.%m.%Y %H:%M:%S'))->format(new Date('2009-12-14 11:45:00'))
     );
   }
 
-  /**
-   * Test timezone names
-   *
-   */
   #[@test]
   public function parseDateWithTimeZoneName() {
     $this->assertEquals(
-      new \util\Date('2009-12-14 11:45:00', new \util\TimeZone('Europe/Berlin')),
+      new Date('2009-12-14 11:45:00', new \util\TimeZone('Europe/Berlin')),
       (new DateFormat('%Y-%m-%d %H:%M:%S %z'))->parse('2009-12-14 11:45:00 Europe/Berlin')
     );
   }
 
-  /**
-   * Test timezone names
-   *
-   */
   #[@test]
   public function formatDateWithTimeZoneName() {
     $this->assertEquals(
       '2009-12-14 11:45:00 Europe/Berlin',
-      (new DateFormat('%Y-%m-%d %H:%M:%S %z'))->format(new \util\Date('2009-12-14 11:45:00', new \util\TimeZone('Europe/Berlin')))
+      (new DateFormat('%Y-%m-%d %H:%M:%S %z'))->format(new Date('2009-12-14 11:45:00', new \util\TimeZone('Europe/Berlin')))
     );
   }
 
-  /**
-   * Test timezone offset
-   *
-   */
   #[@test]
   public function parseDateWithTimeZoneOffset() {
     $this->assertEquals(
-      new \util\Date('2009-12-14 11:45:00-0800'),
+      new Date('2009-12-14 11:45:00-0800'),
       (new DateFormat('%Y-%m-%d %H:%M:%S%Z'))->parse('2009-12-14 11:45:00-0800')
     );
   }
 
-  /**
-   * Test timezone offset
-   *
-   */
   #[@test]
   public function formatDateWithTimeZoneOffset() {
     $this->assertEquals(
       '2009-12-14 11:45:00-0800',
-      (new DateFormat('%Y-%m-%d %H:%M:%S%Z'))->format(new \util\Date('2009-12-14 11:45:00-0800'))
+      (new DateFormat('%Y-%m-%d %H:%M:%S%Z'))->format(new Date('2009-12-14 11:45:00-0800'))
     );
   }
 
-  /**
-   * Test formatting a literal percent sign
-   *
-   */
   #[@test]
   public function formatLiteralPercent() {
-    $this->assertEquals('%', (new DateFormat('%%'))->format(new \util\Date()));
+    $this->assertEquals('%', (new DateFormat('%%'))->format(new Date()));
   }
 
-  /**
-   * Test specialized format (07-Mrz-2011)
-   *
-   */
   #[@test]
   public function parseGermanMonthNamesInInput() {
     $this->assertEquals(
-      new \util\Date('2011-03-07'),
+      new Date('2011-03-07'),
       (new DateFormat('%d-%[month=Jan,Feb,Mrz,Apr,Mai,Jun,Jul,Aug,Sep,Okt,Nov,Dez]-%Y'))->parse('07-Mrz-2011')
     );
   }
 
-  /**
-   * Test specialized format (07-Mrz-2011)
-   *
-   */
   #[@test]
   public function formatGermanMonthNames() {
     $this->assertEquals(
       '07-Mrz-2011',
-      (new DateFormat('%d-%[month=Jan,Feb,Mrz,Apr,Mai,Jun,Jul,Aug,Sep,Okt,Nov,Dez]-%Y'))->format(new \util\Date('2011-03-07'))
+      (new DateFormat('%d-%[month=Jan,Feb,Mrz,Apr,Mai,Jun,Jul,Aug,Sep,Okt,Nov,Dez]-%Y'))->format(new Date('2011-03-07'))
     );
   }
 
-  /**
-   * Test illegal format token
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function illegalToken() {
     new DateFormat('%^');
   }
 
-  /**
-   * Test parsing errors
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function stringTooShort() {
     (new DateFormat('%Y-%m-%d'))->parse('2004');
   }
 
-  /**
-   * Test parsing errors
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function formatMismatch() {
     (new DateFormat('%Y-%m-%d'))->parse('12.12.2004');
   }
 
-
-  /**
-   * Test parsing errors
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function nonNumericInput() {
     (new DateFormat('%Y'))->parse('Hello');
   }

--- a/src/test/php/net/xp_framework/unittest/text/PatternTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/text/PatternTest.class.php
@@ -2,9 +2,11 @@
 
 use text\regex\Pattern;
 use unittest\actions\RuntimeVersion;
+use lang\FormatException;
+use lang\IndexOutOfBoundsException;
 
 /**
- * Patter test 
+ * Pattern test 
  *
  * @see   http://www.regular-expressions.info/unicode.html
  */
@@ -122,7 +124,7 @@ class PatternTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function nonExistantGroup() {
     Pattern::compile('H[ea]llo')->match('Hello')->group(1);
   }
@@ -156,7 +158,7 @@ class PatternTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function illegalPattern() {
     Pattern::compile('(');
   }
@@ -167,7 +169,7 @@ class PatternTest extends \unittest\TestCase {
     try {
       $p->matches('irrelevant');
       $this->fail('Expected exception not thrown', null, 'lang.FormatException');
-    } catch (\lang\FormatException $expected) {
+    } catch (FormatException $expected) {
       // OK
     }
   }

--- a/src/test/php/net/xp_framework/unittest/text/ScannerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/text/ScannerTest.class.php
@@ -2,103 +2,64 @@
 
 use text\regex\Scanner;
 use text\regex\CharacterClass;
+use lang\FormatException;
 
 class ScannerTest extends \unittest\TestCase {
 
-  /**
-   * Test %d
-   *
-   */
   #[@test]
   public function int() {
     $scanner= new Scanner('%d');
     $this->assertEquals(['123', '123'], $scanner->match('123')->group(0));
   }
 
-  /**
-   * Test %d
-   *
-   */
   #[@test]
   public function negativeInt() {
     $scanner= new Scanner('%d');
     $this->assertEquals(['-123', '-123'], $scanner->match('-123')->group(0));
   }
 
-  /**
-   * Test %x
-   *
-   */
   #[@test]
   public function hex() {
     $scanner= new Scanner('%x');
     $this->assertEquals(['FF', 'FF'], $scanner->match('FF')->group(0));
   }
 
-  /**
-   * Test %x
-   *
-   */
   #[@test]
   public function hexWith0XPrefix() {
     $scanner= new Scanner('%x');
     $this->assertEquals(['0xFF', '0xFF'], $scanner->match('0xFF')->group(0));
   }
 
-  /**
-   * Test %f
-   *
-   */
   #[@test]
   public function float() {
     $scanner= new Scanner('%f');
     $this->assertEquals(['123.20', '123.20'], $scanner->match('123.20')->group(0));
   }
 
-  /**
-   * Test %f
-   *
-   */
   #[@test]
   public function negativeFloat() {
     $scanner= new Scanner('%f');
     $this->assertEquals(['-123.20', '-123.20'], $scanner->match('-123.20')->group(0));
   }
 
-  /**
-   * Test %s
-   *
-   */
   #[@test]
   public function string() {
     $scanner= new Scanner('%s');
     $this->assertEquals(['Hello', 'Hello'], $scanner->match('Hello')->group(0));
   }
 
-  /**
-   * Test %%
-   *
-   */
   #[@test]
   public function percentsSign() {
     $scanner= new Scanner('%d%%');
     $this->assertEquals(['100%', '100'], $scanner->match('100%')->group(0));
   }
 
-  /**
-   * Test %s
-   *
-   */
   #[@test]
   public function stringDoesNotMatchSpace() {
     $scanner= new Scanner('%s');
     $this->assertEquals(['Hello', 'Hello'], $scanner->match('Hello World')->group(0));
   }
 
-  /**
-   * Test %s
-   *
-   */
   #[@test]
   public function scanEmptyString() {
     $scanner= new Scanner('%s');
@@ -106,104 +67,60 @@ class ScannerTest extends \unittest\TestCase {
     $this->assertEquals(0, $scanner->match('')->length());
   }
 
-  /**
-   * Test %[a-z ]
-   *
-   */
   #[@test]
   public function characterSequence() {
     $scanner= new Scanner('%[a-z ]');
     $this->assertEquals(['hello world', 'hello world'], $scanner->match('hello world')->group(0));
   }
 
-  /**
-   * Test %[a-z-]
-   *
-   */
   #[@test]
   public function characterSequenceWithMinus() {
     $scanner= new Scanner('%[a-z-]');
     $this->assertEquals(['hello-world', 'hello-world'], $scanner->match('hello-world')->group(0));
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function characterSequenceExcludes() {
     $scanner= new Scanner('%[^ ]');
     $this->assertEquals(['0123', '0123'], $scanner->match('0123 are numbers')->group(0));
   }
 
-  /**
-   * Test %[][0-9.]
-   *
-   */
   #[@test]
   public function characterSequenceWithBracket() {
     $scanner= new Scanner('%[][0-9.]');
     $this->assertEquals(['[0..9]', '[0..9]'], $scanner->match('[0..9]')->group(0));
   }
 
-  /**
-   * Test "SN/%d"
-   *
-   * @see   php://sscanf
-   */
   #[@test]
   public function serialNumberExample() {
     $scanner= new Scanner('SN/%d');
     $this->assertEquals(['SN/2350001', '2350001'], $scanner->match('SN/2350001')->group(0));
   }
 
-  /**
-   * Test "SN/%d"
-   *
-   * @see   php://sscanf
-   */
   #[@test]
   public function serialNumberExampleNotMatching() {
     $scanner= new Scanner('SN/%d');
     $this->assertEquals(0, $scanner->match('/NS2350001')->length());
   }
 
-  /**
-   * Test "%d\t%s %s"
-   *
-   * @see   php://sscanf
-   */
   #[@test]
   public function authorParsingExample() {
     $scanner= new Scanner("%d\t%s %s");
     $this->assertEquals(["24\tLewis Carroll", '24', 'Lewis', 'Carroll'], $scanner->match("24\tLewis Carroll")->group(0));
   }
 
-  /**
-   * Test "file_%[^.].%d.%s"
-   *
-   * @see   php://sscanf
-   */
   #[@test]
   public function fileNameExample() {
     $scanner= new Scanner('file_%[^.].%d.%s');
     $this->assertEquals(['file_hello.0124.gif', 'hello', '0124', 'gif'], $scanner->match('file_hello.0124.gif')->group(0));
   }
 
-  /**
-   * Test unclosed brackets
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function unclosedBrackets() {
     new Scanner('%[');
   }
 
-  /**
-   * Test unclosed brackets
-   *
-   */
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function unknownScanCharacter() {
     new Scanner('%Ü');
   }

--- a/src/test/php/net/xp_framework/unittest/text/encode/QuotedPrintableInputStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/text/encode/QuotedPrintableInputStreamTest.class.php
@@ -4,6 +4,7 @@ use unittest\TestCase;
 use io\streams\InputStream;
 use io\streams\MemoryInputStream;
 use text\encode\QuotedPrintableInputStream;
+use io\IOException;
 
 /**
  * Test QuotedPrintable decoder
@@ -12,10 +13,6 @@ use text\encode\QuotedPrintableInputStream;
  */
 class QuotedPrintableInputStreamTest extends TestCase {
 
-  /**
-   * Test single read
-   *
-   */
   #[@test]
   public function singleRead() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('Hello'));
@@ -24,10 +21,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals('Hello', $chunk);
   }
 
-  /**
-   * Test multiple consecutive reads
-   *
-   */
   #[@test]
   public function multipleReads() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('Hello World'));
@@ -40,10 +33,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals('World', $chunk3);
   }
 
-  /**
-   * Test decoding an umlaut
-   *
-   */
   #[@test]
   public function umlaut() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('=DCbercoder'));
@@ -52,10 +41,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals('Übercoder', $chunk);
   }
 
-  /**
-   * Test decoding a space
-   *
-   */
   #[@test]
   public function space() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('Space between'));
@@ -64,10 +49,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals('Space between', $chunk);
   }
 
-  /**
-   * Test decoding a space
-   *
-   */
   #[@test]
   public function encodedSpace() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('Space=20between'));
@@ -76,10 +57,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals('Space between', $chunk);
   }
 
-  /**
-   * Test decoding a tab
-   *
-   */
   #[@test]
   public function tab() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream("Tab\tbetween"));
@@ -88,10 +65,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals("Tab\tbetween", $chunk);
   }
 
-  /**
-   * Test decoding a tab
-   *
-   */
   #[@test]
   public function encodedTab() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('Tab=09between'));
@@ -100,10 +73,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals("Tab\tbetween", $chunk);
   }
 
-  /**
-   * Test decoding an umlaut
-   *
-   */
   #[@test]
   public function softLineBreak() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream(str_repeat('1', 75)."=\n".str_repeat('2', 75)));
@@ -112,11 +81,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals(str_repeat('1', 75).str_repeat('2', 75), $chunk);
   }
 
-  /**
-   * Test space at the end of input - though not allowed in spec - is
-   * gracefully handled
-   *
-   */
   #[@test]
   public function spaceAtEnd() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('Hello '));
@@ -125,10 +89,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals('Hello ', $chunk);
   }
 
-  /**
-   * Test 
-   *
-   */
   #[@test]
   public function chunkedRead() {
     $expected= 'Hello Übercoder & World';
@@ -156,10 +116,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals($expected, $chunk);
   }
 
-  /**
-   * Test decoding an equals sign
-   *
-   */
   #[@test]
   public function equalsSign() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('A=3D1'));
@@ -168,10 +124,6 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals('A=1', $chunk);
   }
 
-  /**
-   * Test decoding a lowercase escape sequence
-   *
-   */
   #[@test]
   public function lowerCaseEscapeSequence() {
     $stream= new QuotedPrintableInputStream(new MemoryInputStream('=3d'));
@@ -180,11 +132,7 @@ class QuotedPrintableInputStreamTest extends TestCase {
     $this->assertEquals('=', $chunk);
   }
   
-  /**
-   * Test an illegal byte sequence
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function invalidByteSequence() {
     (new QuotedPrintableInputStream(new MemoryInputStream('Hell=XX')))->read();
   }

--- a/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
@@ -1,15 +1,17 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\Properties;
 use util\Hashmap;
+use lang\FormatException;
+use lang\IllegalStateException;
+use lang\ElementNotFoundException;
 
 /**
  * Testcase for util.Properties class.
  *
  * @see      xp://util.Properties
  */
-abstract class AbstractPropertiesTest extends TestCase {
+abstract class AbstractPropertiesTest extends \unittest\TestCase {
 
   /**
    * Create a new properties object from a string source
@@ -274,7 +276,7 @@ abstract class AbstractPropertiesTest extends TestCase {
     $this->assertEquals('final', $p->getNextSection());
   }
 
-  #[@test, @expect('lang.FormatException'), @values([
+  #[@test, @expect(FormatException::class), @values([
   #  ["[section]\nfoo", 'missing equals sign for key'],
   #  ["[section]\nfoo]=value", 'key contains unbalanced bracket'],
   #  ["[section\nfoo=bar", 'section missing closing bracket']
@@ -320,7 +322,7 @@ abstract class AbstractPropertiesTest extends TestCase {
     $this->assertFalse($p->hasSection('section'));
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function remove_non_existant_section() {
     $this->fixture('')->removeSection('non-existant');
   }
@@ -332,7 +334,7 @@ abstract class AbstractPropertiesTest extends TestCase {
     $this->assertNull($p->readString('section', 'key', null));
   }
 
-  #[@test, @expect('lang.IllegalStateException'), @values(['section', 'non-existant'])]
+  #[@test, @expect(IllegalStateException::class), @values(['section', 'non-existant'])]
   public function remove_non_existant_key($section) {
     $this->fixture('key=value')->removeKey($section, 'non-existant');
   }
@@ -366,7 +368,7 @@ abstract class AbstractPropertiesTest extends TestCase {
     $this->assertNotEquals($this->newPropertiesFrom("[section]\ndifferent=value"), $this->newPropertiesFrom($source));
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function resolve_unsupported_type() {
     $this->fixture('test=${not.supported}');
   }
@@ -379,7 +381,7 @@ abstract class AbstractPropertiesTest extends TestCase {
     $this->assertEquals('this', $value);
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function resolve_non_existant_senvironment_variable() {
     putenv('TEST');
     $this->fixture('test=${env.TEST}');

--- a/src/test/php/net/xp_framework/unittest/util/BinfordTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/BinfordTest.class.php
@@ -1,44 +1,31 @@
 <?php namespace net\xp_framework\unittest\util;
  
-use unittest\TestCase;
 use util\Binford;
-
+use lang\IllegalArgumentException;
 
 /**
  * Test Binford class
  *
  * @see  xp://util.Binford
  */
-class BinfordTest extends TestCase {
+class BinfordTest extends \unittest\TestCase {
   protected static $observable;
 
-  /**
-   * Tests constructor
-   */
   #[@test]
   public function can_create() {
     new Binford(6100);
   }
 
-  /**
-   * Tests constructor
-   */
   #[@test]
   public function default_power_is_6100() {
     $this->assertEquals(new Binford(6100), new Binford());
   }
 
-  /**
-   * Tests getPoweredBy()
-   */
   #[@test]
   public function get_powered_by_returns_powerr() {
     $this->assertEquals(6100, (new Binford(6100))->getPoweredBy());
   }
 
-  /**
-   * Tests setPoweredBy()
-   */
   #[@test]
   public function set_powered_by_modifies_power() {
     $binford= new Binford(6100);
@@ -46,57 +33,36 @@ class BinfordTest extends TestCase {
     $this->assertEquals(61000, $binford->getPoweredBy());
   }
 
-  /**
-   * Tests setPoweredBy()
-   */
   #[@test]
   public function zero_power_allowed() {
     new Binford(0);
   }
 
-  /**
-   * Tests setPoweredBy()
-   */
   #[@test]
   public function fraction_0_61_power_allowed() {
     new Binford(0.61);
   }
 
-  /**
-   * Tests setPoweredBy()
-   */
   #[@test]
   public function fraction_6_1_power_allowed() {
     new Binford(6.1);
   }
 
-  /**
-   * Tests setPoweredBy()
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function non_binford_number_not_allowed() {
     new Binford(6200);
   }
 
-  /**
-   * Tests setPoweredBy()
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function double_binford_number_not_allowed() {
     new Binford(6100 * 2);
   }
 
-  /**
-   * Tests toString()
-   */
   #[@test]
   public function string_representation() {
     $this->assertEquals('util.Binford(6100)', (new Binford(6100))->toString());
   }
 
-  /**
-   * Tests getHeader()
-   */
   #[@test]
   public function header_representation() {
     $this->assertEquals(

--- a/src/test/php/net/xp_framework/unittest/util/CompositePropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/CompositePropertiesTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\Properties;
 use util\Hashmap;
 use util\CompositeProperties;
 use unittest\actions\RuntimeVersion;
+use lang\IllegalArgumentException;
+use lang\Error;
 
 /**
  * Test CompositeProperties
@@ -12,7 +13,7 @@ use unittest\actions\RuntimeVersion;
  * @see   https://github.com/xp-framework/xp-framework/issues/302
  * @see    xp://util.CompositeProperies
  */
-class CompositePropertiesTest extends TestCase {
+class CompositePropertiesTest extends \unittest\TestCase {
 
   #[@test]
   public function createCompositeSingle() {
@@ -26,22 +27,22 @@ class CompositePropertiesTest extends TestCase {
     $this->assertEquals(2, $c->length());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function createCompositeThrowsExceptionWhenNoArgumentGiven() {
     new CompositeProperties();
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function createEmptyCompositeThrowsException() {
     new CompositeProperties([]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]]
   public function createCompositeThrowsExceptionWhenSomethingElseThenPropertiesGiven() {
     new CompositeProperties([new Properties(null), 1, new Properties(null)]);
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]]
   public function createCompositeThrowsExceptionWhenSomethingElseThenPropertiesGiven7() {
     new CompositeProperties([new Properties(null), 1, new Properties(null)]);
   }

--- a/src/test/php/net/xp_framework/unittest/util/CurrencyTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/CurrencyTest.class.php
@@ -1,36 +1,21 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\Currency;
+use lang\IllegalArgumentException;
 
+class CurrencyTest extends \unittest\TestCase {
 
-/**
- * TestCase
- *
- * @see      xp://util.Currency
- */
-class CurrencyTest extends TestCase {
-
-  /**
-   * Test getInstance() method
-   */
   #[@test]
   public function get_instance_usd() {
     $this->assertEquals(Currency::$USD, Currency::getInstance('USD'));
   }
 
-  /**
-   * Test getInstance() method
-   */
   #[@test]
   public function get_instance_eur() {
     $this->assertEquals(Currency::$EUR, Currency::getInstance('EUR'));
   }
 
-  /**
-   * Test getInstance() method
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function get_instance_nonexistant() {
     Currency::getInstance('@@not-a-currency@@');
   }

--- a/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
@@ -3,6 +3,8 @@
 use util\Date;
 use util\TimeZone;
 use net\xp_framework\unittest\IgnoredOnHHVM;
+use lang\IllegalArgumentException;
+use lang\IllegalStateException;
 
 /**
  * Tests Date class
@@ -257,7 +259,7 @@ class DateTest extends \unittest\TestCase {
     $this->assertEquals($expect, $this->refDate->format($input));
   }
   
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function unsupportedFormatToken() {
     $this->refDate->format('%b');
   }
@@ -283,7 +285,7 @@ class DateTest extends \unittest\TestCase {
    * Test PHP Bug #42910 - timezone should not fallback to default
    * timezone if it actually is unknown.
    */
-  #[@test, @ignore, @expect('lang.IllegalStateException')]
+  #[@test, @ignore, @expect(IllegalStateException::class)]
   public function emptyTimeZoneNameIfUnknown() {
   
     // Specific timezone id unknown, can be Europe/Paris, Europe/Berlin, ...
@@ -305,27 +307,27 @@ class DateTest extends \unittest\TestCase {
     $this->assertEquals('2007-11-10 19:15:00+0000', $date->toString(Date::DEFAULT_FORMAT, new TimeZone(null)));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function malformedInputString() {
     new Date('@@not-a-date@@');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function monthExceeded() {
     new Date('30.99.2010');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function dayExceeded() {
     new Date('99.30.2010');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function unknownTimeZoneNameInString() {
     new Date('14.12.2010 11:55:00 Europe/Karlsruhe');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function unknownTimeZoneOffsetInString() {
     new Date('14.12.2010 11:55:00+9999');
   }
@@ -335,17 +337,17 @@ class DateTest extends \unittest\TestCase {
     Date::now();
     try {
       new Date('bogus');
-      $this->fail('No exception raised', null, 'lang.IllegalArgumentException');
+      $this->fail('No exception raised', null, IllegalArgumentException::class);
     } catch (\lang\IllegalArgumentException $expected) { }
     Date::now();
   }
   
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new IgnoredOnHHVM())]
+  #[@test, @expect(IllegalArgumentException::class), @action(new IgnoredOnHHVM())]
   public function dateCreateWithAllInvalidArguments() {
     Date::create('', '', '', '', '', '');
   }
   
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new IgnoredOnHHVM())]
+  #[@test, @expect(IllegalArgumentException::class), @action(new IgnoredOnHHVM())]
   public function dateCreateWithInvalidArgumentsExceptTimeZone() {
     Date::create('', '', '', '', '', '', new TimeZone('UTC'));
   }
@@ -385,7 +387,7 @@ class DateTest extends \unittest\TestCase {
     $this->assertDateEquals('1970-01-12T13:46:40+00:00', new Date('1000000'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function testInvalidUnixTimestamp() {
     new Date('+1000000');
   }

--- a/src/test/php/net/xp_framework/unittest/util/DeferredInvokationHandlerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DeferredInvokationHandlerTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\util;
 
 use util\AbstractDeferredInvokationHandler;
+use util\DeferredInitializationException;
 use lang\Runnable;
 use lang\IllegalStateException;
 
@@ -22,7 +23,7 @@ class DeferredInvokationHandlerTest extends \unittest\TestCase {
     $this->assertEquals($args, $handler->invoke($this, 'run', $args));
   }
 
-  #[@test, @expect(class = 'lang.IllegalStateException', withMessage= 'Test')]
+  #[@test, @expect(class= IllegalStateException::class, withMessage= 'Test')]
   public function throwing_runnable_invokation() {
     $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
       'initialize' => function() {
@@ -34,7 +35,7 @@ class DeferredInvokationHandlerTest extends \unittest\TestCase {
     $handler->invoke($this, 'run', ['Test']);
   }
 
-  #[@test, @expect(class = 'util.DeferredInitializationException', withMessage= 'run')]
+  #[@test, @expect(class= DeferredInitializationException::class, withMessage= 'run')]
   public function initialize_returns_null() {
     $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
       'initialize' => function() {
@@ -44,7 +45,7 @@ class DeferredInvokationHandlerTest extends \unittest\TestCase {
     $handler->invoke($this, 'run', []);
   }
 
-  #[@test, @expect(class = 'util.DeferredInitializationException', withMessage= 'run')]
+  #[@test, @expect(class= DeferredInitializationException::class, withMessage= 'run')]
   public function initialize_throws_exception() {
     $handler= newinstance(AbstractDeferredInvokationHandler::class, [], [
       'initialize' => function() {
@@ -90,7 +91,7 @@ class DeferredInvokationHandlerTest extends \unittest\TestCase {
     ]);
     try {
       $handler->invoke($this, 'run', []);
-    } catch (\util\DeferredInitializationException $expected) {
+    } catch (DeferredInitializationException $expected) {
       // OK
     }
     $this->assertEquals(true, $handler->invoke($this, 'run', []));

--- a/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
@@ -5,6 +5,7 @@ use io\streams\Streams;
 use io\streams\MemoryInputStream;;
 use io\IOException;
 use util\Properties;
+use lang\ClassLoader;
 
 /**
  * Testcase for util.Properties class.
@@ -17,7 +18,7 @@ class FileBasedPropertiesTest extends AbstractPropertiesTest {
   protected static $fileStreamAdapter;
   
   static function __static() {
-    self::$fileStreamAdapter= \lang\ClassLoader::defineClass('FileStreamAdapter', 'io.File', [], '{
+    self::$fileStreamAdapter= ClassLoader::defineClass('FileStreamAdapter', File::class, [], '{
       protected $stream= null;
       public function __construct($stream) { $this->stream= $stream; }
       public function exists() { return null !== $this->stream; }

--- a/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
@@ -51,9 +51,9 @@ class FileBasedPropertiesTest extends AbstractPropertiesTest {
   public function lazyRead() {
     $p= new Properties('@@does-not-exist.ini@@');
     
-    // This cannot be done via @expect because it would also catch if an
-    // exception was thrown from util.Properties' constructor. We explicitely
-    // want the exception to be thrown later on
+    // This cannot be done via expect annotation because it would also catch if
+    // an exception was thrown from util.Properties' constructor. We explicitely
+    // want the exception to be thrown later on!
     try {
       $p->readString('section', 'key');
       $this->fail('Expected exception not thrown', null, 'io.IOException');

--- a/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
@@ -2,7 +2,8 @@
 
 use io\File;
 use io\streams\Streams;
-use io\streams\MemoryInputStream;
+use io\streams\MemoryInputStream;;
+use io\IOException;
 use util\Properties;
 
 /**
@@ -17,9 +18,9 @@ class FileBasedPropertiesTest extends AbstractPropertiesTest {
   
   static function __static() {
     self::$fileStreamAdapter= \lang\ClassLoader::defineClass('FileStreamAdapter', 'io.File', [], '{
-      protected $stream= NULL;
+      protected $stream= null;
       public function __construct($stream) { $this->stream= $stream; }
-      public function exists() { return NULL !== $this->stream; }
+      public function exists() { return null !== $this->stream; }
       public function getURI() { return \io\streams\Streams::readableUri($this->stream); }
       public function getInputStream() { return $this->stream; }
     }');
@@ -35,30 +36,17 @@ class FileBasedPropertiesTest extends AbstractPropertiesTest {
     return Properties::fromFile(self::$fileStreamAdapter->newInstance(new MemoryInputStream($source)));
   }
 
-  /**
-   * Test construction via fromFile() method for a non-existant file
-   *
-   */
-  #[@test, @expect('io.IOException')]
+  #[@test, @expect(IOException::class)]
   public function fromNonExistantFile() {
     Properties::fromFile(new File('@@does-not-exist.ini@@'));
   }
 
-  /**
-   * Test construction via fromFile() method for an existant file.
-   * Relies on a file "example.ini" existing parallel to this class.
-   *
-   */
   #[@test]
   public function fromFile() {
     $p= Properties::fromFile($this->getClass()->getPackage()->getResourceAsStream('example.ini'));
     $this->assertEquals('value', $p->readString('section', 'key'));
   }
 
-  /**
-   * Test exceptions are not thrown until first read
-   *
-   */
   #[@test]
   public function lazyRead() {
     $p= new Properties('@@does-not-exist.ini@@');
@@ -69,15 +57,11 @@ class FileBasedPropertiesTest extends AbstractPropertiesTest {
     try {
       $p->readString('section', 'key');
       $this->fail('Expected exception not thrown', null, 'io.IOException');
-    } catch (\io\IOException $expected) {
+    } catch (IOException $expected) {
       \xp::gc();
     }
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function propertiesFromSameFileAreEqual() {
     $one= Properties::fromFile($this->getClass()->getPackage()->getResourceAsStream('example.ini'));
@@ -87,10 +71,6 @@ class FileBasedPropertiesTest extends AbstractPropertiesTest {
     $this->assertTrue($one->equals($two));
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function propertiesFromOtherFilesAreNotEqual() {
     $this->assertNotEquals(new Properties('a.ini'), new Properties('b.ini'));

--- a/src/test/php/net/xp_framework/unittest/util/FilesystemPropertySourceTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FilesystemPropertySourceTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use io\File;
 use io\FileUtil;
 use lang\System;
+use lang\IllegalArgumentException;
 use util\FilesystemPropertySource;
 use util\Properties;
 
@@ -12,7 +12,7 @@ use util\Properties;
  *
  * @see   xp://util.FilesystemPropertySource
  */
-class FilesystemPropertySourceTest extends TestCase {
+class FilesystemPropertySourceTest extends \unittest\TestCase {
   protected $tempFile;
   protected $fixture;
 
@@ -29,25 +29,16 @@ class FilesystemPropertySourceTest extends TestCase {
     $this->tempFile->unlink();
   }
 
-  /**
-   * Test provides()
-   */
   #[@test]
   public function provides_existing_ini_file() {
     $this->assertTrue($this->fixture->provides('temp'));
   }
 
-  /**
-   * Test provides()
-   */
   #[@test]
   public function does_not_provide_non_existant_ini_file() {
     $this->assertFalse($this->fixture->provides('@@non-existant@@'));
   }
 
-  /**
-   * Test fetch()
-   */
   #[@test]
   public function fetch_existing_ini_file() {
     $this->assertEquals(
@@ -56,10 +47,7 @@ class FilesystemPropertySourceTest extends TestCase {
     );
   }
 
-  /**
-   * Test fetch()
-   */
-  #[@test, @expect(class= 'lang.IllegalArgumentException', withMessage= '/No properties @@non-existant@@ found at .+/')]
+  #[@test, @expect(class= IllegalArgumentException::class, withMessage= '/No properties @@non-existant@@ found at .+/')]
   public function fetch_non_existant_ini_file() {
     $this->fixture->fetch('@@non-existant@@');
   }

--- a/src/test/php/net/xp_framework/unittest/util/FiltersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FiltersTest.class.php
@@ -3,6 +3,7 @@
 use util\Filters;
 use util\Filter;
 use lang\IllegalStateException;
+use lang\IllegalArgumentException;
 
 /**
  * Test Filters class
@@ -50,7 +51,7 @@ class FiltersTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function constructor_raises_exception_when_neither_null_nor_closure_given_for_accepting() {
     create('new util.Filters<int>', [], 'callback');
   }

--- a/src/test/php/net/xp_framework/unittest/util/HashmapIteratorTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/HashmapIteratorTest.class.php
@@ -4,6 +4,7 @@ use unittest\TestCase;
 use util\Hashmap;
 use util\HashmapIterator;
 use util\Comparator;
+use util\NoSuchElementException;
 
 /**
  * Test HashmapIterator class
@@ -20,7 +21,7 @@ class HashmapIteratorTest extends TestCase {
     $this->map= new Hashmap(['k1' => 'v1', 'k2' => 'v2', 'k3' => 'v3']);
   }
       
-  #[@test, @expect('util.NoSuchElementException')]
+  #[@test, @expect(NoSuchElementException::class)]
   public function nextOnEmpty() {
     (new HashmapIterator([]))->next();
   }
@@ -61,7 +62,7 @@ class HashmapIteratorTest extends TestCase {
     );
   }
 
-  #[@test, @expect('util.NoSuchElementException')]
+  #[@test, @expect(NoSuchElementException::class)]
   public function nextOnEnd() {
     $i= $this->map->iterator();
     $i->next();

--- a/src/test/php/net/xp_framework/unittest/util/HashmapTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/HashmapTest.class.php
@@ -3,6 +3,7 @@
 use unittest\TestCase;
 use util\Hashmap;
 use util\Comparator;
+use lang\IllegalArgumentException;
 
 /**
  * Test Hashmap class
@@ -112,7 +113,7 @@ class HashmapTest extends TestCase {
     );
   }
   
-  #[@test, @expect('lang.IllegalArgumentException')]    
+  #[@test, @expect(IllegalArgumentException::class)]    
   public function mergeWithIllegalArgument() {
     $this->map->merge(new \lang\Object());
   }

--- a/src/test/php/net/xp_framework/unittest/util/LocaleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/LocaleTest.class.php
@@ -1,75 +1,44 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\Locale;
 
+class LocaleTest extends \unittest\TestCase {
 
-/**
- * TestCase
- *
- * @see      xp://util.Locale
- */
-class LocaleTest extends TestCase {
-
-  /**
-   * Test getDefault()
-   */
   #[@test]
   public function get_default_locale() {
-    $this->assertInstanceOf('util.Locale', Locale::getDefault());
+    $this->assertInstanceOf(Locale::class, Locale::getDefault());
   }
 
-  /**
-   * Test constructor
-   */
   #[@test]
   public function constructor_with_one_arg() {
     $this->assertEquals('de_DE', (new Locale('de_DE'))->toString());
   }
 
-  /**
-   * Test constructor
-   */
   #[@test]
   public function constructor_with_two_args() {
     $this->assertEquals('de_DE', (new Locale('de', 'DE'))->toString());
   }
 
-  /**
-   * Test constructor
-   */
   #[@test]
   public function constructor_with_three_args() {
     $this->assertEquals('de_DE@utf-8', (new Locale('de', 'DE', 'utf-8'))->toString());
   }
 
-  /**
-   * Test getLanguage()
-   */
   #[@test]
   public function de_DE_language() {
     $this->assertEquals('de', (new Locale('de_DE'))->getLanguage());
   }
 
-  /**
-   * Test getLanguage()
-   */
   #[@test]
   public function de_DE_country() {
     $this->assertEquals('DE', (new Locale('de_DE'))->getCountry());
   }
 
-  /**
-   * Test getVariant()
-   */
   #[@test]
   public function de_DE_variant() {
     $this->assertEquals('', (new Locale('de_DE'))->getVariant());
   }
 
-  /**
-   * Test getVariant()
-   */
   #[@test]
   public function de_DE_with_variant() {
     $this->assertEquals('@utf-8', (new Locale('de_DE@utf-8'))->getVariant());

--- a/src/test/php/net/xp_framework/unittest/util/MoneyTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/MoneyTest.class.php
@@ -1,205 +1,138 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\Money;
-
+use util\Currency;
+use lang\IllegalArgumentException;
+use lang\types\Double;
 
 /**
  * TestCase
  *
  * @see      xp://util.Money
  */
-class MoneyTest extends TestCase {
+class MoneyTest extends \unittest\TestCase {
 
-  /**
-   * Test amount() method
-   *
-   */
   #[@test]
   public function tenUsDollarsFromInt() {
     $this->assertEquals(
-      new \lang\types\Double(10.00), 
-      (new Money(10, \util\Currency::$USD))->amount()
+      new Double(10.00), 
+      (new Money(10, Currency::$USD))->amount()
     );
   }
 
-  /**
-   * Test amount() method
-   *
-   */
   #[@test]
   public function tenUsDollarsFromFloat() {
     $this->assertEquals(
-      new \lang\types\Double(10.00), 
-      (new Money(10.00, \util\Currency::$USD))->amount()
+      new Double(10.00), 
+      (new Money(10.00, Currency::$USD))->amount()
     );
   }
 
-  /**
-   * Test amount() method
-   *
-   */
   #[@test]
   public function tenUsDollarsFromString() {
     $this->assertEquals(
-      new \lang\types\Double(10.00), 
-      (new Money('10.00', \util\Currency::$USD))->amount()
+      new Double(10.00), 
+      (new Money('10.00', Currency::$USD))->amount()
     );
   }
 
-  /**
-   * Test currency() method
-   *
-   */
   #[@test]
   public function currency() {
-    $this->assertEquals(\util\Currency::$USD, (new Money('1.00', \util\Currency::$USD))->currency());
+    $this->assertEquals(Currency::$USD, (new Money('1.00', Currency::$USD))->currency());
   }
 
-  /**
-   * Test toString() method
-   *
-   */
   #[@test]
   public function stringRepresentation() {
     $this->assertEquals(
       '19.99 USD', 
-      (new Money('19.99', \util\Currency::$USD))->toString()
+      (new Money('19.99', Currency::$USD))->toString()
     );
   }
 
-  /**
-   * Test add() method
-   *
-   */
   #[@test]
   public function add() {
     $this->assertEquals(
-      new Money('20.00', \util\Currency::$EUR),
-      (new Money('11.50', \util\Currency::$EUR))->add(new Money('8.50', \util\Currency::$EUR))
+      new Money('20.00', Currency::$EUR),
+      (new Money('11.50', Currency::$EUR))->add(new Money('8.50', Currency::$EUR))
     );
   }
 
-  /**
-   * Test add() method
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function cannotAddDifferentCurrencies() {
-    (new Money('11.50', \util\Currency::$EUR))->add(new Money('8.50', \util\Currency::$USD));
+    (new Money('11.50', Currency::$EUR))->add(new Money('8.50', Currency::$USD));
   }
 
-  /**
-   * Test subtract() method
-   *
-   */
   #[@test]
   public function subtract() {
     $this->assertEquals(
-      new Money('3.00', \util\Currency::$EUR),
-      (new Money('11.50', \util\Currency::$EUR))->subtract(new Money('8.50', \util\Currency::$EUR))
+      new Money('3.00', Currency::$EUR),
+      (new Money('11.50', Currency::$EUR))->subtract(new Money('8.50', Currency::$EUR))
     );
   }
 
-  /**
-   * Test subtract() method
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function cannotSubtractDifferentCurrencies() {
-    (new Money('11.50', \util\Currency::$EUR))->subtract(new Money('8.50', \util\Currency::$USD));
+    (new Money('11.50', Currency::$EUR))->subtract(new Money('8.50', Currency::$USD));
   }
 
-  /**
-   * Test multiplyBy() method
-   *
-   */
   #[@test]
   public function multiplyBy() {
     $this->assertEquals(
-      new Money('2.98', \util\Currency::$EUR),
-      (new Money('1.49', \util\Currency::$EUR))->multiplyBy(2)
+      new Money('2.98', Currency::$EUR),
+      (new Money('1.49', Currency::$EUR))->multiplyBy(2)
     );
   }
 
-  /**
-   * Test divideBy() method
-   *
-   */
   #[@test]
   public function divideBy() {
     $this->assertEquals(
-      new Money('9.99', \util\Currency::$EUR),
-      (new Money('19.98', \util\Currency::$EUR))->divideBy(2)
+      new Money('9.99', Currency::$EUR),
+      (new Money('19.98', Currency::$EUR))->divideBy(2)
     );
   }
 
-  /**
-   * Test compareTo() method
-   *
-   */
   #[@test]
   public function compareToReturnsZeroOnEquality() {
     $this->assertEquals(
       0,
-      (new Money('1.01', \util\Currency::$EUR))->compareTo(new Money('1.01', \util\Currency::$EUR))
+      (new Money('1.01', Currency::$EUR))->compareTo(new Money('1.01', Currency::$EUR))
     );
   }
 
-  /**
-   * Test compareTo() method
-   *
-   */
   #[@test]
   public function compareToReturnsNegativeOneIfArgumentIsLess() {
     $this->assertEquals(
       -1,
-      (new Money('1.01', \util\Currency::$EUR))->compareTo(new Money('0.99', \util\Currency::$EUR))
+      (new Money('1.01', Currency::$EUR))->compareTo(new Money('0.99', Currency::$EUR))
     );
   }
 
-  /**
-   * Test compareTo() method
-   *
-   */
   #[@test]
   public function compareToReturnsOneIfArgumentIsMore() {
     $this->assertEquals(
       1,
-      (new Money('0.99', \util\Currency::$EUR))->compareTo(new Money('1.01', \util\Currency::$EUR))
+      (new Money('0.99', Currency::$EUR))->compareTo(new Money('1.01', Currency::$EUR))
     );
   }
 
-  /**
-   * Test compareTo() method
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function cannotCompareDifferentCurrencies() {
-    (new Money('1.01', \util\Currency::$EUR))->compareTo(new Money('0.99', \util\Currency::$USD));
+    (new Money('1.01', Currency::$EUR))->compareTo(new Money('0.99', Currency::$USD));
   }
   
-  /**
-   * Test multiplyBy() method - example: ten gallons of "87"
-   *
-   */
   #[@test]
   public function tenGallonsOfRegular() {
     $this->assertEquals(
-      new Money('32.99', \util\Currency::$EUR),
-      (new Money('3.299', \util\Currency::$EUR))->multiplyBy(10)
+      new Money('32.99', Currency::$EUR),
+      (new Money('3.299', Currency::$EUR))->multiplyBy(10)
     );
   }
 
-  /**
-   * Test multiplyBy() method - example: currency exchange
-   *
-   */
   #[@test]
   public function aThousandEurosInDollars() {
     $this->assertEquals(
-      new Money('1496.64', \util\Currency::$EUR),
-      (new Money('1000.00', \util\Currency::$EUR))->multiplyBy(1.49664)
+      new Money('1496.64', Currency::$EUR),
+      (new Money('1000.00', Currency::$EUR))->multiplyBy(1.49664)
     );
   }
 }

--- a/src/test/php/net/xp_framework/unittest/util/ObservableTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/ObservableTest.class.php
@@ -2,6 +2,7 @@
 
 use util\Observable;
 use util\Observer;
+use lang\ClassLoader;
 
 /**
  * Test Observable class
@@ -11,12 +12,9 @@ use util\Observer;
 class ObservableTest extends \unittest\TestCase {
   protected static $observable;
 
-  /**
-   * Creates observable
-   */
   #[@beforeClass]
   public static function defineObservable() {
-    self::$observable= \lang\ClassLoader::defineClass('net.xp_framework.unittest.util.ObservableFixture', 'util.Observable', [], '{
+    self::$observable= ClassLoader::defineClass('net.xp_framework.unittest.util.ObservableFixture', Observable::class, [], '{
       private $value= 0;
 
       public function setValue($value) {

--- a/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
@@ -25,7 +25,7 @@ class PropertyManagerTest extends \unittest\TestCase {
    * @return  util.PropertyManager
    */
   private function fixture() {
-    $class= ClassLoader::getDefault()->defineClass('NonSingletonPropertyManager', 'util.PropertyManager', [], '{
+    $class= ClassLoader::getDefault()->defineClass('NonSingletonPropertyManager', PropertyManager::class, [], '{
       public static function newInstance() {
         return new self();
       }

--- a/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
@@ -4,6 +4,7 @@ use unittest\TestCase;
 use util\PropertyManager;
 use util\ResourcePropertySource;
 use lang\ClassLoader;
+use lang\ElementNotFoundException;
 use unittest\actions\RuntimeVersion;
 new import('lang.ResourceProvider');
 
@@ -218,7 +219,7 @@ key="overwritten value"'));
 
   }
 
-  #[@test, @expect('lang.ElementNotFoundException')]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function getNonExistantProperties() {
     $this->preconfigured()->getProperties('does-not-exist');
   }

--- a/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
@@ -1,10 +1,13 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use unittest\TestCase;
 use util\PropertyManager;
+use util\Properties;
+use util\PropertyAccess;
 use util\ResourcePropertySource;
+use util\FilesystemPropertySource;
 use lang\ClassLoader;
 use lang\ElementNotFoundException;
+use lang\IllegalArgumentException;
 use unittest\actions\RuntimeVersion;
 new import('lang.ResourceProvider');
 
@@ -13,7 +16,7 @@ new import('lang.ResourceProvider');
  *
  * @see   xp://util.PropertyManager
  */
-class PropertyManagerTest extends TestCase {
+class PropertyManagerTest extends \unittest\TestCase {
   const RESOURCE_PATH = 'net/xp_framework/unittest/util/';
 
   /**
@@ -54,7 +57,7 @@ class PropertyManagerTest extends TestCase {
   #[@test]
   public function testCanAcquireNewInstance() {
     $instance= $this->fixture();
-    $this->assertInstanceOf('util.PropertyManager', $instance);
+    $this->assertInstanceOf(PropertyManager::class, $instance);
     $this->assertNotEquals($instance->hashCode(), $this->fixture()->hashCode());
   }
   
@@ -62,7 +65,7 @@ class PropertyManagerTest extends TestCase {
   public function registerProperties() {
     $fixture= $this->fixture();
     $this->assertFalse($fixture->hasProperties('props'));
-    $fixture->register('props', \util\Properties::fromString('[section]'));
+    $fixture->register('props', Properties::fromString('[section]'));
     
     $this->assertTrue($fixture->hasProperties('props'));
   }
@@ -89,39 +92,39 @@ class PropertyManagerTest extends TestCase {
   #[@test]
   public function registerOverwritesExistingProperties() {
     $fixture= $this->preconfigured();
-    $fixture->register('example', \util\Properties::fromString('[any-section]'));
+    $fixture->register('example', Properties::fromString('[any-section]'));
     $this->assertEquals('any-section', $fixture->getProperties('example')->getFirstSection());
   }
 
   #[@test]
   public function getProperties() {
     $prop= $this->preconfigured()->getProperties('example');
-    $this->assertInstanceOf('util.PropertyAccess', $prop);
+    $this->assertInstanceOf(PropertyAccess::class, $prop);
     $this->assertEquals('value', $prop->readString('section', 'key'));
   }
 
   #[@test]
   public function prependSource() {
-    $path= new \util\FilesystemPropertySource('.');
+    $path= new FilesystemPropertySource('.');
     $this->assertEquals($path, $this->fixture()->prependSource($path));
   }
 
   #[@test]
   public function appendSource() {
-    $path= new \util\FilesystemPropertySource('.');
+    $path= new FilesystemPropertySource('.');
     $this->assertEquals($path, $this->fixture()->appendSource($path));
   }
 
   #[@test]
   public function hasSource() {
-    $path= new \util\FilesystemPropertySource(__DIR__.'/..');
+    $path= new FilesystemPropertySource(__DIR__.'/..');
     $fixture= $this->fixture();
     $this->assertFalse($fixture->hasSource($path));
   }
 
   #[@test]
   public function hasAppendedSource() {
-    $path= new \util\FilesystemPropertySource(__DIR__.'/..');
+    $path= new FilesystemPropertySource(__DIR__.'/..');
     $fixture= $this->fixture();
     $fixture->appendSource($path);
     $this->assertTrue($fixture->hasSource($path));
@@ -129,14 +132,14 @@ class PropertyManagerTest extends TestCase {
 
   #[@test]
   public function removeSource() {
-    $path= new \util\FilesystemPropertySource(__DIR__.'/..');
+    $path= new FilesystemPropertySource(__DIR__.'/..');
     $fixture= $this->fixture();
     $this->assertFalse($fixture->removeSource($path));
   }
 
   #[@test]
   public function removeAppendedSource() {
-    $path= new \util\FilesystemPropertySource(__DIR__.'/..');
+    $path= new FilesystemPropertySource(__DIR__.'/..');
     $fixture= $this->fixture();
     $fixture->appendSource($path);
     $this->assertTrue($fixture->removeSource($path));
@@ -158,7 +161,7 @@ class PropertyManagerTest extends TestCase {
 
   #[@test]
   public function getSourcesAfterAppendingOne() {
-    $path= new \util\FilesystemPropertySource('.');
+    $path= new FilesystemPropertySource('.');
     $fixture= $this->fixture();
     $fixture->appendSource($path);
     $this->assertEquals([$path], $fixture->getSources());
@@ -166,7 +169,7 @@ class PropertyManagerTest extends TestCase {
 
   #[@test]
   public function getSourcesAfterPrependingOne() {
-    $path= new \util\FilesystemPropertySource('.');
+    $path= new FilesystemPropertySource('.');
     $fixture= $this->fixture();
     $fixture->prependSource($path);
     $this->assertEquals([$path], $fixture->getSources());
@@ -177,12 +180,12 @@ class PropertyManagerTest extends TestCase {
     $fixture= $this->preconfigured();
 
     // Register new Properties, with some value in existing section
-    $fixture->register('example', \util\Properties::fromString('[section]
+    $fixture->register('example', Properties::fromString('[section]
 dynamic-value=whatever'));
 
     $prop= $fixture->getProperties('example');
-    $this->assertInstanceOf('util.PropertyAccess', $prop);
-    $this->assertFalse($prop instanceof \util\Properties);
+    $this->assertInstanceOf(PropertyAccess::class, $prop);
+    $this->assertFalse($prop instanceof Properties);
 
     // Check key from example.ini is available
     $this->assertEquals('value', $fixture->getProperties('example')->readString('section', 'key'));
@@ -197,7 +200,7 @@ dynamic-value=whatever'));
 
     $this->assertEquals('value', $fixture->getProperties('example')->readString('section', 'key'));
 
-    $fixture->register('example', \util\Properties::fromString('[section]
+    $fixture->register('example', Properties::fromString('[section]
 key="overwritten value"'));
     $this->assertEquals('overwritten value', $fixture->getProperties('example')->readString('section', 'key'));
   }
@@ -208,13 +211,13 @@ key="overwritten value"'));
     $fixture->appendSource(new ResourcePropertySource(self::RESOURCE_PATH));
     $fixture->appendSource(new ResourcePropertySource(self::RESOURCE_PATH));
 
-    $this->assertInstanceOf('util.Properties', $fixture->getProperties('example'));
+    $this->assertInstanceOf(Properties::class, $fixture->getProperties('example'));
   }
 
   #[@test]
   public function getExistantProperties() {
     $p= $this->preconfigured()->getProperties('example');
-    $this->assertInstanceOf('util.Properties', $p);
+    $this->assertInstanceOf(Properties::class, $p);
     $this->assertTrue($p->exists(), 'Should return an existant Properties instance');
 
   }
@@ -234,7 +237,7 @@ key="overwritten value"'));
 
   #[@test]
   public function setSingleSource() {
-    $source= new \util\FilesystemPropertySource('.');
+    $source= new FilesystemPropertySource('.');
     $fixture= $this->fixture();
     $fixture->setSources([$source]);
 
@@ -243,8 +246,8 @@ key="overwritten value"'));
 
   #[@test]
   public function setSources() {
-    $one= new \util\FilesystemPropertySource('.');
-    $two= new \util\FilesystemPropertySource('..');
+    $one= new FilesystemPropertySource('.');
+    $two= new FilesystemPropertySource('..');
 
     $fixture= $this->fixture();
     $fixture->setSources([$one, $two]);
@@ -254,13 +257,13 @@ key="overwritten value"'));
 
   #[@test, @action(new RuntimeVersion('<7.0.0-dev'))]
   public function setIllegalSourceKeepsPreviousStateAndThrowsException() {
-    $one= new \util\FilesystemPropertySource('.');
+    $one= new FilesystemPropertySource('.');
 
     $fixture= $this->fixture();
     try {
       $fixture->setSources([$one, null]);
       $this->fail('No exception thrown', null, 'lang.IllegalArgumentException');
-    } catch (\lang\IllegalArgumentException $expected) {
+    } catch (IllegalArgumentException $expected) {
     }
 
     $this->assertEquals([], $fixture->getSources());
@@ -268,13 +271,13 @@ key="overwritten value"'));
 
   #[@test, @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function setIllegalSourceKeepsPreviousStateAndThrowsException7() {
-    $one= new \util\FilesystemPropertySource('.');
+    $one= new FilesystemPropertySource('.');
 
     $fixture= $this->fixture();
     try {
       $fixture->setSources([$one, null]);
       $this->fail('No exception thrown', null, 'TypeError');
-    } catch (\TypeError  $expected) {
+    } catch (\TypeError $expected) {
     }
 
     $this->assertEquals([], $fixture->getSources());
@@ -282,7 +285,7 @@ key="overwritten value"'));
 
   #[@test]
   public function passEmptySourcesResetsList() {
-    $one= new \util\FilesystemPropertySource('.');
+    $one= new FilesystemPropertySource('.');
 
     $fixture= $this->fixture();
     $fixture->appendSource($one);

--- a/src/test/php/net/xp_framework/unittest/util/TimeSpanTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/TimeSpanTest.class.php
@@ -2,7 +2,8 @@
 
 use unittest\TestCase;
 use util\TimeSpan;
-
+use lang\IllegalArgumentException;
+use lang\IllegalStateException;
 
 /**
  * TestCase
@@ -11,37 +12,21 @@ use util\TimeSpan;
  */
 class TimeSpanTest extends TestCase {
   
-  /**
-   * Create new TimeSpan
-   *
-   */
   #[@test]
   public function newTimeSpan() {
     $this->assertEquals('0d, 2h, 1m, 5s', (new TimeSpan(7265))->toString());
   }
 
-  /**
-   * Create new TimeSpan
-   *
-   */
   #[@test]
   public function newNegativeTimeSpan() {
     $this->assertEquals('0d, 0h, 0m, 1s', (new TimeSpan(-1))->toString());
   }
 
-  /**
-   * Test wrong arguments for constructor
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function wrongArguments() {
     new TimeSpan('2 days');
   }
 
-  /**
-   * Test TimeSpan::add()
-   *
-   */
   #[@test]
   public function add() {
     $this->assertEquals('0d, 2h, 1m, 5s', (new TimeSpan(3600))
@@ -50,10 +35,6 @@ class TimeSpanTest extends TestCase {
     );
   }
     
-  /**
-   * Test TimeSpan::subtract()
-   *
-   */
   #[@test]
   public function subtract() {
     $this->assertEquals('0d, 22h, 58m, 55s', (new TimeSpan(86400))
@@ -62,10 +43,6 @@ class TimeSpanTest extends TestCase {
     );
   }
 
-  /**
-   * Test TimeSpan::subtract()
-   *
-   */
   #[@test]
   public function subtractToZero() {
     $this->assertEquals(
@@ -74,19 +51,11 @@ class TimeSpanTest extends TestCase {
     );
   }
 
-  /**
-   * Test TimeSpan::subtract()
-   *
-   */
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function subtractToNegative() {
     (new TimeSpan(0))->substract(new TimeSpan(1));
   }
 
-  /**
-   * Test TimeSpan::add() and TimeSpan::subtract()
-   *
-   */
   #[@test]
   public function addAndSubstract() {
     $this->assertEquals('1d, 1h, 0m, 55s', (new TimeSpan(86400))
@@ -95,64 +64,36 @@ class TimeSpanTest extends TestCase {
     );
   }
 
-  /**
-   * Test wrong arguments for TimeSpan::add()
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function addWrongArguments() {
     (new TimeSpan(0))->add('2 days');
   }
 
-  /**
-   * Test static creation
-   *
-   */
   #[@test]
   public function fromSeconds() {
     $this->assertEquals('0d, 1h, 0m, 0s', TimeSpan::seconds(3600)->toString());
   }
 
-  /**
-   * Test static creation
-   *
-   */
   #[@test]
   public function fromMinutes() {
     $this->assertEquals('0d, 2h, 7m, 0s', TimeSpan::minutes(127)->toString());
   }
   
-  /**
-   * Test static creation
-   *
-   */
   #[@test]
   public function fromHours() {
     $this->assertEquals('1d, 3h, 0m, 0s', TimeSpan::hours(27)->toString());
   }
 
-  /**
-   * Test static creation
-   *
-   */
   #[@test]
   public function fromDays() {
     $this->assertEquals('40d, 0h, 0m, 0s', TimeSpan::days(40)->toString());
   }
   
-  /**
-   * Test static creation
-   *
-   */
   #[@test]
   public function fromWeeks() {
     $this->assertEquals('7d, 0h, 0m, 0s', TimeSpan::weeks(1)->toString());
   }
 
-  /**
-   * Test whole values
-   *
-   */
   #[@test]
   public function wholeValues() {
     $t= new TimeSpan(91865);
@@ -162,136 +103,76 @@ class TimeSpanTest extends TestCase {
     $this->assertEquals(1, $t->getWholeDays(), 'wholeDays');
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatSeconds() {
     $this->assertEquals('91865', (new TimeSpan(91865))->format('%s'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatWholeSeconds() {
     $this->assertEquals('5', (new TimeSpan(91865))->format('%w'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatMinutes() {
     $this->assertEquals('1531', (new TimeSpan(91865))->format('%m'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatFloatMinutes() {
     $this->assertEquals('1531.08', (new TimeSpan(91865))->format('%M'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatWholeMinutes() {
     $this->assertEquals('31', (new TimeSpan(91865))->format('%j'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatHours() {
     $this->assertEquals('25', (new TimeSpan(91865))->format('%h'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatFloatHours() {
     $this->assertEquals('25.52', (new TimeSpan(91865))->format('%H'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatWholeHours() {
     $this->assertEquals('1', (new TimeSpan(91865))->format('%y'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatDays() {
     $this->assertEquals('1', (new TimeSpan(91865))->format('%d'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatFloatDays() {
     $this->assertEquals('1.06', (new TimeSpan(91865))->format('%D'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatWholeDays() {
     $this->assertEquals('1', (new TimeSpan(91865))->format('%e'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function format() {
     $this->assertEquals('1d1h', (new TimeSpan(91865))->format('%ed%yh'));
   }
 
-  /**
-   * Test format() method
-   *
-   */
   #[@test]
   public function formatPercent() {
     $this->assertEquals('%1d%1h%', (new TimeSpan(91865))->format('%%%ed%%%yh%%'));
   }
 
-  /**
-   * Test timespan compare
-   *
-   */
   #[@test]
   public function compareTwoEqualInstances() {
     $this->assertEquals(new TimeSpan(3600), new TimeSpan(3600));
   }
 
-  /**
-   * Test timespan compare
-   *
-   */
   #[@test]
   public function compareTwoUnequalInstances() {
     $this->assertNotEquals(new TimeSpan(3600), new TimeSpan(0));

--- a/src/test/php/net/xp_framework/unittest/util/TimeZoneTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/TimeZoneTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\util;
 
 use util\TimeZone;
+use lang\IllegalArgumentException;
 
 class TimeZoneTest extends \unittest\TestCase {
   private $fixture;
@@ -87,7 +88,7 @@ class TimeZoneTest extends \unittest\TestCase {
     $this->assertEquals(new \util\Date('2007-10-28 02:00:00 Europe/Berlin'), $transition->getDate());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function unknownTimeZone() {
     new TimeZone('UNKNOWN');
   }

--- a/src/test/php/net/xp_framework/unittest/util/TimerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/TimerTest.class.php
@@ -4,6 +4,8 @@ use unittest\TestCase;
 use util\profiling\Timer;
 use util\Comparator;
 use unittest\actions\RuntimeVersion;
+use lang\Error;
+use lang\IllegalArgumentException;
 
 /**
  * Tests Timer class
@@ -65,12 +67,12 @@ class TimerTest extends TestCase {
     $this->assertTrue($elapsed > 0.0, 'Elapsed time '.$elapsed.' should be greater than zero');
   }
 
-  #[@test, @expect('lang.IllegalArgumentException'), @action(new RuntimeVersion('<7.0.0-dev'))]
+  #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function not_callable_argument_passed_to_measure() {
     Timer::measure('@not-callable@');
   }
 
-  #[@test, @expect('lang.Error'), @action(new RuntimeVersion('>=7.0.0-dev'))]
+  #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function not_callable_argument_passed_to_measure_7() {
     Timer::measure('@not-callable@');
   }

--- a/src/test/php/net/xp_framework/unittest/util/UUIDTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/UUIDTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\util;
 
 use util\UUID;
+use lang\FormatException;
 
 /**
  * TestCase
@@ -72,48 +73,48 @@ class UUIDTest extends \unittest\TestCase {
     $this->assertEquals($this->fixture, new UUID(new \lang\types\Bytes("k\xa7\xb8\x11\x9d\xad\x11\xd1\x80\xb4\x00\xc0O\xd40\xc8")));
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function emptyInput() {
     new UUID('');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function malFormedMissingOctets() {
     new UUID('00000000-0000-0000-c000');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function malFormedNonHexOctets() {
     new UUID('00000000-0000-0000-c000-XXXXXXXXXXXX');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function emptyBracedNotation() {
     new UUID('{}');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function malFormedBracedNotationMissingOctets() {
     new UUID('{00000000-0000-0000-c000}');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function malFormedBracedNotationNonHexOctets() {
     new UUID('{00000000-0000-0000-c000-XXXXXXXXXXXX}');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function emptyUrnNotation() {
     new UUID('urn:uuid:');
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function malFormedUrnNotationMissingOctets() {
     new UUID('urn:uuid:00000000-0000-0000-c000');
   }
 
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function malFormedUrnNotationNonHexOctets() {
     new UUID('urn:uuid:00000000-0000-0000-c000-XXXXXXXXXXXX');
   }

--- a/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
@@ -2,8 +2,11 @@
 
 use util\cmd\Console;
 use lang\Object;
+use lang\IllegalStateException;
 use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
+use io\streams\ConsoleOutputStream;
+use io\streams\ConsoleInputStream;
 
 /**
  * TestCase for the Console class
@@ -131,7 +134,7 @@ class ConsoleTest extends \unittest\TestCase {
         public function toString() { throw new IllegalStateException("Cannot render string"); }
       }'));
       $this->fail('Expected exception not thrown', null, 'lang.IllegalStateException');
-    } catch (\lang\IllegalStateException $expected) {
+    } catch (IllegalStateException $expected) {
       $this->assertEquals('', $this->streams[1]->getBytes());
     }
   }
@@ -225,9 +228,9 @@ class ConsoleTest extends \unittest\TestCase {
   #[@test]
   public function initialize_on_console() {
     $this->initialize(true, function() {
-      $this->assertInstanceOf('io.streams.ConsoleInputStream', Console::$in->getStream());
-      $this->assertInstanceOf('io.streams.ConsoleOutputStream', Console::$out->getStream());
-      $this->assertInstanceOf('io.streams.ConsoleOutputStream', Console::$err->getStream());
+      $this->assertInstanceOf(ConsoleInputStream::class, Console::$in->getStream());
+      $this->assertInstanceOf(ConsoleOutputStream::class, Console::$out->getStream());
+      $this->assertInstanceOf(ConsoleOutputStream::class, Console::$err->getStream());
     });
   }
 

--- a/src/test/php/net/xp_framework/unittest/util/cmd/ParamStringTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/cmd/ParamStringTest.class.php
@@ -2,13 +2,10 @@
  
 use unittest\TestCase;
 use util\cmd\ParamString;
+use lang\IllegalArgumentException;
 
 class ParamStringTest extends TestCase {
   
-  /**
-   * Test short option without value ("flag")
-   *
-   */
   #[@test]
   public function shortFlag() {
     $p= new ParamString(['-k']);
@@ -17,10 +14,6 @@ class ParamStringTest extends TestCase {
     $this->assertNull($p->value('k'));
   }
 
-  /**
-   * Test short option with value
-   *
-   */
   #[@test]
   public function shortValue() {
     $p= new ParamString(['-d', 'sql']);
@@ -29,10 +22,6 @@ class ParamStringTest extends TestCase {
     $this->assertEquals('sql', $p->value('d'));
   }
 
-  /**
-   * Test long option without value ("flag")
-   *
-   */
   #[@test]
   public function longFlag() {
     $p= new ParamString(['--verbose']);
@@ -41,10 +30,6 @@ class ParamStringTest extends TestCase {
     $this->assertNull($p->value('verbose'));
   }
 
-  /**
-   * Test Long option with value
-   *
-   */
   #[@test]
   public function longValue() {
     $p= new ParamString(['--level=3']);
@@ -53,10 +38,6 @@ class ParamStringTest extends TestCase {
     $this->assertEquals('3', $p->value('level'));
   }
 
-  /**
-   * Test Long option with value
-   *
-   */
   #[@test]
   public function longValueShortGivenDefault() {
     $p= new ParamString(['-l', '3']);
@@ -65,10 +46,6 @@ class ParamStringTest extends TestCase {
     $this->assertEquals('3', $p->value('level'));
   }
 
-  /**
-   * Test Long option with value
-   *
-   */
   #[@test]
   public function longValueShortGiven() {
     $p= new ParamString(['-L', '3', '-l', 'FAIL']);
@@ -77,10 +54,6 @@ class ParamStringTest extends TestCase {
     $this->assertEquals('3', $p->value('level', 'L'));
   }
 
-  /**
-   * Test positional query
-   *
-   */
   #[@test]
   public function positional() {
     $p= new ParamString(['That is a realm']);
@@ -89,10 +62,6 @@ class ParamStringTest extends TestCase {
     $this->assertEquals('That is a realm', $p->value(0));
   }
 
-  /**
-   * Test exists() method
-   *
-   */
   #[@test]
   public function existance() {
     $p= new ParamString(['a', 'b']);
@@ -102,19 +71,11 @@ class ParamStringTest extends TestCase {
     $this->assertFalse($p->exists(2));
   }
 
-  /**
-   * Test positional query
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function nonExistantPositional() {
     (new ParamString(['a']))->value(1);
   }
 
-  /**
-   * Test positional query
-   *
-   */
   #[@test]
   public function nonExistantPositionalWithDefault() {
     $this->assertEquals(
@@ -123,19 +84,11 @@ class ParamStringTest extends TestCase {
     );
   }
 
-  /**
-   * Test named query
-   *
-   */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function nonExistantNamed() {
     (new ParamString(['--verbose']))->value('name');
   }
 
-  /**
-   * Test named query
-   *
-   */
   #[@test]
   public function nonExistantNamedWithDefault() {
     $this->assertEquals(
@@ -144,10 +97,6 @@ class ParamStringTest extends TestCase {
     );
   }
   
-  /**
-   * Test long option with whitespace in value
-   *
-   */
   #[@test]
   public function whitespaceInParameter() {
     $p= new ParamString(['--realm=That is a realm']);

--- a/src/test/php/net/xp_framework/unittest/util/collections/ArrayAccessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/ArrayAccessTest.class.php
@@ -3,6 +3,8 @@
 use util\collections\HashTable;
 use util\collections\HashSet;
 use util\collections\Vector;
+use lang\IndexOutOfBoundsException;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
@@ -39,7 +41,7 @@ class ArrayAccessTest extends \unittest\TestCase {
    * Tests array access operator is overloaded for reading
    *
    */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableReadIllegalElement() {
     $c= create('new util.collections.HashTable<string, Object>()');
     $c[STDIN];
@@ -61,7 +63,7 @@ class ArrayAccessTest extends \unittest\TestCase {
    * Tests array access operator is overloaded for writing
    *
    */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableWriteIllegalKey() {
     $c= create('new util.collections.HashTable<string, Object>()');
     $c[STDIN]= new Name('Hello');
@@ -71,7 +73,7 @@ class ArrayAccessTest extends \unittest\TestCase {
    * Tests array access operator is overloaded for writing
    *
    */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableWriteIllegalValue() {
     $c= create('new util.collections.HashTable<string, Object>()');
     $c['hello']= 'scalar';
@@ -118,7 +120,7 @@ class ArrayAccessTest extends \unittest\TestCase {
    * Tests array access operator is overloaded for reading
    *
    */
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function vectorReadNonExistantElement() {
     $v= new Vector();
     $v[0];
@@ -152,7 +154,7 @@ class ArrayAccessTest extends \unittest\TestCase {
    * Tests array access operator is overloaded for writing
    *
    */
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function vectorWriteElementBeyondBoundsKey() {
     $v= new Vector();
     $v[0]= new Name('world');
@@ -162,7 +164,7 @@ class ArrayAccessTest extends \unittest\TestCase {
    * Tests array access operator is overloaded for writing
    *
    */
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function vectorWriteElementNegativeKey() {
     $v= new Vector();
     $v[-1]= new Name('world');
@@ -221,7 +223,7 @@ class ArrayAccessTest extends \unittest\TestCase {
    * Tests hashset array access operator overloading
    *
    */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function hashSetWriteElement() {
     $s= new HashSet();
     $s[0]= new Name('X');
@@ -231,7 +233,7 @@ class ArrayAccessTest extends \unittest\TestCase {
    * Tests hashset array access operator overloading
    *
    */
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function hashSetReadElement() {
     $s= new HashSet();
     $s[]= new Name('X');

--- a/src/test/php/net/xp_framework/unittest/util/collections/ArrayAccessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/ArrayAccessTest.class.php
@@ -15,10 +15,6 @@ use lang\IllegalArgumentException;
  */
 class ArrayAccessTest extends \unittest\TestCase {
 
-  /**
-   * Tests array access operator is overloaded for reading
-   *
-   */
   #[@test]
   public function hashTableReadElement() {
     $c= new HashTable();
@@ -27,30 +23,18 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertEquals($world, $c[new Name('hello')]);
   }
 
-  /**
-   * Tests array access operator is overloaded for reading
-   *
-   */
   #[@test]
   public function hashTableReadNonExistantElement() {
     $c= new HashTable();
     $this->assertEquals(null, $c[new Name('hello')]);
   }
 
-  /**
-   * Tests array access operator is overloaded for reading
-   *
-   */
   #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableReadIllegalElement() {
     $c= create('new util.collections.HashTable<string, Object>()');
     $c[STDIN];
   }
 
-  /**
-   * Tests array access operator is overloaded for writing
-   *
-   */
   #[@test]
   public function hashTableWriteElement() {
     $c= new HashTable();
@@ -59,30 +43,18 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertEquals($world, $c->get(new Name('hello')));
   }
 
-  /**
-   * Tests array access operator is overloaded for writing
-   *
-   */
   #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableWriteIllegalKey() {
     $c= create('new util.collections.HashTable<string, Object>()');
     $c[STDIN]= new Name('Hello');
   }
 
-  /**
-   * Tests array access operator is overloaded for writing
-   *
-   */
   #[@test, @expect(IllegalArgumentException::class)]
   public function hashTableWriteIllegalValue() {
     $c= create('new util.collections.HashTable<string, Object>()');
     $c['hello']= 'scalar';
   }
 
-  /**
-   * Tests array access operator is overloaded for isset()
-   *
-   */
   #[@test]
   public function hashTableTestElement() {
     $c= new HashTable();
@@ -91,10 +63,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertFalse(isset($c[new Name('world')]));
   }
 
-  /**
-   * Tests array access operator is overloaded for unset()
-   *
-   */
   #[@test]
   public function hashTableRemoveElement() {
     $c= new HashTable();
@@ -104,10 +72,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertFalse(isset($c[new Name('hello')]));
   }
 
-  /**
-   * Tests array access operator is overloaded for reading
-   *
-   */
   #[@test]
   public function vectorReadElement() {
     $v= new Vector();
@@ -116,20 +80,12 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertEquals($world, $v[0]);
   }
 
-  /**
-   * Tests array access operator is overloaded for reading
-   *
-   */
   #[@test, @expect(IndexOutOfBoundsException::class)]
   public function vectorReadNonExistantElement() {
     $v= new Vector();
     $v[0];
   }
 
-  /**
-   * Tests array access operator is overloaded for adding
-   *
-   */
   #[@test]
   public function vectorAddElement() {
     $v= new Vector();
@@ -138,10 +94,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertEquals($world, $v[0]);
   }
   
-  /**
-   * Tests array access operator is overloaded for writing
-   *
-   */
   #[@test]
   public function vectorWriteElement() {
     $v= new Vector([new Name('hello')]);
@@ -150,30 +102,18 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertEquals($world, $v[0]);
   }
 
-  /**
-   * Tests array access operator is overloaded for writing
-   *
-   */
   #[@test, @expect(IndexOutOfBoundsException::class)]
   public function vectorWriteElementBeyondBoundsKey() {
     $v= new Vector();
     $v[0]= new Name('world');
   }
 
-  /**
-   * Tests array access operator is overloaded for writing
-   *
-   */
   #[@test, @expect(IndexOutOfBoundsException::class)]
   public function vectorWriteElementNegativeKey() {
     $v= new Vector();
     $v[-1]= new Name('world');
   }
 
-  /**
-   * Tests array access operator is overloaded for isset()
-   *
-   */
   #[@test]
   public function vectorTestElement() {
     $v= new Vector();
@@ -183,10 +123,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertFalse(isset($v[-1]));
   }
 
-  /**
-   * Tests array access operator is overloaded for unset()
-   *
-   */
   #[@test]
   public function vectorRemoveElement() {
     $v= new Vector();
@@ -195,10 +131,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertFalse(isset($v[0]));
   }
 
-  /**
-   * Tests Vector is usable in foreach()
-   *
-   */
   #[@test]
   public function vectorIsUsableInForeach() {
     $values= [new Name('hello'), new Name('world')];
@@ -208,10 +140,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertEquals(sizeof($values)- 1, $i);
   }
 
-  /**
-   * Tests hashset array access operator overloading
-   *
-   */
   #[@test]
   public function hashSetAddElement() {
     $s= new HashSet();
@@ -219,20 +147,12 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertTrue($s->contains(new Name('X')));
   }
 
-  /**
-   * Tests hashset array access operator overloading
-   *
-   */
   #[@test, @expect(IllegalArgumentException::class)]
   public function hashSetWriteElement() {
     $s= new HashSet();
     $s[0]= new Name('X');
   }
 
-  /**
-   * Tests hashset array access operator overloading
-   *
-   */
   #[@test, @expect(IllegalArgumentException::class)]
   public function hashSetReadElement() {
     $s= new HashSet();
@@ -240,10 +160,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $x= $s[0];
   }
 
-  /**
-   * Tests hashset array access operator overloading
-   *
-   */
   #[@test]
   public function hashSetTestElement() {
     $s= new HashSet();
@@ -252,10 +168,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertTrue(isset($s[new Name('X')]));
   }
 
-  /**
-   * Tests hashset array access operator overloading
-   *
-   */
   #[@test]
   public function hashSetRemoveElement() {
     $s= new HashSet();
@@ -264,10 +176,6 @@ class ArrayAccessTest extends \unittest\TestCase {
     $this->assertFalse(isset($s[new Name('X')]));
   }
 
-  /**
-   * Tests hashset array access operator overloading
-   *
-   */
   #[@test]
   public function hashSetUsableInForeach() {
     $s= new HashSet();

--- a/src/test/php/net/xp_framework/unittest/util/collections/GenericsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/GenericsTest.class.php
@@ -8,6 +8,7 @@ use util\collections\Queue;
 use util\collections\LRUBuffer;
 use lang\types\Integer;
 use lang\types\String;
+use lang\IllegalArgumentException;
 
 /**
  * TestCase
@@ -117,7 +118,7 @@ class GenericsTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function nonGenericPassedToCreate() {
     create('new lang.Object<lang.types.String>');
   }
@@ -135,22 +136,22 @@ class GenericsTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringVectorAddIllegalValue() {
     create('new util.collections.Vector<lang.types.String>')->add(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringVectorSetIllegalValue() {
     create('new util.collections.Vector<lang.types.String>', [new \lang\types\String('')])->set(0, new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringVectorContainsIllegalValue() {
     create('new util.collections.Vector<lang.types.String>')->contains(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function createStringVectorWithIllegalValue() {
     create('new util.collections.Vector<lang.types.String>', [new \lang\types\Integer(1)]);
   }
@@ -160,12 +161,12 @@ class GenericsTest extends \unittest\TestCase {
     create('new util.collections.Stack<lang.types.String>')->push(new \lang\types\String('One'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringStackPushIllegalValue() {
     create('new util.collections.Stack<lang.types.String>')->push(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringStackSearchIllegalValue() {
     create('new util.collections.Stack<lang.types.String>')->search(new \lang\types\Integer(1));
   }
@@ -175,17 +176,17 @@ class GenericsTest extends \unittest\TestCase {
     create('new util.collections.Queue<lang.types.String>')->put(new \lang\types\String('One'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringQueuePutIllegalValue() {
     create('new util.collections.Queue<lang.types.String>')->put(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringQueueSearchIllegalValue() {
     create('new util.collections.Queue<lang.types.String>')->search(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringQueueRemoveIllegalValue() {
     create('new util.collections.Queue<lang.types.String>')->remove(new \lang\types\Integer(1));
   }
@@ -195,12 +196,12 @@ class GenericsTest extends \unittest\TestCase {
     create('new util.collections.LRUBuffer<lang.types.String>', 1)->add(new \lang\types\String('One'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringLRUBufferAddIllegalValue() {
     create('new util.collections.LRUBuffer<lang.types.String>', 1)->add(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringLRUBufferUpdateIllegalValue() {
     create('new util.collections.LRUBuffer<lang.types.String>', 1)->update(new \lang\types\Integer(1));
   }
@@ -210,22 +211,22 @@ class GenericsTest extends \unittest\TestCase {
     create('new util.collections.HashSet<lang.types.String>')->add(new \lang\types\String('One'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringHashSetAddIllegalValue() {
     create('new util.collections.HashSet<lang.types.String>')->add(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringHashSetContainsIllegalValue() {
     create('new util.collections.HashSet<lang.types.String>')->contains(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringHashSetRemoveIllegalValue() {
     create('new util.collections.HashSet<lang.types.String>')->remove(new \lang\types\Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function stringHashSetAddAllIllegalValue() {
     create('new util.collections.HashSet<lang.types.String>')->addAll([
       new \lang\types\String('HELLO'),    // Still OK
@@ -259,12 +260,12 @@ class GenericsTest extends \unittest\TestCase {
     }
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function arrayAsKeyArrayComponentTypeMismatch() {
     create('new util.collections.HashTable<string[], lang.types.String>')->put([1], new \lang\types\String('World'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function arrayAsKeyTypeMismatch() {
     create('new util.collections.HashTable<string[], lang.types.String>')->put('hello', new \lang\types\String('World'));
   }

--- a/src/test/php/net/xp_framework/unittest/util/collections/HashTableTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/HashTableTest.class.php
@@ -5,6 +5,7 @@ use util\collections\Pair;
 use lang\types\Integer;
 use lang\types\Double;
 use lang\Object;
+use lang\IllegalArgumentException;
 
 /**
  * Test HashTable class
@@ -112,22 +113,22 @@ class HashTableTest extends \unittest\TestCase {
     $this->assertEquals(1, $fixture->size());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function put_illegal_type_in_key() {
     create('new util.collections.HashTable<string, net.xp_framework.unittest.util.collections.Name>')->put(5, new Name('hello'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function put_illegal_type_in_value() {
     create('new util.collections.HashTable<string, net.xp_framework.unittest.util.collections.Name>')->put('hello', new Integer(1));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function put_raises_when_using_null_for_string_instance() {
     create('new util.collections.HashTable<string, net.xp_framework.unittest.util.collections.Name>')->put('test', null);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function put_raises_when_using_null_for_arrays() {
     create('new util.collections.HashTable<string, var[]>')->put('test', null);
   }
@@ -154,7 +155,7 @@ class HashTableTest extends \unittest\TestCase {
     $this->assertEquals($pairs[0]->value, $fixture[$pairs[0]->key]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function get_illegal_type_in_argument() {
     create('new util.collections.HashTable<net.xp_framework.unittest.util.collections.Name, net.xp_framework.unittest.util.collections.Name>')->get(new Integer(1));
   }
@@ -181,7 +182,7 @@ class HashTableTest extends \unittest\TestCase {
     $this->assertTrue(isset($fixture[$pairs[0]->key]));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function containsKey_illegal_type_in_argument() {
     create('new util.collections.HashTable<net.xp_framework.unittest.util.collections.Name, net.xp_framework.unittest.util.collections.Name>')->containsKey(new Integer(1));
   }
@@ -197,7 +198,7 @@ class HashTableTest extends \unittest\TestCase {
     $this->assertTrue($fixture->containsValue($pairs[0]->value));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function containsValue_illegal_type_in_argument() {
     create('new util.collections.HashTable<net.xp_framework.unittest.util.collections.Name, net.xp_framework.unittest.util.collections.Name>')->containsValue(new Integer(1));
   }
@@ -234,7 +235,7 @@ class HashTableTest extends \unittest\TestCase {
     $this->assertFalse($fixture->containsKey($pairs[0]->key));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function remove_illegal_type_in_argument() {
     create('new util.collections.HashTable<net.xp_framework.unittest.util.collections.Name, net.xp_framework.unittest.util.collections.Name>')->remove(new Integer(1));
   }

--- a/src/test/php/net/xp_framework/unittest/util/collections/LRUBufferTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/LRUBufferTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\util\collections;
 
 use util\collections\LRUBuffer;
+use lang\IllegalArgumentException;
 
 class LRUBufferTest extends \unittest\TestCase {
   const DEFAULT_SIZE = 3;
@@ -96,7 +97,7 @@ class LRUBufferTest extends \unittest\TestCase {
     $this->assertEquals(10, $this->buffer->getSize());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function illegalSize() {
     $this->buffer->setSize(0);
   }

--- a/src/test/php/net/xp_framework/unittest/util/collections/QueueTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/QueueTest.class.php
@@ -1,6 +1,8 @@
 <?php namespace net\xp_framework\unittest\util\collections;
  
 use util\collections\Queue;
+use util\NoSuchElementException;
+use lang\IndexOutOfBoundsException;
 
 class QueueTest extends \unittest\TestCase {
   private $queue;
@@ -40,7 +42,7 @@ class QueueTest extends \unittest\TestCase {
     $this->assertTrue($this->queue->isEmpty());
   }
 
-  #[@test, @expect('util.NoSuchElementException')]
+  #[@test, @expect(NoSuchElementException::class)]
   public function exceptionOnNoMoreElements() {
     $this->queue->get();
   }
@@ -109,18 +111,18 @@ class QueueTest extends \unittest\TestCase {
     }
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function elementAtIllegalOffset() {
     $this->queue->elementAt(-1);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function elementAtOffsetOutOfBounds() {
     $this->queue->put(new Name('one'));
     $this->queue->elementAt($this->queue->size() + 1);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function elementAtEmptyList() {
     $this->queue->elementAt(0);
   }

--- a/src/test/php/net/xp_framework/unittest/util/collections/StackTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/StackTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\util\collections;
  
 use util\collections\Stack;
+use lang\IndexOutOfBoundsException;
 
 class StackTest extends \unittest\TestCase {
   private $stack;
@@ -67,7 +68,7 @@ class StackTest extends \unittest\TestCase {
     $this->assertEquals(new Name('red'), $this->stack->elementAt(2));
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function elementAtIllegalOffset() {
     $this->stack->elementAt(-1);
   }

--- a/src/test/php/net/xp_framework/unittest/util/collections/VectorTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/VectorTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\Object;
 use lang\IllegalArgumentException;
+use lang\IndexOutOfBoundsException;
 use lang\types\ArrayList;
 use util\collections\Vector;
 
@@ -97,7 +98,7 @@ class VectorTest extends \unittest\TestCase {
     $this->assertTrue($v->isEmpty());
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function addingNull() {
     create('new util.collections.Vector<Object>()')->add(null);
   }
@@ -112,17 +113,17 @@ class VectorTest extends \unittest\TestCase {
     $this->assertEquals($o, $r);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function replacingWithNull() {
     create('new util.collections.Vector<Object>', [new Object()])->set(0, null);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function settingPastEnd() {
     (new Vector())->set(0, new Object());
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function settingNegative() {
     (new Vector())->set(-1, new Object());
   }
@@ -136,12 +137,12 @@ class VectorTest extends \unittest\TestCase {
     $this->assertEquals($o, $r);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function readingPastEnd() {
     (new Vector())->get(0);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function readingNegative() {
     (new Vector())->get(-1);
   }
@@ -156,12 +157,12 @@ class VectorTest extends \unittest\TestCase {
     $this->assertEquals($o, $r);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function removingPastEnd() {
     (new Vector())->get(0);
   }
 
-  #[@test, @expect('lang.IndexOutOfBoundsException')]
+  #[@test, @expect(IndexOutOfBoundsException::class)]
   public function removingNegative() {
     (new Vector())->get(-1);
   }


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/298#issuecomment-133754840, this converts all dotted classes inside `@expect` annotations, newinstance(), defineClass(), defineInterface() and assertInstanceOf() to the native notation:

```php
#[@test, @expect(IllegalArgumentException::class)]
public function negative_test() {
  // ...
}

#[@test]
public function creating_instance() {
  newinstance(Object::class, [], [ ... ]);
}

#[@test]
public function creating_type() {
  ClassLoader::defineClass('_Fixture1', Fixture::class, [], [ ... ]);
}

#[@test]
public function testing_instance() {
  $this->assertInstanceOf(Object::class, ...);
}
```