### PR TITLE
Extend util.Objects to handle instances of non-XP classes

### DIFF
--- a/src/main/php/util/Objects.class.php
+++ b/src/main/php/util/Objects.class.php
@@ -105,7 +105,7 @@ abstract class Objects extends \lang\Object {
       }
       return $s;
     } else {
-      return serialize($val);
+      return is_object($val) ? spl_object_hash($val) : serialize($val);
     }
   }
 }

--- a/src/main/php/util/Objects.class.php
+++ b/src/main/php/util/Objects.class.php
@@ -29,7 +29,11 @@ abstract class Objects extends \lang\Object {
       }
       return true;
     } else {
-      return $a === $b;
+      return $a === $b || (
+        is_object($a) && is_object($b) &&
+        get_class($a) === get_class($b) &&
+        self::equal((array)$a, (array)$b)
+      );
     }
   }
 
@@ -54,8 +58,15 @@ abstract class Objects extends \lang\Object {
         if (0 !== $r= self::compare($val, $b[$key])) return $r;
       }
       return 0;
+    } else if ($a === $b) {
+      return 0;
+    } else if (is_object($a)) {
+      return (is_object($b) && get_class($a) === get_class($b))
+        ? self::compare((array)$a, (array)$b)
+        : 1
+      ;
     } else {
-      return $a === $b ? 0 : ($a < $b ? -1 : 1);
+      return $a < $b ? -1 : 1;
     }
   }
 

--- a/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
@@ -328,6 +328,11 @@ class ObjectsTest extends \unittest\TestCase {
     $this->assertEquals($val->hashCode(), Objects::hashOf($val));
   }
 
+  #[@test, @values('natives')]
+  public function hashOf_calls_spl_object_hash_on_natives($val) {
+    $this->assertEquals(spl_object_hash($val), Objects::hashOf($val));
+  }
+
   #[@test]
   public function function_hash() {
     $this->assertEquals(spl_object_hash(self::$func), Objects::hashOf(self::$func));

--- a/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
@@ -303,6 +303,11 @@ class ObjectsTest extends \unittest\TestCase {
     $this->assertEquals($val->toString(), Objects::stringOf($val));
   }
 
+  #[@test, @values('natives')]
+  public function stringOf_calls_xpStringOf_on_natives($val) {
+    $this->assertEquals(\xp::stringOf($val), Objects::stringOf($val));
+  }
+
   #[@test]
   public function null_hash() {
     $this->assertEquals('N;', Objects::hashOf(null));


### PR DESCRIPTION
Now, the following yield the expected results:

```php
Objects::equal(new \ReflectionClass(self::class), new \ReflectionClass(self::class));   // true
Objects::compare(new \ReflectionClass(self::class), new \ReflectionClass(self::class)); // 0
```

Essentially, with this in place, `equal()` is the equivalent of `===` and `compare()` that of `<=>` but with the possibility to overload (via lang.Object::equals() / lang.Value::compareTo() for both cases).

Also, `hashOf()` was optimized to use spl_object_hash() instead of serialize() on objects, which gives a much shorter representation!

See https://github.com/xp-framework/unittest/issues/13
See https://wiki.php.net/rfc/combined-comparison-operator
See http://php.net/manual/en/language.oop5.object-comparison.php
http://php.net/manual/en/function.spl-object-hash.php