### PR TITLE
Improve error messages when file loaded fails to declare type

### DIFF
--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -361,10 +361,18 @@ class ClassParser extends \lang\Object {
     $annotations= [0 => [], 1 => []];
     $imports= [];
     $comment= null;
+    $namespace= '';
     $parsed= '';
     $tokens= token_get_all($bytes);
     for ($i= 0, $s= sizeof($tokens); $i < $s; $i++) {
       switch ($tokens[$i][0]) {
+        case T_NAMESPACE:
+          while (';' !== $tokens[++$i] && $i < $s) {
+            T_WHITESPACE === $tokens[$i][0] || $namespace.= $tokens[$i][1];
+          }
+          $namespace.= '\\';
+          break;
+
         case T_USE:
           if (isset($details['class'])) break;  // Inside class, e.g. function() use(...) {}
           $type= '';
@@ -402,7 +410,7 @@ class ClassParser extends \lang\Object {
               strpos($comment, '* @')- 2      // position of first details token
             ))),
             DETAIL_ANNOTATIONS  => $annotations[0],
-            DETAIL_RETURNS      => $tokens[$i + 2][1]
+            DETAIL_ARGUMENTS    => $namespace.$tokens[$i + 2][1]
           ];
           $annotations= [0 => [], 1 => []];
           $comment= null;

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -401,7 +401,8 @@ class ClassParser extends \lang\Object {
               4,                              // "/**\n"
               strpos($comment, '* @')- 2      // position of first details token
             ))),
-            DETAIL_ANNOTATIONS  => $annotations[0]
+            DETAIL_ANNOTATIONS  => $annotations[0],
+            DETAIL_RETURNS      => $tokens[$i + 2][1]
           ];
           $annotations= [0 => [], 1 => []];
           $comment= null;

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -39,7 +39,7 @@ class ClassDetailsTest extends \unittest\TestCase {
   public function parses($kind) {
     $details= (new ClassParser())->parseDetails('<?php '.$kind.' Test { }');
     $this->assertEquals(
-      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => [], DETAIL_RETURNS => 'Test'],
+      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => [], DETAIL_ARGUMENTS => 'Test'],
       $details['class']
     );
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -39,7 +39,7 @@ class ClassDetailsTest extends \unittest\TestCase {
   public function parses($kind) {
     $details= (new ClassParser())->parseDetails('<?php '.$kind.' Test { }');
     $this->assertEquals(
-      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => []],
+      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => [], DETAIL_RETURNS => 'Test'],
       $details['class']
     );
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
@@ -143,12 +143,12 @@ class ClassLoaderTest extends \unittest\TestCase {
     ClassLoader::getDefault()->loadClass('@@NON-EXISTANT@@');
   }
 
-  #[@test, @expect(ClassFormatException::class)]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/No types declared in .+/')]
   public function loadClassFileWithoutDeclaration() {
     XPClass::forName('net.xp_framework.unittest.reflection.classes.broken.NoClass');
   }
 
-  #[@test, @expect(ClassFormatException::class)]
+  #[@test, @expect(class= ClassFormatException::class, withMessage= '/File does not declare type `.+FalseClass`, but `.+TrueClass`/')]
   public function loadClassFileWithIncorrectDeclaration() {
     XPClass::forName('net.xp_framework.unittest.reflection.classes.broken.FalseClass');
   }


### PR DESCRIPTION
See xp-framework/unittest#17

## Case 1) No type declared at all

```sh
friebe@wirearchy ~
$ cat Test.class.php
<?php

# Before
friebe@wirearchy ~
$ xp Test
Uncaught exception: Exception lang.ClassFormatException (Class "Test" not declared in loaded file)
  at lang.AbstractClassLoader::loadClass0((0x4)'Test') [line 425 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass0((0x4)'Test') [line 529 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass((0x4)'Test') [line 346 of class-main.php]

# After
friebe@wirearchy ~
$ xp Test
Uncaught exception: Exception lang.ClassFormatException (Loading `Test`: No types declared in C:\tools\cygwin\home\friebe\Test.class.php)
  at lang.AbstractClassLoader::loadClass0((0x4)'Test') [line 425 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass0((0x4)'Test') [line 529 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass((0x4)'Test') [line 346 of class-main.php]
```

## Case 2) Type / file name mismatch

```sh
$ cat Test.class.php
<?php

class TrialAndError {
}

# Before
friebe@wirearchy ~
$ xp Test
Uncaught exception: Exception lang.ClassFormatException (Class "Test" not declared in loaded file)
  at lang.AbstractClassLoader::loadClass0((0x4)'Test') [line 425 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass0((0x4)'Test') [line 529 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass((0x4)'Test') [line 346 of class-main.php]

# After
friebe@wirearchy ~
$ xp Test
Uncaught exception: Exception lang.ClassFormatException (File does not declare type `Test`, but `TrialAndError`)
  at <main>::<main>() [line 3 of Test.class.php]
  at lang.AbstractClassLoader::loadClass0((0x4)'Test') [line 425 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass0((0x4)'Test') [line 529 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass((0x4)'Test') [line 346 of class-main.php]
```

## Case 3) Namespace mismatch

```sh
$ cat Test.class.php
<?php namespace example;

class TrialAndError {
}

# Before
friebe@wirearchy ~
$ xp Test
Uncaught exception: Exception lang.ClassFormatException (Class "Test" not declared in loaded file)
  at lang.AbstractClassLoader::loadClass0((0x4)'Test') [line 425 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass0((0x4)'Test') [line 529 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass((0x4)'Test') [line 346 of class-main.php]

# After
friebe@wirearchy ~
$ xp Test
Uncaught exception: Exception lang.ClassFormatException (File does not declare type `Test`, but `example.TrialAndError`)
  at <main>::<main>() [line 3 of Test.class.php]
  at lang.AbstractClassLoader::loadClass0((0x4)'Test') [line 425 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass0((0x4)'Test') [line 529 of ClassLoader.class.php]
  at lang.ClassLoader::loadClass((0x4)'Test') [line 346 of class-main.php]
```