### PR TITLE
Show traits w/ trait keyword, w/o abstract modifiers

### DIFF
--- a/src/main/php/xp/runtime/Reflect.class.php
+++ b/src/main/php/xp/runtime/Reflect.class.php
@@ -163,6 +163,37 @@ class Reflect extends \lang\Object {
   }
 
   /**
+   * Handles traits
+   *
+   * @param   lang.XPClass trait
+   */
+  protected static function printTrait(XPClass $trait) {
+    Console::write(implode(' ', Modifiers::namesOf($trait->getModifiers() ^ MODIFIER_ABSTRACT)));
+    Console::write(' trait ', self::displayNameOf($trait));
+
+    // Fields
+    $i && Console::writeLine();
+    $i= 0;
+    foreach ($trait->getFields() as $field) {
+      Console::writeLine('  ', $field);
+      $i++;
+    }
+
+    // Constructor
+    $i && Console::writeLine();
+    $i= 0;
+    if ($trait->hasConstructor()) {
+      Console::writeLine('  ', $trait->getConstructor());
+      $i++;
+    }
+
+    // Methods
+    $i && Console::writeLine();
+    self::printMethods($trait->getMethods());
+    Console::writeLine('}');
+  }
+
+  /**
    * Handles classes
    *
    * @param   lang.XPClass class
@@ -229,6 +260,7 @@ class Reflect extends \lang\Object {
     // Classes
     $order= [
       'interface' => [],
+      'trait'     => [],
       'enum'      => [],
       'class'     => []
     ];
@@ -236,6 +268,9 @@ class Reflect extends \lang\Object {
       $mod= $class->getModifiers();
       if ($class->isInterface()) {
         $type= 'interface';
+        $mod= $mod ^ MODIFIER_ABSTRACT;
+      } else if ($class->isTrait()) {
+        $type= 'trait';
         $mod= $mod ^ MODIFIER_ABSTRACT;
       } else if ($class->isEnum()) {
         $type= 'enum';
@@ -327,6 +362,8 @@ class Reflect extends \lang\Object {
     Console::writeLine('@', $class->getClassLoader());
     if ($class->isInterface()) {
       self::printInterface($class);
+    } else if ($class->isTrait()) {
+      self::printTrait($class);
     } else if ($class->isEnum()) {
       self::printEnum($class);
     } else {

--- a/src/test/php/net/xp_framework/unittest/tests/ListenerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/tests/ListenerTest.class.php
@@ -19,7 +19,7 @@ class ListenerTest extends TestCase implements \unittest\TestListener {
    * Setup method. Creates a new test suite.
    */
   public function setUp() {
-    $this->invocations= create('new util.collections.HashTable<string, lang.types.ArrayList>()');
+    $this->invocations= [];
     $this->suite= new TestSuite();
     $this->suite->addListener($this);
   }


### PR DESCRIPTION
## Before
Shown as abstract classes
```sh
$ xp -r lang.partial
@FileSystemCL<...\xp\partial\src\main\php\>
@FileSystemCL<...\xp\partial\src\test\php\>
package lang.partial {
  package lang.partial.unittest

  public abstract class lang.partial.Identity
  public abstract class lang.partial.InstanceCreation
  public abstract class lang.partial.ListIndexedBy
  public abstract class lang.partial.ListOf
  public abstract class lang.partial.Transformation
  public class lang.partial.Comparators
  public class lang.partial.Comparison
  public class lang.partial.Constructor
  public class lang.partial.Sortable
  public class lang.partial.ValueObject
  public class lang.partial.WithCreation
}
```

## After
Distinguishable by "trait" keyword, ordered after interfaces (if any)
```sh
$ xp -r lang.partial
@FileSystemCL<...\xp\partial\src\main\php\>
@FileSystemCL<...\xp\partial\src\test\php\>
package lang.partial {
  package lang.partial.unittest

  public trait lang.partial.Identity
  public trait lang.partial.ListIndexedBy
  public trait lang.partial.ListOf

  public abstract class lang.partial.InstanceCreation
  public abstract class lang.partial.Transformation
  public class lang.partial.Comparators
  public class lang.partial.Comparison
  public class lang.partial.Constructor
  public class lang.partial.Sortable
  public class lang.partial.ValueObject
  public class lang.partial.WithCreation
}
```