### PR TITLE
Use Objects::hashOf() in collections

### DIFF
--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -82,7 +82,11 @@ class FunctionType extends Type {
    * @return  string
    */
   public function literal() {
-    throw new IllegalStateException('Function types cannot be used in type literals');
+    return sprintf(
+      "\xaa%s\xbb%s",
+      null === $this->signature ? "\xbf" : implode("\xb8", array_map(function($e) { return $e->literal(); }, $this->signature)),
+      $this->returns->literal()
+    );
   }
 
   /**

--- a/src/main/php/util/collections/HashSet.class.php
+++ b/src/main/php/util/collections/HashSet.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\collections;
 
-use lang\Generic;
-use lang\Value;
+use util\Objects;
+use lang\IllegalArgumentException;
 
 /**
  * A set of objects
@@ -12,8 +12,7 @@ use lang\Value;
  */
 #[@generic(self= 'T', implements= ['T'])]
 class HashSet extends \lang\Object implements Set {
-  protected static
-    $iterate   = null;
+  protected static $iterate;
 
   protected
     $_elements = [],
@@ -48,7 +47,7 @@ class HashSet extends \lang\Object implements Set {
    * @return  lang.Generic
    */
   public function offsetGet($offset) {
-    throw new \lang\IllegalArgumentException('Unsupported operation');
+    throw new IllegalArgumentException('Unsupported operation');
   }
 
   /**
@@ -63,7 +62,7 @@ class HashSet extends \lang\Object implements Set {
      if (null === $offset) {
       $this->add($value);
     } else {
-      throw new \lang\IllegalArgumentException('Unsupported operation');
+      throw new IllegalArgumentException('Unsupported operation');
     }
   }
 
@@ -96,7 +95,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function add($element) { 
-    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
+    $h= Objects::hashOf($element);
     if (isset($this->_elements[$h])) return false;
     
     $this->_hash+= HashProvider::hashOf($h);
@@ -112,7 +111,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function remove($element) { 
-    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
+    $h= Objects::hashOf($element);
     if (!isset($this->_elements[$h])) return false;
 
     $this->_hash-= HashProvider::hashOf($h);
@@ -128,7 +127,7 @@ class HashSet extends \lang\Object implements Set {
    */
   #[@generic(params= 'T')]
   public function contains($element) { 
-    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
+    $h= Objects::hashOf($element);
     return isset($this->_elements[$h]);
   }
 
@@ -144,6 +143,7 @@ class HashSet extends \lang\Object implements Set {
   /**
    * Removes all of the elements from this set
    *
+   * @return void
    */
   public function clear() { 
     $this->_elements= [];
@@ -169,7 +169,7 @@ class HashSet extends \lang\Object implements Set {
   public function addAll($elements) { 
     $changed= false;
     foreach ($elements as $element) {
-      $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
+      $h= Objects::hashOf($element);
       if (isset($this->_elements[$h])) continue;
 
       $this->_hash+= HashProvider::hashOf($h);

--- a/src/main/php/util/collections/HashTable.class.php
+++ b/src/main/php/util/collections/HashTable.class.php
@@ -1,8 +1,8 @@
 <?php namespace util\collections;
 
-use lang\Primitive;
-use lang\Generic;
+use util\Objects;
 use lang\Value;
+use lang\Generic;
 
 /**
  * Hash table consisting of non-null objects as keys and values
@@ -101,7 +101,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K, V', return= 'V')]
   public function put($key, $value) {
-    $h= ($key instanceof Generic || $key instanceof Value) ? $key->hashCode() : serialize($key);
+    $h= Objects::hashOf($key);
     if (!isset($this->_buckets[$h])) {
       $previous= null;
     } else {
@@ -109,7 +109,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
     }
 
     $this->_buckets[$h]= [$key, $value];
-    $this->_hash+= HashProvider::hashOf($h.(($value instanceof Generic || $value instanceof Value) ? $value->hashCode() : serialize($value)));
+    $this->_hash+= HashProvider::hashOf($h.Objects::hashOf($value));
     return $previous;
   }
 
@@ -122,7 +122,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K', return= 'V')]
   public function get($key) {
-    $h= ($key instanceof Generic || $key instanceof Value) ? $key->hashCode() : serialize($key);
+    $h= Objects::hashOf($key);
     return isset($this->_buckets[$h]) ? $this->_buckets[$h][1] : null; 
   }
   
@@ -136,12 +136,12 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K', return= 'V')]
   public function remove($key) {
-    $h= ($key instanceof Generic || $key instanceof Value) ? $key->hashCode() : serialize($key);
+    $h= Objects::hashOf($key);
     if (!isset($this->_buckets[$h])) {
       $prev= null;
     } else {
       $prev= $this->_buckets[$h][1];
-      $this->_hash-= HashProvider::hashOf($h.(($prev instanceof Generic || $prev instanceof Value) ? $prev->hashCode() : serialize($prev)));
+      $this->_hash-= HashProvider::hashOf($h.Objects::hashOf($prev));
       unset($this->_buckets[$h]);
     }
 
@@ -151,6 +151,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
   /**
    * Removes all mappings from this map.
    *
+   * @return void
    */
   public function clear() {
     $this->_buckets= [];
@@ -183,7 +184,7 @@ class HashTable extends \lang\Object implements Map, \IteratorAggregate {
    */
   #[@generic(params= 'K')]
   public function containsKey($key) {
-    $h= ($key instanceof Generic || $key instanceof Value) ? $key->hashCode() : serialize($key);
+    $h= Objects::hashOf($key);
     return isset($this->_buckets[$h]);
   }
 

--- a/src/main/php/util/collections/LRUBuffer.class.php
+++ b/src/main/php/util/collections/LRUBuffer.class.php
@@ -1,5 +1,8 @@
 <?php namespace util\collections;
 
+use util\Objects;
+use lang\IllegalArgumentException;
+
 /**
  * LRU (last recently used) buffer.
  *
@@ -44,7 +47,7 @@ class LRUBuffer extends \lang\Object {
    */
   #[@generic(params= 'T', return= 'T')]
   public function add($element) {
-    $h= $this->prefix.(($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element));
+    $h= $this->prefix.Objects::hashOf($element);
     $this->_elements[$h]= $element;
 
     // Check if this buffer's size has been exceeded
@@ -65,7 +68,7 @@ class LRUBuffer extends \lang\Object {
    */
   #[@generic(params= 'T')]
   public function update($element) {
-    $h= $this->prefix.(($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element));
+    $h= $this->prefix.Objects::hashOf($element);
     unset($this->_elements[$h]);
     $this->_elements= $this->_elements + [$h => $element];
   }
@@ -86,7 +89,7 @@ class LRUBuffer extends \lang\Object {
    * @throws  lang.IllegalArgumentException is size is not greater than zero
    */
   public function setSize($size) {
-    if ($size <= 0) throw new \lang\IllegalArgumentException(
+    if ($size <= 0) throw new IllegalArgumentException(
       'Size must be greater than zero, '.$size.' given'
     );
 

--- a/src/main/php/util/collections/Queue.class.php
+++ b/src/main/php/util/collections/Queue.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\collections;
 
+use util\Objects;
 use lang\IndexOutOfBoundsException;
 use util\NoSuchElementException;
 use lang\Generic;
@@ -45,7 +46,7 @@ class Queue extends \lang\Object {
    */
   #[@generic(params= 'T', return= 'T')]
   public function put($element) {
-    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
+    $h= Objects::hashOf($element);
     $this->_elements[]= $element;
     $this->_hash+= HashProvider::hashOf($h);
     return $element;
@@ -64,7 +65,7 @@ class Queue extends \lang\Object {
     }
 
     $element= $this->_elements[0];
-    $h= ($element instanceof Generic || $element instanceof Value)? $element->hashCode() : serialize($element);
+    $h= Objects::hashOf($element);
     $this->_hash-= HashProvider::hashOf($h);
     $this->_elements= array_slice($this->_elements, 1);
     return $element;
@@ -124,9 +125,9 @@ class Queue extends \lang\Object {
   #[@generic(params= 'T')]
   public function remove($element) {
     if (-1 == ($pos= $this->search($element))) return false;
-    
+
     $element= $this->_elements[$pos];
-    $h= ($element instanceof Generic || $element instanceof Value)? $element->hashCode() : serialize($element);
+    $h= Objects::hashOf($element);
     $this->_hash-= HashProvider::hashOf($h);
     unset($this->_elements[$pos]);
     $this->_elements= array_values($this->_elements);   // Re-index

--- a/src/main/php/util/collections/Stack.class.php
+++ b/src/main/php/util/collections/Stack.class.php
@@ -4,6 +4,7 @@ use lang\IndexOutOfBoundsException;
 use util\NoSuchElementException;
 use lang\Generic;
 use lang\Value;
+use util\Objects;
 
 /**
  * A Last-In-First-Out (LIFO) stack of objects.
@@ -47,7 +48,7 @@ class Stack extends \lang\Object {
    */
   #[@generic(params= 'T', return= 'T')]
   public function push($element) {
-    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
+    $h= Objects::hashOf($element);
     array_unshift($this->_elements, $element);
     $this->_hash+= HashProvider::hashOf($h);
     return $element;
@@ -65,7 +66,7 @@ class Stack extends \lang\Object {
       throw new NoSuchElementException('Stack is empty');
     }
     $element= array_shift($this->_elements);
-    $h= ($element instanceof Generic || $element instanceof Value) ? $element->hashCode() : serialize($element);
+    $h= Objects::hashOf($element);
     $this->_hash+= HashProvider::hashOf($h);
     return $element;
   }

--- a/src/main/php/util/collections/Vector.class.php
+++ b/src/main/php/util/collections/Vector.class.php
@@ -1,6 +1,7 @@
 <?php namespace util\collections;
 
 use lang\Generic;
+use lang\Value;
 use lang\IllegalArgumentException;
 use lang\IndexOutOfBoundsException;
 

--- a/src/test/php/net/xp_framework/unittest/util/collections/HashSetTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/HashSetTest.class.php
@@ -155,4 +155,11 @@ class HashSetTest extends \unittest\TestCase {
       $this->set->toString()
     );
   }
+
+  #[@test]
+  public function addFunction() {
+    $f= function() { return 'test'; };
+    $this->set->add($f);
+    $this->assertEquals([$f], $this->set->toArray());
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/util/collections/HashTableTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/HashTableTest.class.php
@@ -36,7 +36,11 @@ class HashTableTest extends \unittest\TestCase {
       [create('new util.collections.HashTable<int[], var>'), [
         new Pair([1, 2], 3),
         new Pair([0, -1], 'Test')
-      ]]
+      ]],
+      [create('new util.collections.HashTable<string, function(): var>'), [
+        new Pair('color', function() { return 'purple'; }),
+        new Pair('price', function() { return 12.99; }),
+      ]],
     ];
   }
 

--- a/src/test/php/net/xp_framework/unittest/util/collections/LRUBufferTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/LRUBufferTest.class.php
@@ -121,4 +121,11 @@ class LRUBufferTest extends \unittest\TestCase {
     }
     $this->assertFalse($this->buffer->equals($other));
   }
+
+  #[@test]
+  public function addFunction() {
+    $f= function() { return 'test'; };
+    $this->buffer->add($f);
+    $this->assertEquals(1, $this->buffer->numElements());
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/util/collections/QueueTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/QueueTest.class.php
@@ -126,4 +126,11 @@ class QueueTest extends \unittest\TestCase {
   public function elementAtEmptyList() {
     $this->queue->elementAt(0);
   }
+
+  #[@test]
+  public function addFunction() {
+    $f= function() { return 'test'; };
+    $this->queue->put($f);
+    $this->assertEquals($f, $this->queue->elementAt(0));
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/util/collections/StackTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/StackTest.class.php
@@ -72,4 +72,11 @@ class StackTest extends \unittest\TestCase {
   public function elementAtIllegalOffset() {
     $this->stack->elementAt(-1);
   }
+
+  #[@test]
+  public function addFunction() {
+    $f= function() { return 'test'; };
+    $this->stack->push($f);
+    $this->assertEquals($f, $this->stack->elementAt(0));
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/util/collections/VectorTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/collections/VectorTest.class.php
@@ -298,4 +298,16 @@ class VectorTest extends \unittest\TestCase {
     $b= [new Name('b'), new Name('a')];
     $this->assertFalse((new Vector($a))->equals(new Vector($b)));
   }
+
+  #[@test]
+  public function addFunction() {
+    $f= function() { return 'test'; };
+    $this->assertEquals($f, (new Vector([$f]))[0]);
+  }
+
+  #[@test]
+  public function addFunctions() {
+    $f= [function() { return 'one'; }, function() { return 'two'; }];
+    $this->assertEquals($f, (new Vector($f))->elements());
+  }
 }


### PR DESCRIPTION
This pull request refactors the following:

```php
// Before
$h=  ($val instanceof Generic || $val instanceof Value) ? $val->hashCode() : serialize($val);

// After
$h= Objects::hashOf($val);
```

This has the benefit of not repeating ourselves and allows closures inside util.collections; they would previously raise a `cannot serialize instances of Closure` error!