### PR TITLE
Variadic parameter support in reflection

### DIFF
--- a/src/main/php/lang/ClassLoader.class.php
+++ b/src/main/php/lang/ClassLoader.class.php
@@ -38,14 +38,12 @@ use lang\reflect\Module;
  * @see   xp://lang.reflect.Package#loadClass
  */
 final class ClassLoader extends Object implements IClassLoader {
-  private static $VARIADIC;
   protected static
     $delegates = [],
     $modules   = [];
 
   static function __static() {
     $modules= [];
-    self::$VARIADIC= method_exists('ReflectionParameter', 'isVariadic');
     
     // Scan include-path, setting up classloaders for each element
     foreach (\xp::$classpath as $element) {
@@ -227,7 +225,7 @@ final class ClassLoader extends Object implements IClassLoader {
         $sig.= ', callable $'.$p;
       } else if (null !== ($restriction= $param->getClass())) {
         $sig.= ', \\'.$restriction->getName().' $'.$p;
-      } else if (self::$VARIADIC && $param->isVariadic()) {
+      } else if (XPClass::$VARIADIC_SUPPORTED && $param->isVariadic()) {
         $sig.= ', ...$'.$p;
         $pass.= ', ...$'.$p;
         continue;

--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -9,11 +9,8 @@
 class FunctionType extends Type {
   protected $signature;
   protected $returns;
-  private static $VARIADIC_SUPPORTED;
 
-  static function __static() {
-    self::$VARIADIC_SUPPORTED= method_exists('ReflectionParameter', 'isVariadic');
-  }
+  static function __static() { }
 
   /**
    * Creates a new array type instance
@@ -128,7 +125,7 @@ class FunctionType extends Type {
         return $false('No parameter #'.($i + 1));
       } else {
         $param= $params[$i];
-        if (self::$VARIADIC_SUPPORTED && $param->isVariadic()) {
+        if (XPClass::$VARIADIC_SUPPORTED && $param->isVariadic()) {
           return true;  // No further checks necessary
         } else if ($param->isArray()) {
           if (!$type->equals(Primitive::$ARRAY) && !$type instanceof ArrayType && !$type instanceof MapType) {
@@ -149,7 +146,7 @@ class FunctionType extends Type {
     // Check if there are required parameters
     while (++$i < $r->getNumberOfParameters()) {
       $param= $params[$i];
-      if ($param->isOptional() || self::$VARIADIC_SUPPORTED && $param->isVariadic()) {
+      if ($param->isOptional() || XPClass::$VARIADIC_SUPPORTED && $param->isVariadic()) {
         return true;  // No further checks necessary
       } else {
         return $false('Signature mismatch, additional required parameter $'.$param->getName().' found');

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -57,7 +57,10 @@ class XPClass extends Type {
   private $_class;
   private $_reflect= null;
 
+  public static $VARIADIC_SUPPORTED;
+
   static function __static() {
+    self::$VARIADIC_SUPPORTED= method_exists('ReflectionParameter', 'isVariadic');
 
     // Workaround for missing detail information about return types in
     // builtin classes.

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -58,9 +58,11 @@ class XPClass extends Type {
   private $_reflect= null;
 
   public static $VARIADIC_SUPPORTED;
+  public static $TYPE_SUPPORTED;
 
   static function __static() {
     self::$VARIADIC_SUPPORTED= method_exists('ReflectionParameter', 'isVariadic');
+    self::$TYPE_SUPPORTED= method_exists('ReflectionParameter', 'getType');
 
     // Workaround for missing detail information about return types in
     // builtin classes.

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -117,7 +117,7 @@ class Parameter extends \lang\Object {
    * @return  bool
    */
   public function isOptional() {
-    return $this->_reflect->isOptional();
+    return $this->_reflect->isOptional() || (defined('HHVM_VERSION') && $this->_reflect->isVariadic());
   }
 
   /**

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -15,12 +15,6 @@ class Parameter extends \lang\Object {
     $_reflect = null,
     $_details = null;
 
-  public static $TYPE_SUPPORTED;
-
-  static function __static() {
-    self::$TYPE_SUPPORTED= method_exists('ReflectionParameter', 'getType');
-  }
-
   /**
    * Constructor
    *
@@ -50,7 +44,7 @@ class Parameter extends \lang\Object {
     try {
       if ($c= $this->_reflect->getClass()) {
         return new \lang\XPClass($c);
-      } else if (self::$TYPE_SUPPORTED && $t= $this->_reflect->getType()) {
+      } else if (\lang\XPClass::$TYPE_SUPPORTED && $t= $this->_reflect->getType()) {
         return \lang\Type::forName((string)$t);
       }
     } catch (\ReflectionException $e) {
@@ -84,7 +78,7 @@ class Parameter extends \lang\Object {
    * @return  string
    */
   public function getTypeName() {
-    if (self::$TYPE_SUPPORTED && ($t= $this->_reflect->getType())) {
+    if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getType())) {
       return (string)$t;
     } else if (
       !($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||  

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -15,12 +15,6 @@ class Parameter extends \lang\Object {
     $_reflect = null,
     $_details = null;
 
-  private static $VARIADIC_SUPPORTED;
-
-  static function __static() {
-    self::$VARIADIC_SUPPORTED= method_exists('ReflectionParameter', 'isVariadic');
-  }
-
   /**
    * Constructor
    *
@@ -132,7 +126,7 @@ class Parameter extends \lang\Object {
    * @return  bool
    */
   public function isVariadic() {
-    if (self::$VARIADIC_SUPPORTED) {
+    if (\lang\XPClass::$VARIADIC_SUPPORTED) {
       return $this->_reflect->isVariadic();
     } else if (
       ($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) &&

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -126,8 +126,8 @@ class Parameter extends \lang\Object {
    * @return  bool
    */
   public function isVariadic() {
-    if (\lang\XPClass::$VARIADIC_SUPPORTED) {
-      return $this->_reflect->isVariadic();
+    if (\lang\XPClass::$VARIADIC_SUPPORTED && $this->_reflect->isVariadic()) {
+      return true;
     } else if (
       ($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) &&
       isset($details[DETAIL_ARGUMENTS][$this->_details[2]])

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -1,6 +1,9 @@
 <?php namespace lang\reflect;
 
 use lang\ElementNotFoundException;
+use lang\ClassFormatException;
+use lang\XPClass;
+use lang\Type;
 
 /**
  * Represents a method's parameter
@@ -43,12 +46,12 @@ class Parameter extends \lang\Object {
   public function getType() {
     try {
       if ($c= $this->_reflect->getClass()) {
-        return new \lang\XPClass($c);
-      } else if (\lang\XPClass::$TYPE_SUPPORTED && $t= $this->_reflect->getType()) {
-        return \lang\Type::forName((string)$t);
+        return new XPClass($c);
+      } else if (XPClass::$TYPE_SUPPORTED && $t= $this->_reflect->getType()) {
+        return Type::forName((string)$t);
       }
     } catch (\ReflectionException $e) {
-      throw new \lang\ClassFormatException(sprintf(
+      throw new ClassFormatException(sprintf(
         'Typehint for %s::%s()\'s parameter "%s" cannot be resolved: %s',
         strtr($this->_details[0], '\\', '.'),
         $this->_details[1],
@@ -58,17 +61,17 @@ class Parameter extends \lang\Object {
     }
 
     if (
-      !($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||  
+      !($details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||
       !isset($details[DETAIL_ARGUMENTS][$this->_details[2]])
     ) {   // Unknown or unparseable, return ANYTYPE
-      return \lang\Type::$VAR;
+      return Type::$VAR;
     }
 
     $t= rtrim(ltrim($details[DETAIL_ARGUMENTS][$this->_details[2]], '&'), '.');
     if ('self' === $t) {
-      return new \lang\XPClass($this->_details[0]);
+      return new XPClass($this->_details[0]);
     } else {
-      return \lang\Type::forName($t);
+      return Type::forName($t);
     }
   }
 
@@ -78,10 +81,10 @@ class Parameter extends \lang\Object {
    * @return  string
    */
   public function getTypeName() {
-    if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getType())) {
+    if (XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getType())) {
       return (string)$t;
     } else if (
-      !($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||  
+      !($details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||
       !isset($details[DETAIL_ARGUMENTS][$this->_details[2]])
     ) {   // Unknown or unparseable, return ANYTYPE
       return 'var';
@@ -99,16 +102,16 @@ class Parameter extends \lang\Object {
   public function getTypeRestriction() {
     try {
       if ($this->_reflect->isArray()) {
-        return \lang\Type::$ARRAY;
+        return Type::$ARRAY;
       } else if ($this->_reflect->isCallable()) {
-        return \lang\Type::$CALLABLE;
+        return Type::$CALLABLE;
       } else if ($c= $this->_reflect->getClass()) {
-        return new \lang\XPClass($c);
+        return new XPClass($c);
       } else {
         return null;
       }
     } catch (\ReflectionException $e) {
-      throw new \lang\ClassFormatException(sprintf(
+      throw new ClassFormatException(sprintf(
         'Typehint for %s::%s()\'s parameter "%s" cannot be resolved: %s',
         strtr($this->_details[0], '\\', '.'),
         $this->_details[1],
@@ -133,11 +136,11 @@ class Parameter extends \lang\Object {
    * @return  bool
    */
   public function isVariadic() {
-    if (\lang\XPClass::$VARIADIC_SUPPORTED && $this->_reflect->isVariadic()) {
+    if (XPClass::$VARIADIC_SUPPORTED && $this->_reflect->isVariadic()) {
       return true;
     } else if (
       $this->_reflect->isOptional() &&
-      ($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) &&
+      ($details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) &&
       isset($details[DETAIL_ARGUMENTS][$this->_details[2]])
     ) {
       return 0 === substr_compare($details[DETAIL_ARGUMENTS][$this->_details[2]], '...', -3);
@@ -170,7 +173,7 @@ class Parameter extends \lang\Object {
   public function hasAnnotation($name, $key= null) {
     $n= '$'.$this->_reflect->getName();
     if (
-      !($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||  
+      !($details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||
       !isset($details[DETAIL_TARGET_ANNO][$n])
     ) {   // Unknown or unparseable
       return false;
@@ -193,7 +196,7 @@ class Parameter extends \lang\Object {
   public function getAnnotation($name, $key= null) {
     $n= '$'.$this->_reflect->getName();
     if (
-      !($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||  
+      !($details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||
       !isset($details[DETAIL_TARGET_ANNO][$n]) || !($key 
         ? array_key_exists($key, (array)@$details[DETAIL_TARGET_ANNO][$n][$name]) 
         : array_key_exists($name, (array)@$details[DETAIL_TARGET_ANNO][$n])
@@ -216,7 +219,7 @@ class Parameter extends \lang\Object {
   public function hasAnnotations() {
     $n= '$'.$this->_reflect->getName();
     if (
-      !($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||  
+      !($details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||
       !isset($details[DETAIL_TARGET_ANNO][$n])
     ) {   // Unknown or unparseable
       return false;
@@ -232,7 +235,7 @@ class Parameter extends \lang\Object {
   public function getAnnotations() {
     $n= '$'.$this->_reflect->getName();
     if (
-      !($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||  
+      !($details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) ||
       !isset($details[DETAIL_TARGET_ANNO][$n])
     ) {   // Unknown or unparseable
       return [];

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -15,6 +15,12 @@ class Parameter extends \lang\Object {
     $_reflect = null,
     $_details = null;
 
+  private static $VARIADIC_SUPPORTED;
+
+  static function __static() {
+    self::$VARIADIC_SUPPORTED= method_exists('ReflectionParameter', 'isVariadic');
+  }
+
   /**
    * Constructor
    *
@@ -118,6 +124,24 @@ class Parameter extends \lang\Object {
    */
   public function isOptional() {
     return $this->_reflect->isOptional();
+  }
+
+  /**
+   * Retrieve whether this argument is variadic
+   *
+   * @return  bool
+   */
+  public function isVariadic() {
+    if (self::$VARIADIC_SUPPORTED) {
+      return $this->_reflect->isVariadic();
+    } else if (
+      ($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) &&
+      isset($details[DETAIL_ARGUMENTS][$this->_details[2]])
+    ) {
+      return 0 === substr_compare($details[DETAIL_ARGUMENTS][$this->_details[2]], '...', -3);
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -129,6 +129,7 @@ class Parameter extends \lang\Object {
     if (\lang\XPClass::$VARIADIC_SUPPORTED && $this->_reflect->isVariadic()) {
       return true;
     } else if (
+      $this->_reflect->isOptional() &&
       ($details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1])) &&
       isset($details[DETAIL_ARGUMENTS][$this->_details[2]])
     ) {

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -82,10 +82,18 @@ class MethodParametersTest extends MethodsTest {
     $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getType();
   }
 
-  #[@test]
-  public function nonexistant_name_class_parameter() {
+  #[@test, @action(new RuntimeVersion("<=7.0"))]
+  public function nonexistant_name_class_parameter_before_php7() {
     $this->assertEquals(
       'var',
+      $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getTypeName()
+    );
+  }
+
+  #[@test, @action(new RuntimeVersion(">=7.0"))]
+  public function nonexistant_name_class_parameter_with_php7() {
+    $this->assertEquals(
+      'net\xp_framework\unittest\reflection\UnknownTypeRestriction',
       $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getTypeName()
     );
   }
@@ -228,12 +236,21 @@ class MethodParametersTest extends MethodsTest {
     $this->assertEquals($expected, $this->method($declaration.' { }')->getParameter(0)->toString());
   }
 
+  #[@test, @action(new RuntimeVersion('>=7.0'))]
+  public function variadic_via_syntax_with_type() {
+    $param= $this->method('function fixture(string... $args) { }')->getParameter(0);
+    $this->assertEquals(
+      ['variadic' => true, 'optional' => true, 'type' => Primitive::$STRING],
+      ['variadic' => $param->isVariadic(), 'optional' => $param->isOptional(), 'type' => $param->getType()]
+    );
+  }
+
   #[@test, @action(new RuntimeVersion('>=5.6'))]
   public function variadic_via_syntax() {
     $param= $this->method('function fixture(... $args) { }')->getParameter(0);
     $this->assertEquals(
-      ['variadic' => true, 'optional' => true],
-      ['variadic' => $param->isVariadic(), 'optional' => $param->isOptional()]
+      ['variadic' => true, 'optional' => true, 'type' => Type::$VAR],
+      ['variadic' => $param->isVariadic(), 'optional' => $param->isOptional(), 'type' => $param->getType()]
     );
   }
 
@@ -241,8 +258,8 @@ class MethodParametersTest extends MethodsTest {
   public function variadic_via_apidoc() {
     $param= $this->method('/** @param var... $args */ function fixture($args= null) { }')->getParameter(0);
     $this->assertEquals(
-      ['variadic' => true, 'optional' => true],
-      ['variadic' => $param->isVariadic(), 'optional' => $param->isOptional()]
+      ['variadic' => true, 'optional' => true, 'type' => Type::$VAR],
+      ['variadic' => $param->isVariadic(), 'optional' => $param->isOptional(), 'type' => $param->getType()]
     );
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -227,4 +227,14 @@ class MethodParametersTest extends MethodsTest {
   public function parameter_representations($declaration, $expected) {
     $this->assertEquals($expected, $this->method($declaration.' { }')->getParameter(0)->toString());
   }
+
+  #[@test, @action(new RuntimeVersion('>=5.6'))]
+  public function variadic_via_syntax() {
+    $this->assertTrue($this->method('function fixture(... $args) { }')->getParameter(0)->isVariadic());
+  }
+
+  #[@test]
+  public function variadic_via_apidoc() {
+    $this->assertTrue($this->method('/** @param var... $args */ function fixture($args= null) { }')->getParameter(0)->isVariadic());
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -230,11 +230,19 @@ class MethodParametersTest extends MethodsTest {
 
   #[@test, @action(new RuntimeVersion('>=5.6'))]
   public function variadic_via_syntax() {
-    $this->assertTrue($this->method('function fixture(... $args) { }')->getParameter(0)->isVariadic());
+    $param= $this->method('function fixture(... $args) { }')->getParameter(0);
+    $this->assertEquals(
+      ['variadic' => true, 'optional' => true],
+      ['variadic' => $param->isVariadic(), 'optional' => $param->isOptional()]
+    );
   }
 
   #[@test]
   public function variadic_via_apidoc() {
-    $this->assertTrue($this->method('/** @param var... $args */ function fixture($args= null) { }')->getParameter(0)->isVariadic());
+    $param= $this->method('/** @param var... $args */ function fixture($args= null) { }')->getParameter(0);
+    $this->assertEquals(
+      ['variadic' => true, 'optional' => true],
+      ['variadic' => $param->isVariadic(), 'optional' => $param->isOptional()]
+    );
   }
 }


### PR DESCRIPTION
## Usage
Supports both PHP 5.6 / HHVM dedicated syntax (with optional PHP 7 varargs typing via `T...`):

```php
public function format($str, ...$args) {
  // ...
}
```
...as well as apidoc "typing" via `@param T...` which also works in PHP 5.4 and PHP 5.5 (*though note the optional value is necessary!*):

```php
/**
 * @param  string $str
 * @param  var... $args
 */
public function format($str, $args= null) {
  $args= array_slice(func_get_args(), 1);
  // ...
}
```

In both situations, `lang.reflect.Parameter::isVariadic()` will return true (as will `isOptional()`). The type of a variadic parameter is the simple type it's annotated with, e.g. `string... $args` will yield the **string** primitive.

## Inner workings
Checks using `ReflectionParameter::isVariadic()` first. If this method is available (it's not in versions before 5.6) and returns true, returns true. Otherwise, checks by parsing the apidoc.

Types are discovered via `ReflectionParameter::getType()` (if available, which it is as of PHP 7), or alternatively via parsing the api docs.

Contains the following workaround for [this HHVM incompatibility](https://github.com/facebook/hhvm/pull/4673):

```php
public function isOptional() {
  return (
    $this->_reflect->isOptional() ||
    (defined('HHVM_VERSION') && $this->_reflect->isVariadic())
  );
}
```

This is a bit suboptimal, since HHVM 3.7 (?) fixes this (verified w/ local HHVM 3.10), and we're still checking required parameters for being variadic there. On the other hand, adding a `version_compare()` in there costs even more performance, so we'll have to live with an extra function call w/ an hashtable lookup inside and a method invocation (and a boolean comparison inside that) in this situation.