### PR TITLE
Go baseless

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ use util\Date;
 use util\DateUtil;
 use util\cmd\Console;
 
-class AgeInDays extends \lang\Object {
+class AgeInDays {
 
   public static function main(array $args) {
     $span= DateUtil::timespanBetween(new Date($args[0]), Date::now());

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -522,9 +522,9 @@ function newinstance($spec, $args, $def= null) {
 
   $name= strtr($type, '\\', '.').$n;
   if (interface_exists($type)) {
-    $decl= ['kind' => 'class', 'extends' => null, 'implements' => ['\\'.$type], 'use' => []];
+    $decl= ['kind' => 'class', 'extends' => ['lang.Object'], 'implements' => ['\\'.$type], 'use' => []];
   } else if (trait_exists($type)) {
-    $decl= ['kind' => 'class', 'extends' => null, 'implements' => [], 'use' => ['\\'.$type]];
+    $decl= ['kind' => 'class', 'extends' => ['lang.Object'], 'implements' => [], 'use' => ['\\'.$type]];
   } else {
     $decl= ['kind' => 'class', 'extends' => ['\\'.$type], 'implements' => [], 'use' => []];
   }

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -522,9 +522,9 @@ function newinstance($spec, $args, $def= null) {
 
   $name= strtr($type, '\\', '.').$n;
   if (interface_exists($type)) {
-    $decl= ['kind' => 'class', 'extends' => ['lang.Object'], 'implements' => ['\\'.$type], 'use' => []];
+    $decl= ['kind' => 'class', 'extends' => null, 'implements' => ['\\'.$type], 'use' => []];
   } else if (trait_exists($type)) {
-    $decl= ['kind' => 'class', 'extends' => ['lang.Object'], 'implements' => [], 'use' => ['\\'.$type]];
+    $decl= ['kind' => 'class', 'extends' => null, 'implements' => [], 'use' => ['\\'.$type]];
   } else {
     $decl= ['kind' => 'class', 'extends' => ['\\'.$type], 'implements' => [], 'use' => []];
   }

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -598,9 +598,7 @@ function nameof($arg) {
 // {{{ proto lang.Type typeof(mixed arg)
 //     Returns type
 function typeof($arg) {
-  if ($arg instanceof \lang\Generic) {
-    return new \lang\XPClass($arg);
-  } else if (null === $arg) {
+  if (null === $arg) {
     return \lang\Type::$VOID;
   } else if ($arg instanceof \Closure) {
     $r= new \ReflectionFunction($arg);
@@ -617,6 +615,8 @@ function typeof($arg) {
       }
     }
     return new \lang\FunctionType($signature, \lang\Type::$VAR);
+  } else if (is_object($arg)) {
+    return new \lang\XPClass($arg);
   } else if (is_array($arg)) {
     return 0 === key($arg) ? \lang\ArrayType::forName('var[]') : \lang\MapType::forName('[:var]');
   } else {

--- a/src/main/php/lang/Object.class.php
+++ b/src/main/php/lang/Object.class.php
@@ -29,11 +29,11 @@ class Object implements Generic { use \__xp;
   /**
    * Indicates whether some other object is "equal to" this one.
    *
-   * @param   lang.Generic cmp
+   * @param   var $cmp
    * @return  bool TRUE if the compared object is equal to this object
    */
   public function equals($cmp) {
-    if (!$cmp instanceof Generic) return false;
+    if (!$cmp instanceof self) return false;
     if (!$this->__id) $this->__id= uniqid('', true);
     if (!$cmp->__id) $cmp->__id= uniqid('', true);
     return $this === $cmp;

--- a/src/main/php/lang/Throwable.class.php
+++ b/src/main/php/lang/Throwable.class.php
@@ -226,11 +226,11 @@ class Throwable extends \Exception implements Generic { use \__xp;
   /**
    * Indicates whether some other object is "equal to" this one.
    *
-   * @param   lang.Generic cmp
+   * @param   var $cmp
    * @return  bool TRUE if the compared object is equal to this object
    */
   public function equals($cmp) {
-    if (!$cmp instanceof Generic) return false;
+    if (!$cmp instanceof self) return false;
     if (!$cmp->__id) $cmp->__id= uniqid('', true);
     return $this === $cmp;
   }

--- a/src/main/php/lang/WildcardType.class.php
+++ b/src/main/php/lang/WildcardType.class.php
@@ -105,7 +105,7 @@ class WildcardType extends Type {
    * @return  bool
    */
   public function isInstance($obj) {
-    return $obj instanceof Generic && $this->assignableFromClass($obj->getClass());
+    return is_object($obj) && $this->assignableFromClass(typeof($obj));
   }
 
   /**

--- a/src/main/php/util/AbstractDeferredInvokationHandler.class.php
+++ b/src/main/php/util/AbstractDeferredInvokationHandler.class.php
@@ -1,6 +1,8 @@
 <?php namespace util;
 
 use lang\reflect\InvocationHandler;
+use lang\Throwable;
+use lang\ClassCastException;
 
 /**
  * Lazy initializable InvokationHandler 
@@ -21,26 +23,24 @@ abstract class AbstractDeferredInvokationHandler extends \lang\Object implements
    * Processes a method invocation on a proxy instance and returns
    * the result.
    *
-   * @param   lang.reflect.Proxy proxy
-   * @param   string method the method name
-   * @param   var* args an array of arguments
-   * @return  var
-   * @throws  util.DeferredInitializationException
+   * @param  lang.reflect.Proxy $proxy
+   * @param  string $method the method name
+   * @param  var... $args an array of arguments
+   * @return var
+   * @throws util.DeferredInitializationException
    */
   public function invoke($proxy, $method, $args) {
     if (null === $this->_instance) {
       try {
         $this->_instance= $this->initialize();
-      } catch (\lang\Throwable $e) {
+      } catch (Throwable $e) {
         $this->_instance= null;
         throw new DeferredInitializationException($method, $e);
       }
-      if (!$this->_instance instanceof \lang\Generic) {
+      if (!is_object($this->_instance)) {
         throw new DeferredInitializationException(
           $method,
-          \lang\XPClass::forName('lang.ClassCastException')->newInstance(
-            'Initializer returned '.\xp::typeOf($this->_instance)
-          )
+          new ClassCastException('Initializer returned '.\xp::typeOf($this->_instance))
         );
       }
     }

--- a/src/main/php/util/Objects.class.php
+++ b/src/main/php/util/Objects.class.php
@@ -38,7 +38,7 @@ abstract class Objects extends \lang\Object {
    *
    * @param   var $a
    * @param   var $b
-   * @return  bool
+   * @return  int
    */
   public static function compare($a, $b) {
     if ($a instanceof Value) {

--- a/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
@@ -98,12 +98,6 @@ class NewInstanceTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function new_interface_does_not_use_any_base_class() {
-    $o= newinstance(Runnable::class, [], '{ public function run() { } }');
-    $this->assertFalse(get_parent_class($o));
-  }
-
-  #[@test]
   public function new_interface_with_body_as_string() {
     $o= newinstance(Runnable::class, [], '{ public function run() { } }');
     $this->assertInstanceOf(Runnable::class, $o);

--- a/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NewInstanceTest.class.php
@@ -98,6 +98,12 @@ class NewInstanceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function new_interface_does_not_use_any_base_class() {
+    $o= newinstance(Runnable::class, [], '{ public function run() { } }');
+    $this->assertFalse(get_parent_class($o));
+  }
+
+  #[@test]
   public function new_interface_with_body_as_string() {
     $o= newinstance(Runnable::class, [], '{ public function run() { } }');
     $this->assertInstanceOf(Runnable::class, $o);
@@ -116,7 +122,7 @@ class NewInstanceTest extends \unittest\TestCase {
     $o= newinstance('#[@test] lang.Runnable', [], [
       'run' => function() { }
     ]);
-    $this->assertTrue($o->getClass()->hasAnnotation('test'));
+    $this->assertTrue(typeof($o)->hasAnnotation('test'));
   }
 
   #[@test]
@@ -140,7 +146,7 @@ class NewInstanceTest extends \unittest\TestCase {
     $o= newinstance('#[@test] net.xp_framework.unittest.core.Named', [], [
       'run' => function() { }
     ]);
-    $this->assertTrue($o->getClass()->hasAnnotation('test'));
+    $this->assertTrue(typeof($o)->hasAnnotation('test'));
   }
 
   #[@test]
@@ -260,7 +266,7 @@ class NewInstanceTest extends \unittest\TestCase {
     $i= newinstance(Object::class, [], '{}');
     $this->assertEquals(
       Package::forName('lang'),
-      $i->getClass()->getPackage()
+      typeof($i)->getPackage()
     );
   }
 
@@ -269,7 +275,7 @@ class NewInstanceTest extends \unittest\TestCase {
     $i= newinstance($class, [], '{ public function getIterator() { /* Empty */ }}');
     $this->assertEquals(
       Package::forName(''),
-      $i->getClass()->getPackage()
+      typeof($i)->getPackage()
     );
   }
 
@@ -278,7 +284,7 @@ class NewInstanceTest extends \unittest\TestCase {
     $i= newinstance($class, [], '{}');
     $this->assertEquals(
       Package::forName('net.xp_framework.unittest.core'),
-      $i->getClass()->getPackage()
+      typeof($i)->getPackage()
     );
   }
 
@@ -287,7 +293,7 @@ class NewInstanceTest extends \unittest\TestCase {
     $i= newinstance(NamespacedInterface::class, [], '{}');
     $this->assertEquals(
       Package::forName('net.xp_framework.unittest.core'),
-      $i->getClass()->getPackage()
+      typeof($i)->getPackage()
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/TypeOfTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeOfTest.class.php
@@ -2,13 +2,13 @@
 
 use lang\Primitive;
 use lang\Type;
+use lang\XPClass;
 use lang\ArrayType;
 use lang\MapType;
 use lang\FunctionType;
 
 /**
  * Tests typeof() functionality
- *
  */
 class TypeOfTest extends \unittest\TestCase {
 
@@ -19,7 +19,12 @@ class TypeOfTest extends \unittest\TestCase {
 
   #[@test]
   public function this() {
-    $this->assertEquals($this->getClass(), typeof($this));
+    $this->assertEquals(new XPClass(self::class), typeof($this));
+  }
+
+  #[@test]
+  public function native() {
+    $this->assertEquals(new XPClass(\ArrayObject::class), typeof(new \ArrayObject([])));
   }
 
   #[@test]


### PR DESCRIPTION
This pull request adopts changes to make the framework work without `lang.Object`, and is a prerequisite for removing it as suggested in xp-framework/rfc#297

* [x] Adjusts `typeof()` core functionality
* [x] Adjusts `WildcardType::isInstance()`
* [x] ~~Change newinstance() to no longer use `lang.Object` as base class~~ (*phase 2, not until 7.0*)