### PR TITLE
Add hack language support

### DIFF
--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -143,7 +143,11 @@ class Type extends Object {
       'double'    => 'double',
       'float'     => 'double',
       'bool'      => 'bool',
-      'boolean'   => 'bool'
+      'boolean'   => 'bool',
+      'HH\int'    => 'int',
+      'HH\string' => 'string',
+      'HH\float'  => 'double',
+      'HH\bool'   => 'bool'
     ];
 
     if (0 === strlen($type)) {
@@ -162,9 +166,9 @@ class Type extends Object {
     // * Anything else is a qualified or unqualified class name
     if (isset($primitives[$type])) {
       return Primitive::forName($primitives[$type]);
-    } else if ('var' === $type || 'resource' === $type) {
+    } else if ('var' === $type || 'resource' === $type || 'HH\mixed' === $type) {
       return self::$VAR;
-    } else if ('void' === $type) {
+    } else if ('void' === $type || 'HH\void' == $type) {
       return self::$VOID;
     } else if ('array' === $type) {
       return self::$ARRAY;
@@ -176,6 +180,11 @@ class Type extends Object {
       return new ArrayType(self::forName(substr($type, 0, -2)));
     } else if (0 === substr_compare($type, '[:', 0, 2)) {
       return new MapType(self::forName(substr($type, 2, -1)));
+    } else if (0 === substr_compare($type, 'array<', 0, 6)) {
+      $components= self::forNames(substr($type, 6, -1));
+      return 1 === sizeof($components)? new ArrayType($components[0]) : new MapType($components[1]);
+    } else if ('?' === $type{0}) {
+      return self::forName(substr($type, 1));
     } else if ('(' === $type{0}) {
       return self::forName(substr($type, 1, -1));
     } else if (0 === substr_compare($type, '*', -1)) {

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -180,9 +180,6 @@ class Type extends Object {
       return new ArrayType(self::forName(substr($type, 0, -2)));
     } else if (0 === substr_compare($type, '[:', 0, 2)) {
       return new MapType(self::forName(substr($type, 2, -1)));
-    } else if (0 === substr_compare($type, 'array<', 0, 6)) {
-      $components= self::forNames(substr($type, 6, -1));
-      return 1 === sizeof($components)? new ArrayType($components[0]) : new MapType($components[1]);
     } else if ('?' === $type{0}) {
       return self::forName(substr($type, 1));
     } else if ('(' === $type{0}) {
@@ -199,7 +196,11 @@ class Type extends Object {
     } else {
       $base= substr($type, 0, $p);
       $components= self::forNames(substr($type, $p+ 1, -1));
-      return cast(self::forName($base), 'lang.XPClass')->newGenericType($components);
+      if ('array' === $base) {
+        return 1 === sizeof($components)? new ArrayType($components[0]) : new MapType($components[1]);
+      } else {
+        return cast(self::forName($base), 'lang.XPClass')->newGenericType($components);
+      }
     }
   }
   

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -490,12 +490,15 @@ class XPClass extends Type {
   }
 
   /**
-   * Determines if this XPClass object represents an interface type.
+   * Determines if this XPClass object represents an enum type.
    *
    * @return  bool
    */
   public function isEnum() {
-    return class_exists('lang\Enum', false) && $this->reflect()->isSubclassOf('lang\Enum');
+    return
+      (class_exists('lang\Enum', false) && $this->reflect()->isSubclassOf('lang\Enum')) ||
+      (class_exists('HH\BuiltinEnum', false) && $this->reflect()->isSubclassOf('HH\BuiltinEnum'))
+    ;
   }
 
   /**

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -600,11 +600,13 @@ class XPClass extends Type {
    */
   public function hasAnnotation($name, $key= null) {
     $details= self::detailsForClass($this->name);
-    
-    return $details && ($key 
-      ? @array_key_exists($key, @$details['class'][DETAIL_ANNOTATIONS][$name]) 
-      : @array_key_exists($name, @$details['class'][DETAIL_ANNOTATIONS])
-    );
+    if ($details && ($annotations= $details['class'][DETAIL_ANNOTATIONS])) {
+      return $key ? array_key_exists($key, @$annotations[$name]) : array_key_exists($name, $annotations);
+    } else if (defined('HHVM_VERSION')) {
+      $attr= $this->reflect()->getAttributes();
+      return $key ? isset($attr[$name]) && array_key_exists($key, @$attr[$name][0]) : isset($attr[$name]); 
+    }
+    return false;
   }
 
   /**
@@ -617,18 +619,21 @@ class XPClass extends Type {
    */
   public function getAnnotation($name, $key= null) {
     $details= self::detailsForClass($this->name);
-
-    if (!$details || !($key 
-      ? @array_key_exists($key, @$details['class'][DETAIL_ANNOTATIONS][$name]) 
-      : @array_key_exists($name, @$details['class'][DETAIL_ANNOTATIONS])
-    )) {
-      throw new ElementNotFoundException('Annotation "'.$name.($key ? '.'.$key : '').'" does not exist');
+    if ($details && ($annotations= $details['class'][DETAIL_ANNOTATIONS])) {
+      if ($key) {
+        if (array_key_exists($key, @$annotations[$name])) return $annotations[$name][$key];  
+      } else {
+        if (array_key_exists($name, $annotations)) return $annotations[$name];  
+      }  
+    } else if (defined('HHVM_VERSION')) {
+      $attr= $this->reflect()->getAttributes();
+      if ($key) {
+        if (isset($attr[$name]) && array_key_exists($key, @$attr[$name][0])) return $attr[$name][0][$key];
+      } else {
+        if (isset($attr[$name])) return empty($attr[$name]) ? null : $attr[$name][0];
+      }  
     }
-
-    return ($key 
-      ? $details['class'][DETAIL_ANNOTATIONS][$name][$key] 
-      : $details['class'][DETAIL_ANNOTATIONS][$name]
-    );
+    throw new ElementNotFoundException('Annotation "'.$name.($key ? '.'.$key : '').'" does not exist');
   }
 
   /**
@@ -638,7 +643,12 @@ class XPClass extends Type {
    */
   public function hasAnnotations() {
     $details= self::detailsForClass($this->name);
-    return $details ? !empty($details['class'][DETAIL_ANNOTATIONS]) : false;
+    if ($details && $details['class'][DETAIL_ANNOTATIONS]) {
+      return true;
+    } else if (defined('HHVM_VERSION')) {
+      return sizeof($this->reflect()->getAttributes()) > 0; 
+    }
+    return false;
   }
 
   /**
@@ -648,7 +658,16 @@ class XPClass extends Type {
    */
   public function getAnnotations() {
     $details= self::detailsForClass($this->name);
-    return $details ? $details['class'][DETAIL_ANNOTATIONS] : [];
+    if ($details && $details['class'][DETAIL_ANNOTATIONS]) {
+      return $details['class'][DETAIL_ANNOTATIONS];
+    } else if (defined('HHVM_VERSION')) {
+      $return= [];
+      foreach (array_reverse($this->reflect()->getAttributes()) as $name => $attr) {
+        $return[$name]= empty($attr) ? null : $attr[0];
+      }
+      return $return;
+    }
+    return [];
   }
   
   /**

--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -49,6 +49,8 @@ class Field extends \lang\Object {
         $type= $details[DETAIL_RETURNS];
       } else if (isset($details[DETAIL_ANNOTATIONS]['type'])) {
         $type= $details[DETAIL_ANNOTATIONS]['type'];
+      } else if (defined('HHVM_VERSION')) {
+        $type= $this->_reflect->getTypeText() ?: 'var';
       } else {
         return \lang\Type::$VAR;
       }
@@ -73,6 +75,8 @@ class Field extends \lang\Object {
         return $details[DETAIL_RETURNS];
       } else if (isset($details[DETAIL_ANNOTATIONS]['type'])) {
         return $details[DETAIL_ANNOTATIONS]['type'];
+      } else if (defined('HHVM_VERSION')) {
+        return str_replace('HH\\', '', $this->_reflect->getTypeText()) ?: 'var';
       }
     }
     return 'var';

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -66,6 +66,8 @@ class Parameter extends \lang\Object {
       // where PHP simply knows about "arrays" (of whatever).
       if (XPClass::$TYPE_SUPPORTED && $t= $this->_reflect->getType()) {
         return Type::forName((string)$t);
+      } else if (defined('HHVM_VERSION')) {
+        return Type::forName($this->_reflect->getTypeText());
       } else {
         return Type::$VAR;
       }
@@ -92,6 +94,8 @@ class Parameter extends \lang\Object {
       return ltrim($details[DETAIL_ARGUMENTS][$this->_details[2]], '&');
     } else if (XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getType())) {
       return str_replace('HH\\', '', $t);
+    } else if (defined('HHVM_VERSION')) {
+      return str_replace('HH\\', '', $this->_reflect->getTypeText());
     } else {
       return 'var';
     }

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -67,7 +67,7 @@ class Parameter extends \lang\Object {
       if (XPClass::$TYPE_SUPPORTED && $t= $this->_reflect->getType()) {
         return Type::forName((string)$t);
       } else if (defined('HHVM_VERSION')) {
-        return Type::forName($this->_reflect->getTypeText());
+        return Type::forName($this->_reflect->getTypeText() ?: 'var');
       } else {
         return Type::$VAR;
       }
@@ -95,7 +95,7 @@ class Parameter extends \lang\Object {
     } else if (XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getType())) {
       return str_replace('HH\\', '', $t);
     } else if (defined('HHVM_VERSION')) {
-      return str_replace('HH\\', '', $this->_reflect->getTypeText());
+      return str_replace('HH\\', '', $this->_reflect->getTypeText() ?: 'var');
     } else {
       return 'var';
     }

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -91,7 +91,7 @@ class Parameter extends \lang\Object {
     ) {
       return ltrim($details[DETAIL_ARGUMENTS][$this->_details[2]], '&');
     } else if (XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getType())) {
-      return (string)$t;
+      return str_replace('HH\\', '', $t);
     } else {
       return 'var';
     }

--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -222,6 +222,7 @@ class Routine extends \lang\Object {
       $attr= $this->_reflect->getAttributes();
       return $key ? isset($attr[$name]) && array_key_exists($key, @$attr[$name][0]) : isset($attr[$name]); 
     }
+    return false;
   }
 
   /**

--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -137,6 +137,8 @@ class Routine extends \lang\Object {
       }
     } else if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getReturnType())) {
       return \lang\Type::forName((string)$t);
+    } else if (defined('HHVM_VERSION')) {
+      return \lang\Type::forName($this->_reflect->getReturnTypeText());
     } else {
       return \lang\Type::$VAR;
     }
@@ -155,6 +157,8 @@ class Routine extends \lang\Object {
       return ltrim($details[DETAIL_RETURNS], '&');
     } else if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getReturnType())) {
       return str_replace('HH\\', '', $t);
+    } else if (defined('HHVM_VERSION')) {
+      return str_replace('HH\\', '', $this->_reflect->getReturnTypeText());
     } else {
       return 'var';
     }

--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -154,7 +154,7 @@ class Routine extends \lang\Object {
     ) {
       return ltrim($details[DETAIL_RETURNS], '&');
     } else if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getReturnType())) {
-      return (string)$t;
+      return str_replace('HH\\', '', $t);
     } else {
       return 'var';
     }
@@ -216,11 +216,12 @@ class Routine extends \lang\Object {
    */
   public function hasAnnotation($name, $key= null) {
     $details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_reflect->getName());
-
-    return $details && ($key 
-      ? array_key_exists($key, (array)@$details[DETAIL_ANNOTATIONS][$name]) 
-      : array_key_exists($name, (array)@$details[DETAIL_ANNOTATIONS])
-    );
+    if ($details && ($annotations= $details[DETAIL_ANNOTATIONS])) {
+      return $key ? array_key_exists($key, @$annotations[$name]) : array_key_exists($name, $annotations); 
+    } else if (defined('HHVM_VERSION')) {
+      $attr= $this->_reflect->getAttributes();
+      return $key ? isset($attr[$name]) && array_key_exists($key, @$attr[$name][0]) : isset($attr[$name]); 
+    }
   }
 
   /**
@@ -233,17 +234,21 @@ class Routine extends \lang\Object {
    */
   public function getAnnotation($name, $key= null) {
     $details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_reflect->getName());
-    if (!$details || !($key 
-      ? array_key_exists($key, @$details[DETAIL_ANNOTATIONS][$name]) 
-      : array_key_exists($name, @$details[DETAIL_ANNOTATIONS])
-    )) {
-      throw new ElementNotFoundException('Annotation "'.$name.($key ? '.'.$key : '').'" does not exist');
+    if ($details && ($annotations= $details[DETAIL_ANNOTATIONS])) {
+      if ($key) {
+        if (array_key_exists($key, @$annotations[$name])) return $annotations[$name][$key];  
+      } else {
+        if (array_key_exists($name, $annotations)) return $annotations[$name];  
+      }  
+    } else if (defined('HHVM_VERSION')) {
+      $attr= $this->_reflect->getAttributes();
+      if ($key) {
+        if (isset($attr[$name]) && array_key_exists($key, @$attr[$name][0])) return $attr[$name][0][$key];
+      } else {
+        if (isset($attr[$name])) return empty($attr[$name]) ? null : $attr[$name][0];
+      }  
     }
-
-    return ($key 
-      ? $details[DETAIL_ANNOTATIONS][$name][$key] 
-      : $details[DETAIL_ANNOTATIONS][$name]
-    );
+    throw new ElementNotFoundException('Annotation "'.$name.($key ? '.'.$key : '').'" does not exist');
   }
 
   /**
@@ -253,7 +258,12 @@ class Routine extends \lang\Object {
    */
   public function hasAnnotations() {
     $details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_reflect->getName());
-    return $details ? !empty($details[DETAIL_ANNOTATIONS]) : false;
+    if ($details && $details[DETAIL_ANNOTATIONS]) {
+      return true;
+    } else if (defined('HHVM_VERSION')) {
+      return sizeof($this->_reflect->getAttributes()) > 0; 
+    }
+    return false;
   }
 
   /**
@@ -263,7 +273,16 @@ class Routine extends \lang\Object {
    */
   public function getAnnotations() {
     $details= \lang\XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_reflect->getName());
-    return $details ? $details[DETAIL_ANNOTATIONS] : [];
+    if ($details && $details[DETAIL_ANNOTATIONS]) {
+      return $details[DETAIL_ANNOTATIONS];
+    } else if (defined('HHVM_VERSION')) {
+      $return= [];
+      foreach (array_reverse($this->_reflect->getAttributes()) as $name => $attr) {
+        $return[$name]= empty($attr) ? null : $attr[0];
+      }
+      return $return;
+    }
+    return [];
   }
   
   /**

--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -138,7 +138,7 @@ class Routine extends \lang\Object {
     } else if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getReturnType())) {
       return \lang\Type::forName((string)$t);
     } else if (defined('HHVM_VERSION')) {
-      return \lang\Type::forName($this->_reflect->getReturnTypeText());
+      return \lang\Type::forName($this->_reflect->getReturnTypeText() ?: 'var');
     } else {
       return \lang\Type::$VAR;
     }
@@ -158,7 +158,7 @@ class Routine extends \lang\Object {
     } else if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getReturnType())) {
       return str_replace('HH\\', '', $t);
     } else if (defined('HHVM_VERSION')) {
-      return str_replace('HH\\', '', $this->_reflect->getReturnTypeText());
+      return str_replace('HH\\', '', $this->_reflect->getReturnTypeText() ?: 'var');
     } else {
       return 'var';
     }

--- a/src/test/config/unittest/core.ini
+++ b/src/test/config/unittest/core.ini
@@ -272,3 +272,6 @@ class="net.xp_framework.unittest.runtime.CodeTest"
 
 [markdown-rendering]
 class="net.xp_framework.unittest.runtime.RenderMarkdownTest"
+
+[hhvm:hack]
+class="net.xp_framework.unittest.reflection.HackLanguageSupportTest"

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageEnum.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageEnum.class.php
@@ -1,0 +1,8 @@
+<?hh namespace net\xp_framework\unittest\reflection;
+
+enum HackLanguageEnum : int {
+  SMALL = 0;
+  MEDIUM = 1;
+  LARGE = 2;
+  X_LARGE = 3;
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupport.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupport.class.php
@@ -1,0 +1,14 @@
+<?hh namespace net\xp_framework\unittest\reflection;
+
+<<action('Actionable')>>
+class HackLanguageSupport extends \lang\Object {
+  public bool $typed= false;
+  public $untyped;
+
+  public function returnsString(): string { return 'Test'; }
+
+  public function returnsNothing(int $param): void { }
+
+  <<test, limit(1.0), expect(['class' => 'lang.IllegalArgumentExcepton', 'withMessage' => '/*Blam*/'] )>>
+  public function testAnnotations() { }
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
@@ -27,26 +27,6 @@ class HackLanguageSupportTest extends \unittest\TestCase {
     return XPClass::forName('net.xp_framework.unittest.reflection.HackLanguageSupport');
   }
 
-  /**
-   * Returns a fixture for integration tests
-   *
-   * @param  string $decl
-   * @param  string $name
-   * @return lang.XPClass
-   */
-  private function genericClass($decl, $name= null) {
-    $name= $name ?: 'HackLanguageSupportTest_'.$this->name;
-    $class= 'net.xp_framework.unittest.reflection.'.$name;
-
-    $dyn= DynamicClassLoader::instanceFor(__METHOD__);
-    $dyn->setClassBytes(
-      $class,
-      sprintf($decl, $name),
-      '<?hh namespace net\xp_framework\unittest\reflection;'
-    );
-    return $dyn->loadClass($class);
-  }
-
   #[@test]
   public function mixed_type() {
     $this->assertEquals(Type::$VAR, Type::forName('HH\mixed'));

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
@@ -1,12 +1,14 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use lang\Type;
+use lang\Enum;
 use lang\Primitive;
 use lang\ArrayType;
 use lang\MapType;
 use lang\XPClass;
 use lang\ElementNotFoundException;
 use lang\DynamicClassLoader;
+use lang\IllegalArgumentException;
 use unittest\actions\VerifyThat;
 
 /**
@@ -25,6 +27,15 @@ class HackLanguageSupportTest extends \unittest\TestCase {
    */
   private function testClass() {
     return XPClass::forName('net.xp_framework.unittest.reflection.HackLanguageSupport');
+  }
+
+  /**
+   * Returns a fixture for integration tests
+   *
+   * @return lang.XPClass
+   */
+  private function enumClass() {
+    return XPClass::forName('net.xp_framework.unittest.reflection.HackLanguageEnum');
   }
 
   #[@test]
@@ -176,5 +187,29 @@ class HackLanguageSupportTest extends \unittest\TestCase {
   #[@test]
   public function untyped_field_type_name() {
     $this->assertEquals('var', $this->testClass()->getField('untyped')->getTypeName());
+  }
+
+  #[@test]
+  public function is_enum() {
+    $this->assertTrue($this->enumClass()->isEnum());
+  }
+
+  #[@test]
+  public function enum_values() {
+    $values= [];
+    foreach (Enum::valuesOf($this->enumClass()) as $value) {
+      $values[$value->name()]= $value->ordinal();
+    }
+    $this->assertEquals(['SMALL' => 0, 'MEDIUM' => 1, 'LARGE' => 2, 'X_LARGE' => 3], $values);
+  }
+
+  #[@test]
+  public function enum_valueOf() {
+    $this->assertEquals(1, Enum::valueOf($this->enumClass(), 'MEDIUM')->ordinal());
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function enum_valueOf_nonexistant() {
+    Enum::valueOf($this->enumClass(), 'does-not-exist');
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
@@ -1,0 +1,200 @@
+<?php namespace net\xp_framework\unittest\reflection;
+
+use lang\Type;
+use lang\Primitive;
+use lang\ArrayType;
+use lang\MapType;
+use lang\XPClass;
+use lang\ElementNotFoundException;
+use lang\DynamicClassLoader;
+use unittest\actions\VerifyThat;
+
+/**
+ * TestCase for HACK language feature support
+ *
+ * @see    http://docs.hhvm.com/manual/en/hack.annotations.types.php
+ * @see    xp://lang.Type
+ */
+#[@action(new VerifyThat(function() { return defined('HHVM_VERSION'); }))]
+class HackLanguageSupportTest extends \unittest\TestCase {
+
+  /**
+   * Returns a fixture for integration tests
+   *
+   * @return lang.XPClass
+   */
+  private function testClass() {
+    return XPClass::forName('net.xp_framework.unittest.reflection.HackLanguageSupport');
+  }
+
+  /**
+   * Returns a fixture for integration tests
+   *
+   * @param  string $decl
+   * @param  string $name
+   * @return lang.XPClass
+   */
+  private function genericClass($decl, $name= null) {
+    $name= $name ?: 'HackLanguageSupportTest_'.$this->name;
+    $class= 'net.xp_framework.unittest.reflection.'.$name;
+
+    $dyn= DynamicClassLoader::instanceFor(__METHOD__);
+    $dyn->setClassBytes(
+      $class,
+      sprintf($decl, $name),
+      '<?hh namespace net\xp_framework\unittest\reflection;'
+    );
+    return $dyn->loadClass($class);
+  }
+
+  #[@test]
+  public function mixed_type() {
+    $this->assertEquals(Type::$VAR, Type::forName('HH\mixed'));
+  }
+
+  #[@test]
+  public function string_type() {
+    $this->assertEquals(Primitive::$STRING, Type::forName('HH\string'));
+  }
+
+  #[@test]
+  public function int_type() {
+    $this->assertEquals(Primitive::$INT, Type::forName('HH\int'));
+  }
+
+  #[@test]
+  public function double_type() {
+    $this->assertEquals(Primitive::$DOUBLE, Type::forName('HH\float'));
+  }
+
+  #[@test]
+  public function bool_type() {
+    $this->assertEquals(Primitive::$BOOL, Type::forName('HH\bool'));
+  }
+
+  #[@test]
+  public function array_of_string_type() {
+    $this->assertEquals(new ArrayType('string'), Type::forName('array<HH\string>'));
+  }
+
+  #[@test]
+  public function map_of_int_type() {
+    $this->assertEquals(new MapType('int'), Type::forName('array<HH\string, HH\int>'));
+  }
+
+  #[@test]
+  public function nullable_type() {
+    $this->assertEquals(XPClass::forName('lang.Object'), Type::forName('?lang\Object'));
+  }
+
+  #[@test]
+  public function method_string_return_type() {
+    $this->assertEquals(Primitive::$STRING, $this->testClass()->getMethod('returnsString')->getReturnType());
+  }
+
+  #[@test]
+  public function method_string_return_type_name() {
+    $this->assertEquals('string', $this->testClass()->getMethod('returnsString')->getReturnTypeName());
+  }
+
+  #[@test]
+  public function method_void_return_type() {
+    $this->assertEquals(Type::$VOID, $this->testClass()->getMethod('returnsNothing')->getReturnType());
+  }
+
+  #[@test]
+  public function method_int_param_type() {
+    $this->assertEquals(Primitive::$INT, $this->testClass()->getMethod('returnsNothing')->getParameter(0)->getType());
+  }
+
+  #[@test]
+  public function method_int_param_type_name() {
+    $this->assertEquals('int', $this->testClass()->getMethod('returnsNothing')->getParameter(0)->getTypeName());
+  }
+
+  #[@test]
+  public function class_annotations() {
+    $this->assertEquals(
+      ['action' => 'Actionable'],
+      $this->testClass()->getAnnotations()
+    );
+  }
+
+  #[@test]
+  public function class_has_annotations() {
+    $this->assertTrue($this->testClass()->hasAnnotations());
+  }
+
+  #[@test]
+  public function class_has_action_annotation() {
+    $this->assertTrue($this->testClass()->hasAnnotation('action'));
+  }
+
+  #[@test]
+  public function class_does_not_have_test_annotation() {
+    $this->assertFalse($this->testClass()->hasAnnotation('test'));
+  }
+
+  #[@test]
+  public function class_action_annotation() {
+    $this->assertEquals('Actionable', $this->testClass()->getAnnotation('action'));
+  }
+
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function class_test_annotation() {
+    $this->testClass()->getAnnotation('test');
+  }
+
+  #[@test]
+  public function method_annotations() {
+    $this->assertEquals(
+      ['test' => null, 'limit' => 1.0, 'expect' => ['class' => 'lang.IllegalArgumentExcepton', 'withMessage' => '/*Blam*/']],
+      $this->testClass()->getMethod('testAnnotations')->getAnnotations()
+    );
+  }
+
+  #[@test]
+  public function method_has_annotations() {
+    $this->assertTrue($this->testClass()->getMethod('testAnnotations')->hasAnnotations());
+  }
+
+  #[@test]
+  public function method_has_test_annotation() {
+    $this->assertTrue($this->testClass()->getMethod('testAnnotations')->hasAnnotation('test'));
+  }
+
+  #[@test]
+  public function method_does_not_have_action_annotation() {
+    $this->assertFalse($this->testClass()->getMethod('testAnnotations')->hasAnnotation('action'));
+  }
+
+  #[@test]
+  public function method_test_annotation() {
+    $this->assertEquals(null, $this->testClass()->getMethod('testAnnotations')->getAnnotation('test'));
+  }
+
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function method_action_annotation() {
+    $this->testClass()->getMethod('testAnnotations')->getAnnotation('action');
+  }
+
+  #[@test]
+  public function typed_field_type() {
+    $this->assertEquals(Primitive::$BOOL, $this->testClass()->getField('typed')->getType());
+  }
+
+  #[@test]
+  public function typed_field_type_name() {
+    $this->assertEquals('bool', $this->testClass()->getField('typed')->getTypeName());
+  }
+
+  #[@test]
+  public function untyped_field_type() {
+    $this->assertEquals(Type::$VAR, $this->testClass()->getField('untyped')->getType());
+  }
+
+  #[@test]
+  public function untyped_field_type_name() {
+    $this->assertEquals('var', $this->testClass()->getField('untyped')->getTypeName());
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -82,18 +82,15 @@ class MethodParametersTest extends MethodsTest {
     $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getType();
   }
 
-  #[@test, @action(new RuntimeVersion("<=7.0"))]
-  public function nonexistant_name_class_parameter_before_php7() {
+  #[@tes]
+  public function nonexistant_name_class_parameter() {
+    if (PHP_VERSION >= '7.0.0' || defined('HHVM_VERSION')) {
+      $expect= 'net\xp_framework\unittest\reflection\UnknownTypeRestriction';
+    } else {
+      $expect= 'var';
+    }
     $this->assertEquals(
-      'var',
-      $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getTypeName()
-    );
-  }
-
-  #[@test, @action(new RuntimeVersion(">=7.0"))]
-  public function nonexistant_name_class_parameter_with_php7() {
-    $this->assertEquals(
-      'net\xp_framework\unittest\reflection\UnknownTypeRestriction',
+      $expect,
       $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getTypeName()
     );
   }


### PR DESCRIPTION
## Scope

This pull request supersedes #57 and implements the following [Hack](http://hacklang.org/) features in XP reflection:

* [x] Running hack code alongside PHP
* [x] Hack attributes, e.g. `<<test>>` instead of `#[@test]`
* [x] Hack parameter and return types
* [x] Hack typed arrays `array<T>` and maps `array<?, T>`
* [x] Hack enums

Hack generics are not supported.

## Example
Test.class.php:
```php
<?hh

use util\cmd\Console;

<<example(['author' => 'thekid'])>>
class Test {

  public static function main(array<string> $args): int {
    Console::writeLine('Hello World');
    return 0;
  }
}
```

```sh
vagrant@vagrant-ubuntu-vivid-64:/devel/xp/core$ XP_RT=hhvm xp Test
Hello World
```

## Attributes vs. Annotations
Hack attributes can be used in the same way XP annotations can be used. Not all features of XP annotations are supported, though: Hack attributes don't allow constants, functions or instance creation expressions. Hack attributes and XP annotations may co-exist inside a class, but XP annotations always take precedence!

## Hack lambdas
Quoting their manual: "PHP's closure feature has several shortcomings. First, capturing variables from the enclosing function body is not done implicitly, but rather it requires the programmer to explicitly list which variables should be captured in the "use(..)"clause. Second, even when no variables from the enclosing function body are being captured, the syntax is still relatively verbose compared with anonymous functions in several other languages."

```php
Sequence::of($args)
  ->filter($e ==> strstr($e, 'e'))
  ->map($e ==> strtoupper($e))
  ->each([Console::class, 'writeLine'], [])
;
```