### PR TITLE
Make paths displayed in toString() copy&pasteable

### DIFF
--- a/src/main/php/lang/AbstractClassLoader.class.php
+++ b/src/main/php/lang/AbstractClassLoader.class.php
@@ -152,11 +152,11 @@ abstract class AbstractClassLoader extends Object implements IClassLoader {
    */
   private function compactPath($path, $bases) {
     foreach ($bases as $base => $replace) {
-      if (0 === substr_compare($path, $base, 0, $length= strlen($base))) {
-        $path= $replace.substr($path, $length);
+      if (0 === strpos($path, $base)) {
+        $path= $replace.substr($path, strlen($base));
       }
     }
-    return $path;;
+    return $path;
   }
 
   /**

--- a/src/main/php/lang/AbstractClassLoader.class.php
+++ b/src/main/php/lang/AbstractClassLoader.class.php
@@ -144,17 +144,42 @@ abstract class AbstractClassLoader extends Object implements IClassLoader {
   }
 
   /**
+   * Compacts paths by replacing base directories by placeholders
+   *
+   * @param  string $path
+   * @param  [:string] $bases
+   * @return string
+   */
+  private function compactPath($path, $bases) {
+    foreach ($bases as $base => $replace) {
+      if (0 === substr_compare($path, $base, 0, $length= strlen($base))) {
+        $path= $replace.substr($path, $length);
+      }
+    }
+    return $path;;
+  }
+
+  /**
    * Creates a string representation
    *
    * @return  string
    */
   public function toString() {
-    $segments= explode(DIRECTORY_SEPARATOR, $this->path);
-    if (sizeof($segments) > 6) {
-      $path= '...'.DIRECTORY_SEPARATOR.implode(DIRECTORY_SEPARATOR, array_slice($segments, -6));
+    if ($home= getenv('HOME')) {    // Un*x or Cygwin
+      $separator= '/';
+      $bases= [getcwd() => '.', $home => '~', getenv('APPDATA') => '$APPDATA'];
+    } else if (0 === strncasecmp(PHP_OS, 'Win', 3)) {
+      $separator= '\\';
+      $bases= [getcwd() => '.', getenv('APPDATA') => '%APPDATA%'];
     } else {
-      $path= $this->path;
+      $separator= DIRECTORY_SEPARATOR;
+      $bases= [getcwd() => '.'];
     }
-    return str_replace('ClassLoader', 'CL', $this->getClass()->getSimpleName()).'<'.$path.'>';
+
+    $path= $this->compactPath(rtrim($this->path, DIRECTORY_SEPARATOR), $bases);
+    return
+      str_replace('ClassLoader', 'CL', $this->getClass()->getSimpleName()).
+      '<'.strtr($path, DIRECTORY_SEPARATOR, $separator).'>'
+    ;
   }
 }


### PR DESCRIPTION
* Remove shortening paths by omitting path segments
* Instead, replace current directory with ".", home directory with "~" and the APPDATA special folder with $APPDATA (or %APPDATA% on Windows)

### Before

```sh
$ xp -m $APPDATA/Composer/vendor/xp-framework/unittest -v
XP 6.9.3-dev { PHP 7.0.0 & ZE 3.0.0 } @ Windows NT SLATE 10.0 build 10586 (Windows 10) i586 
Copyright (c) 2001-2016 the XP group
FileSystemCL<...\xp-framework\unittest\src\main\php\>
FileSystemCL<...\xp\core\src\main\php\>
FileSystemCL<...\xp\sequence\src\main\php\>
FileSystemCL<...\xp\sequence\src\test\php\>
FileSystemCL<...\xp\collections\src\main\php\>
FileSystemCL<...\xp\core\src\test\php\>
FileSystemCL<...\xp\core\src\main\resources\>
FileSystemCL<...\xp\core\src\test\resources\>
FileSystemCL<...\xp-framework\unittest\src\test\php\>
FileSystemCL<...\home\Timm\devel\xp\sequence\>
```

### After
Running in Cygwin:

```sh
$ xp -m $APPDATA/Composer/vendor/xp-framework/unittest -v
XP 6.9.3-dev { PHP 7.0.0 & ZE 3.0.0 } @ Windows NT SLATE 10.0 build 10586 (Windows 10) i586 
Copyright (c) 2001-2016 the XP group
FileSystemCL<$APPDATA/Composer/vendor/xp-framework/unittest/src/main/php>
FileSystemCL<~/devel/xp/core/src/main/php>
FileSystemCL<./src/main/php>
FileSystemCL<./src/test/php>
FileSystemCL<~/devel/xp/collections/src/main/php>
FileSystemCL<~/devel/xp/core/src/test/php>
FileSystemCL<~/devel/xp/core/src/main/resources>
FileSystemCL<~/devel/xp/core/src/test/resources>
FileSystemCL<$APPDATA/Composer/vendor/xp-framework/unittest/src/test/php>
FileSystemCL<.>
```

Running inside native Windows shell

```sh
> xp -m %APPDATA%\Composer\vendor\xp-framework\unittest -v
XP 6.9.3-dev { PHP 7.0.0 & ZE 3.0.0 } @ Windows NT SLATE 10.0 build 10586 (Windows 10) i586
Copyright (c) 2001-2016 the XP group
FileSystemCL<%APPDATA%\Composer\vendor\xp-framework\unittest\src\main\php>
FileSystemCL<C:\tools\cygwin\home\Timm\devel\xp\core\src\main\php>
FileSystemCL<.\src\main\php>
FileSystemCL<.\src\test\php>
FileSystemCL<C:\tools\cygwin\home\Timm\devel\xp\collections\src\main\php>
FileSystemCL<C:\tools\cygwin\home\Timm\devel\xp\core\src\test\php>
FileSystemCL<C:\tools\cygwin\home\Timm\devel\xp\core\src\main\resources>
FileSystemCL<C:\tools\cygwin\home\Timm\devel\xp\core\src\test\resources>
FileSystemCL<%APPDATA%\Composer\vendor\xp-framework\unittest\src\test\php>
FileSystemCL<.>
```