### PR TITLE
Add basic hack language support

### DIFF
--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -143,7 +143,11 @@ class Type extends Object {
       'double'    => 'double',
       'float'     => 'double',
       'bool'      => 'bool',
-      'boolean'   => 'bool'
+      'boolean'   => 'bool',
+      'HH\int'    => 'int',
+      'HH\string' => 'string',
+      'HH\float'  => 'double',
+      'HH\bool'   => 'bool'
     ];
 
     if (0 === strlen($type)) {
@@ -162,9 +166,9 @@ class Type extends Object {
     // * Anything else is a qualified or unqualified class name
     if (isset($primitives[$type])) {
       return Primitive::forName($primitives[$type]);
-    } else if ('var' === $type || 'resource' === $type) {
+    } else if ('var' === $type || 'resource' === $type || 'HH\mixed' === $type) {
       return self::$VAR;
-    } else if ('void' === $type) {
+    } else if ('void' === $type || 'HH\void' == $type) {
       return self::$VOID;
     } else if ('array' === $type) {
       return self::$ARRAY;
@@ -176,6 +180,8 @@ class Type extends Object {
       return new ArrayType(self::forName(substr($type, 0, -2)));
     } else if (0 === substr_compare($type, '[:', 0, 2)) {
       return new MapType(self::forName(substr($type, 2, -1)));
+    } else if ('?' === $type{0}) {
+      return self::forName(substr($type, 1));
     } else if ('(' === $type{0}) {
       return self::forName(substr($type, 1, -1));
     } else if (0 === substr_compare($type, '*', -1)) {
@@ -190,7 +196,11 @@ class Type extends Object {
     } else {
       $base= substr($type, 0, $p);
       $components= self::forNames(substr($type, $p+ 1, -1));
-      return cast(self::forName($base), 'lang.XPClass')->newGenericType($components);
+      if ('array' === $base) {
+        return 1 === sizeof($components)? new ArrayType($components[0]) : new MapType($components[1]);
+      } else {
+        return cast(self::forName($base), 'lang.XPClass')->newGenericType($components);
+      }
     }
   }
   

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -168,7 +168,7 @@ class Type extends Object {
       return Primitive::forName($primitives[$type]);
     } else if ('var' === $type || 'resource' === $type || 'HH\mixed' === $type) {
       return self::$VAR;
-    } else if ('void' === $type || 'HH\void' == $type) {
+    } else if ('void' === $type || 'HH\void' === $type || 'HH\noreturn' === $type) {
       return self::$VOID;
     } else if ('array' === $type) {
       return self::$ARRAY;
@@ -188,6 +188,10 @@ class Type extends Object {
       return new ArrayType(self::forName(substr($type, 0, -1)));
     } else if (strstr($type, '|')) {
       return TypeUnion::forName($type);
+    } else if ('HH\num' === $type) {
+      return new TypeUnion([Primitive::$INT, Primitive::$DOUBLE]);
+    } else if ('HH\arraykey' === $type) {
+      return new TypeUnion([Primitive::$INT, Primitive::$STRING]);
     } else if (false === ($p= strpos($type, '<'))) {
       $normalized= strtr($type, '\\', '.');
       return strstr($normalized, '.') ? XPClass::forName($normalized) : new XPClass($normalized);

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -180,7 +180,7 @@ class Type extends Object {
       return new ArrayType(self::forName(substr($type, 0, -2)));
     } else if (0 === substr_compare($type, '[:', 0, 2)) {
       return new MapType(self::forName(substr($type, 2, -1)));
-    } else if ('?' === $type{0}) {
+    } else if ('?' === $type{0} || '@' === $type{0}) {
       return self::forName(substr($type, 1));
     } else if ('(' === $type{0}) {
       return self::forName(substr($type, 1, -1));

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -490,12 +490,15 @@ class XPClass extends Type {
   }
 
   /**
-   * Determines if this XPClass object represents an interface type.
+   * Determines if this XPClass object represents an enum type.
    *
    * @return  bool
    */
   public function isEnum() {
-    return class_exists('lang\Enum', false) && $this->reflect()->isSubclassOf('lang\Enum');
+    return
+      (class_exists('lang\Enum', false) && $this->reflect()->isSubclassOf('lang\Enum')) ||
+      (class_exists('HH\BuiltinEnum', false) && $this->reflect()->isSubclassOf('HH\BuiltinEnum'))
+    ;
   }
 
   /**
@@ -617,7 +620,6 @@ class XPClass extends Type {
    */
   public function getAnnotation($name, $key= null) {
     $details= self::detailsForClass($this->name);
-
     if (!$details || !($key 
       ? @array_key_exists($key, @$details['class'][DETAIL_ANNOTATIONS][$name]) 
       : @array_key_exists($name, @$details['class'][DETAIL_ANNOTATIONS])

--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -49,6 +49,8 @@ class Field extends \lang\Object {
         $type= $details[DETAIL_RETURNS];
       } else if (isset($details[DETAIL_ANNOTATIONS]['type'])) {
         $type= $details[DETAIL_ANNOTATIONS]['type'];
+      } else if (defined('HHVM_VERSION')) {
+        $type= $this->_reflect->getTypeText() ?: 'var';
       } else {
         return \lang\Type::$VAR;
       }
@@ -73,6 +75,8 @@ class Field extends \lang\Object {
         return $details[DETAIL_RETURNS];
       } else if (isset($details[DETAIL_ANNOTATIONS]['type'])) {
         return $details[DETAIL_ANNOTATIONS]['type'];
+      } else if (defined('HHVM_VERSION')) {
+        return str_replace('HH\\', '', $this->_reflect->getTypeText()) ?: 'var';
       }
     }
     return 'var';

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -66,6 +66,8 @@ class Parameter extends \lang\Object {
       // where PHP simply knows about "arrays" (of whatever).
       if (XPClass::$TYPE_SUPPORTED && $t= $this->_reflect->getType()) {
         return Type::forName((string)$t);
+      } else if (defined('HHVM_VERSION')) {
+        return Type::forName($this->_reflect->getTypeText() ?: 'var');
       } else {
         return Type::$VAR;
       }
@@ -91,7 +93,9 @@ class Parameter extends \lang\Object {
     ) {
       return ltrim($details[DETAIL_ARGUMENTS][$this->_details[2]], '&');
     } else if (XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getType())) {
-      return (string)$t;
+      return str_replace('HH\\', '', $t);
+    } else if (defined('HHVM_VERSION')) {
+      return str_replace('HH\\', '', $this->_reflect->getTypeText() ?: 'var');
     } else {
       return 'var';
     }

--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -135,10 +135,17 @@ class Routine extends \lang\Object {
       } else {
         return \lang\Type::forName($t);
       }
+    } else if (defined('HHVM_VERSION')) {
+      $t= $this->_reflect->getReturnTypeText() ?: 'var';
+      if ('self' === $t) {
+        return new \lang\XPClass($this->_reflect->getDeclaringClass());
+      } else if ('HH\\this' === $t) {
+        return new \lang\XPClass($this->_class);
+      } else {
+        return \lang\Type::forName($t);
+      }
     } else if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getReturnType())) {
       return \lang\Type::forName((string)$t);
-    } else if (defined('HHVM_VERSION')) {
-      return \lang\Type::forName($this->_reflect->getReturnTypeText() ?: 'var');
     } else {
       return \lang\Type::$VAR;
     }

--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -137,6 +137,8 @@ class Routine extends \lang\Object {
       }
     } else if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getReturnType())) {
       return \lang\Type::forName((string)$t);
+    } else if (defined('HHVM_VERSION')) {
+      return \lang\Type::forName($this->_reflect->getReturnTypeText() ?: 'var');
     } else {
       return \lang\Type::$VAR;
     }
@@ -154,7 +156,9 @@ class Routine extends \lang\Object {
     ) {
       return ltrim($details[DETAIL_RETURNS], '&');
     } else if (\lang\XPClass::$TYPE_SUPPORTED && ($t= $this->_reflect->getReturnType())) {
-      return (string)$t;
+      return str_replace('HH\\', '', $t);
+    } else if (defined('HHVM_VERSION')) {
+      return str_replace('HH\\', '', $this->_reflect->getReturnTypeText() ?: 'var');
     } else {
       return 'var';
     }

--- a/src/test/config/unittest/core.ini
+++ b/src/test/config/unittest/core.ini
@@ -272,3 +272,6 @@ class="net.xp_framework.unittest.runtime.CodeTest"
 
 [markdown-rendering]
 class="net.xp_framework.unittest.runtime.RenderMarkdownTest"
+
+[hhvm:hack]
+class="net.xp_framework.unittest.reflection.HackLanguageSupportTest"

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageEnum.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageEnum.class.php
@@ -1,0 +1,8 @@
+<?hh namespace net\xp_framework\unittest\reflection;
+
+enum HackLanguageEnum : int {
+  SMALL = 0;
+  MEDIUM = 1;
+  LARGE = 2;
+  X_LARGE = 3;
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupport.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupport.class.php
@@ -6,7 +6,13 @@ class HackLanguageSupport extends \lang\Object {
 
   public function returnsString(): string { return 'Test'; }
 
+  public function returnsNum(): num { return 1; }
+
+  public function returnsArraykey(): arraykey { return 1; }
+
   public function returnsThis(): this { return $this; }
+
+  public function returnsNoreturn(): noreturn { }
 
   public function returnsSelf(self $self): self { return $self; }
 

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupport.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupport.class.php
@@ -1,0 +1,11 @@
+<?hh namespace net\xp_framework\unittest\reflection;
+
+class HackLanguageSupport extends \lang\Object {
+  public bool $typed= false;
+  public $untyped;
+
+  public function returnsString(): string { return 'Test'; }
+
+  public function returnsNothing(int $param): void { }
+
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupport.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupport.class.php
@@ -6,6 +6,10 @@ class HackLanguageSupport extends \lang\Object {
 
   public function returnsString(): string { return 'Test'; }
 
+  public function returnsThis(): this { return $this; }
+
+  public function returnsSelf(self $self): self { return $self; }
+
   public function returnsNothing(int $param): void { }
 
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
@@ -93,7 +93,7 @@ class HackLanguageSupportTest extends \unittest\TestCase {
     $this->assertEquals(Type::$VOID, $this->testClass()->getMethod('returnsNothing')->getReturnType());
   }
 
-  #[@test]
+  #[@test, @action(new VerifyThat(function() { return version_compare(HHVM_VERSION, '3.7.0', 'ge'); }))]
   public function method_noreturn_type() {
     $this->assertEquals(Type::$VOID, $this->testClass()->getMethod('returnsNoreturn')->getReturnType());
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
@@ -93,8 +93,23 @@ class HackLanguageSupportTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function method_this_return_type() {
+    $this->assertEquals($this->testClass(), $this->testClass()->getMethod('returnsThis')->getReturnType());
+  }
+
+  #[@test]
+  public function method_self_return_type() {
+    $this->assertEquals($this->testClass(), $this->testClass()->getMethod('returnsSelf')->getReturnType());
+  }
+
+  #[@test]
   public function method_int_param_type() {
     $this->assertEquals(Primitive::$INT, $this->testClass()->getMethod('returnsNothing')->getParameter(0)->getType());
+  }
+
+  #[@test]
+  public function method_self_param_type() {
+    $this->assertEquals($this->testClass(), $this->testClass()->getMethod('returnsSelf')->getParameter(0)->getType());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
@@ -1,0 +1,148 @@
+<?php namespace net\xp_framework\unittest\reflection;
+
+use lang\Type;
+use lang\Enum;
+use lang\Primitive;
+use lang\ArrayType;
+use lang\MapType;
+use lang\XPClass;
+use lang\ElementNotFoundException;
+use lang\DynamicClassLoader;
+use lang\IllegalArgumentException;
+use unittest\actions\VerifyThat;
+
+/**
+ * TestCase for HACK language feature support
+ *
+ * @see  xp://lang.Type
+ */
+#[@action(new VerifyThat(function() { return defined('HHVM_VERSION'); }))]
+class HackLanguageSupportTest extends \unittest\TestCase {
+
+  /**
+   * Returns a fixture for integration tests
+   *
+   * @return lang.XPClass
+   */
+  private function testClass() {
+    return XPClass::forName('net.xp_framework.unittest.reflection.HackLanguageSupport');
+  }
+
+  /**
+   * Returns a fixture for integration tests
+   *
+   * @return lang.XPClass
+   */
+  private function enumClass() {
+    return XPClass::forName('net.xp_framework.unittest.reflection.HackLanguageEnum');
+  }
+
+  #[@test]
+  public function mixed_type() {
+    $this->assertEquals(Type::$VAR, Type::forName('HH\mixed'));
+  }
+
+  #[@test]
+  public function string_type() {
+    $this->assertEquals(Primitive::$STRING, Type::forName('HH\string'));
+  }
+
+  #[@test]
+  public function int_type() {
+    $this->assertEquals(Primitive::$INT, Type::forName('HH\int'));
+  }
+
+  #[@test]
+  public function double_type() {
+    $this->assertEquals(Primitive::$DOUBLE, Type::forName('HH\float'));
+  }
+
+  #[@test]
+  public function bool_type() {
+    $this->assertEquals(Primitive::$BOOL, Type::forName('HH\bool'));
+  }
+
+  #[@test]
+  public function array_of_string_type() {
+    $this->assertEquals(new ArrayType('string'), Type::forName('array<HH\string>'));
+  }
+
+  #[@test]
+  public function map_of_int_type() {
+    $this->assertEquals(new MapType('int'), Type::forName('array<HH\string, HH\int>'));
+  }
+
+  #[@test]
+  public function nullable_type() {
+    $this->assertEquals(XPClass::forName('lang.Object'), Type::forName('?lang\Object'));
+  }
+
+  #[@test]
+  public function method_string_return_type() {
+    $this->assertEquals(Primitive::$STRING, $this->testClass()->getMethod('returnsString')->getReturnType());
+  }
+
+  #[@test]
+  public function method_string_return_type_name() {
+    $this->assertEquals('string', $this->testClass()->getMethod('returnsString')->getReturnTypeName());
+  }
+
+  #[@test]
+  public function method_void_return_type() {
+    $this->assertEquals(Type::$VOID, $this->testClass()->getMethod('returnsNothing')->getReturnType());
+  }
+
+  #[@test]
+  public function method_int_param_type() {
+    $this->assertEquals(Primitive::$INT, $this->testClass()->getMethod('returnsNothing')->getParameter(0)->getType());
+  }
+
+  #[@test]
+  public function method_int_param_type_name() {
+    $this->assertEquals('int', $this->testClass()->getMethod('returnsNothing')->getParameter(0)->getTypeName());
+  }
+
+  #[@test]
+  public function typed_field_type() {
+    $this->assertEquals(Primitive::$BOOL, $this->testClass()->getField('typed')->getType());
+  }
+
+  #[@test]
+  public function typed_field_type_name() {
+    $this->assertEquals('bool', $this->testClass()->getField('typed')->getTypeName());
+  }
+
+  #[@test]
+  public function untyped_field_type() {
+    $this->assertEquals(Type::$VAR, $this->testClass()->getField('untyped')->getType());
+  }
+
+  #[@test]
+  public function untyped_field_type_name() {
+    $this->assertEquals('var', $this->testClass()->getField('untyped')->getTypeName());
+  }
+
+  #[@test]
+  public function is_enum() {
+    $this->assertTrue($this->enumClass()->isEnum());
+  }
+
+  #[@test]
+  public function enum_values() {
+    $values= [];
+    foreach (Enum::valuesOf($this->enumClass()) as $value) {
+      $values[$value->name()]= $value->ordinal();
+    }
+    $this->assertEquals(['SMALL' => 0, 'MEDIUM' => 1, 'LARGE' => 2, 'X_LARGE' => 3], $values);
+  }
+
+  #[@test]
+  public function enum_valueOf() {
+    $this->assertEquals(1, Enum::valueOf($this->enumClass(), 'MEDIUM')->ordinal());
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function enum_valueOf_nonexistant() {
+    Enum::valueOf($this->enumClass(), 'does-not-exist');
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/HackLanguageSupportTest.class.php
@@ -5,6 +5,7 @@ use lang\Enum;
 use lang\Primitive;
 use lang\ArrayType;
 use lang\MapType;
+use lang\TypeUnion;
 use lang\XPClass;
 use lang\ElementNotFoundException;
 use lang\DynamicClassLoader;
@@ -93,6 +94,11 @@ class HackLanguageSupportTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function method_noreturn_type() {
+    $this->assertEquals(Type::$VOID, $this->testClass()->getMethod('returnsNoreturn')->getReturnType());
+  }
+
+  #[@test]
   public function method_this_return_type() {
     $this->assertEquals($this->testClass(), $this->testClass()->getMethod('returnsThis')->getReturnType());
   }
@@ -100,6 +106,16 @@ class HackLanguageSupportTest extends \unittest\TestCase {
   #[@test]
   public function method_self_return_type() {
     $this->assertEquals($this->testClass(), $this->testClass()->getMethod('returnsSelf')->getReturnType());
+  }
+
+  #[@test]
+  public function method_num_return_type() {
+    $this->assertEquals(new TypeUnion([Primitive::$INT, Primitive::$DOUBLE]), $this->testClass()->getMethod('returnsNum')->getReturnType());
+  }
+
+  #[@test]
+  public function method_arraykey_return_type() {
+    $this->assertEquals(new TypeUnion([Primitive::$INT, Primitive::$STRING]), $this->testClass()->getMethod('returnsArraykey')->getReturnType());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -82,18 +82,15 @@ class MethodParametersTest extends MethodsTest {
     $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getType();
   }
 
-  #[@test, @action(new RuntimeVersion("<=7.0"))]
-  public function nonexistant_name_class_parameter_before_php7() {
+  #[@tes]
+  public function nonexistant_name_class_parameter() {
+    if (PHP_VERSION >= '7.0.0' || defined('HHVM_VERSION')) {
+      $expect= 'net\xp_framework\unittest\reflection\UnknownTypeRestriction';
+    } else {
+      $expect= 'var';
+    }
     $this->assertEquals(
-      'var',
-      $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getTypeName()
-    );
-  }
-
-  #[@test, @action(new RuntimeVersion(">=7.0"))]
-  public function nonexistant_name_class_parameter_with_php7() {
-    $this->assertEquals(
-      'net\xp_framework\unittest\reflection\UnknownTypeRestriction',
+      $expect,
       $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getTypeName()
     );
   }


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/308

## Scope

This pull request supersedes #57 and implements the following [Hack](http://hacklang.org/) features in XP:


* [x] Running hack code alongside PHP - *seamless*
* [x] The short [hack lambdas](https://docs.hhvm.com/hack/lambdas/introduction) inside regular code - *seamless*
* [x] Hack parameter and return [types](https://docs.hhvm.com/hack/types/type-system), including `void`, `this`, `noreturn`, the num and arraykey unions, [function types](https://docs.hhvm.com/hack/callables/introduction) and typed arrays `array<T>` and maps `array<?, T>` - *via changes to type system* 
* [x] [Hack enums](https://docs.hhvm.com/hack/enums/introduction) to be recognized as enum types correctly - *by checking for HH\BuiltinEnum*

Hack generics and attributes are not supported. See [this comment on #122](https://github.com/xp-framework/core/pull/122#issuecomment-174302371): We only cover the very basics to make reflection work consistently with PHP and Hack. Other features need to be implemented (or already are) in libraries such as https://github.com/xp-forge/mirrors!

## Example
Test.class.php:
```php
<?hh

use util\cmd\Console;

class Test {

  public static function main(array<string> $args): int {
    Console::writeLine('Hello World');
    return 0;
  }
}
```

Load and run:
```sh
vagrant@vagrant-ubuntu-vivid-64:/devel/xp/core$ XP_RT=hhvm xp Test
Hello World
```

Reflect:
```sh
vagrant@vagrant-ubuntu-vivid-64:/devel/xp/core$ XP_RT=hhvm xp -w \
  '\lang\XPClass::forName("Test")->getMethods()'
[public static int main(array<string> $args)]
vagrant@vagrant-ubuntu-vivid-64:/devel/xp/core$ XP_RT=hhvm xp -w \
  '\lang\XPClass::forName("Test")->getMethods ()[0]->getParameters()[0]->getType()'
lang.ArrayType<string[]>
```
