### PR TITLE
Add in() and out() methods to replace get(Input|Output)Stream()

### DIFF
--- a/src/main/php/io/collections/ArchiveElement.class.php
+++ b/src/main/php/io/collections/ArchiveElement.class.php
@@ -119,10 +119,32 @@ class ArchiveElement extends \lang\Object implements IOElement {
   /**
    * Gets input stream to read from this element
    *
+   * @deprecated Use in() instead
    * @return  io.streams.InputStream
    * @throws  io.IOException
    */
   public function getInputStream() {
+    return $this->in();
+  }
+
+  /**
+   * Gets output stream to read from this element
+   *
+   * @deprecated Use out() instead
+   * @return  io.streams.OutputStream
+   * @throws  io.IOException
+   */
+  public function getOutputStream() {
+    return $this->out();
+  }
+
+  /**
+   * Gets input stream to read from this element
+   *
+   * @return  io.streams.InputStream
+   * @throws  io.IOException
+   */
+  public function in() {
     return new MemoryInputStream($this->archive->extract($this->name));
   }
 
@@ -132,7 +154,7 @@ class ArchiveElement extends \lang\Object implements IOElement {
    * @return  io.streams.OutputStream
    * @throws  io.IOException
    */
-  public function getOutputStream() {
+  public function out() {
     throw new \io\IOException('Cannot write to an archive');
   }
 } 

--- a/src/main/php/io/collections/FileElement.class.php
+++ b/src/main/php/io/collections/FileElement.class.php
@@ -110,10 +110,32 @@ class FileElement extends \lang\Object implements IOElement {
   /**
    * Gets input stream to read from this element
    *
+   * @deprecated Use in() instead
    * @return  io.streams.InputStream
    * @throws  io.IOException
    */
   public function getInputStream() {
+    return $this->in();
+  }
+
+  /**
+   * Gets output stream to read from this element
+   *
+   * @deprecated Use out() instead
+   * @return  io.streams.OutputStream
+   * @throws  io.IOException
+   */
+  public function getOutputStream() {
+    return $this->out();
+  }
+
+  /**
+   * Gets input stream to read from this element
+   *
+   * @return  io.streams.InputStream
+   * @throws  io.IOException
+   */
+  public function in() {
     return new FileInputStream($this->uri);
   }
 
@@ -123,7 +145,7 @@ class FileElement extends \lang\Object implements IOElement {
    * @return  io.streams.OutputStream
    * @throws  io.IOException
    */
-  public function getOutputStream() {
+  public function out() {
     return new FileOutputStream($this->uri);
   }
 } 

--- a/src/test/php/net/xp_framework/unittest/io/collections/MockElement.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/collections/MockElement.class.php
@@ -120,10 +120,32 @@ class MockElement extends \lang\Object implements IOElement {
   /**
    * Gets input stream to read from this element
    *
+   * @deprecated Use in() instead
    * @return  io.streams.InputStream
    * @throws  io.IOException
    */
   public function getInputStream() {
+    return $this->in();
+  }
+
+  /**
+   * Gets output stream to read from this element
+   *
+   * @deprecated Use out() instead
+   * @return  io.streams.OutputStream
+   * @throws  io.IOException
+   */
+  public function getOutputStream() {
+    return $this->out();
+  }
+
+  /**
+   * Gets input stream to read from this element
+   *
+   * @return  io.streams.InputStream
+   * @throws  io.IOException
+   */
+  public function in() {
     return new MemoryInputStream('File contents of {'.$this->uri.'}');
   }
 
@@ -133,7 +155,7 @@ class MockElement extends \lang\Object implements IOElement {
    * @return  io.streams.OutputStream
    * @throws  io.IOException
    */
-  public function getOutputStream() {
+  public function out() {
     return new MemoryOutputStream();
   }
   


### PR DESCRIPTION
Consistent with io.File API