### PR TITLE
Unbase streams

### DIFF
--- a/src/main/php/io/Path.class.php
+++ b/src/main/php/io/Path.class.php
@@ -4,7 +4,7 @@ use lang\IllegalStateException;
 use lang\IllegalArgumentException;
 use io\collections\IOElement;
 
-class Path extends \lang\Object {
+class Path implements \lang\Value {
   const EXISTING = true;
   protected $path;
 
@@ -362,13 +362,22 @@ class Path extends \lang\Object {
   }
 
   /**
-   * Returns whether this path instance is equal to a given object.
+   * Returns a hashcode for this path instance
    *
-   * @param  var $cmp
    * @return bool
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->normalize()->path === $cmp->normalize()->path;
+  public function hashCode() {
+    return $this->normalize()->path;
+  }
+
+  /**
+   * Returns whether this path instance is equal to a given object.
+   *
+   * @param  var $value
+   * @return bool
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->normalize()->path, $value->normalize()->path) : 1;
   }
 
   /** @return string */

--- a/src/main/php/io/streams/BufferedInputStream.class.php
+++ b/src/main/php/io/streams/BufferedInputStream.class.php
@@ -3,7 +3,7 @@
 /**
  * Buffered InputStream
  */
-class BufferedInputStream extends \lang\Object implements InputStream {
+class BufferedInputStream implements InputStream {
   protected 
     $in   = null,
     $buf  = '',

--- a/src/main/php/io/streams/BufferedOutputStream.class.php
+++ b/src/main/php/io/streams/BufferedOutputStream.class.php
@@ -5,7 +5,7 @@
  * results internally. This means not every single byte passed to
  * write() will be written.
  */
-class BufferedOutputStream extends \lang\Object implements OutputStream {
+class BufferedOutputStream implements OutputStream {
   protected 
     $out  = null,
     $buf  = '',

--- a/src/main/php/io/streams/Bz2CompressingOutputStream.class.php
+++ b/src/main/php/io/streams/Bz2CompressingOutputStream.class.php
@@ -6,7 +6,7 @@
  * @ext   bz2
  * @test  xp://net.xp_framework.unittest.io.streams.Bz2CompressingOutputStreamTest
  */
-class Bz2CompressingOutputStream extends \lang\Object implements OutputStream {
+class Bz2CompressingOutputStream implements OutputStream {
   protected $out= null;
   
   /**

--- a/src/main/php/io/streams/Bz2DecompressingInputStream.class.php
+++ b/src/main/php/io/streams/Bz2DecompressingInputStream.class.php
@@ -6,7 +6,7 @@
  * @ext   bz2
  * @test  xp://net.xp_framework.unittest.io.streams.Bz2DecompressingInputStreamTest
  */
-class Bz2DecompressingInputStream extends \lang\Object implements InputStream {
+class Bz2DecompressingInputStream implements InputStream {
   protected $in = null;
   
   /**

--- a/src/main/php/io/streams/ChannelInputStream.class.php
+++ b/src/main/php/io/streams/ChannelInputStream.class.php
@@ -10,7 +10,7 @@ use io\IOException;
  * @see   php://wrappers
  * @see   xp://io.streams.ChannelOutputStream
  */
-class ChannelInputStream extends \lang\Object implements InputStream {
+class ChannelInputStream implements InputStream {
   protected
     $name = null,
     $fd   = null;

--- a/src/main/php/io/streams/ChannelOutputStream.class.php
+++ b/src/main/php/io/streams/ChannelOutputStream.class.php
@@ -10,7 +10,7 @@ use io\IOException;
  * @see   php://wrappers
  * @see   xp://io.streams.ChannelInputStream
  */
-class ChannelOutputStream extends \lang\Object implements OutputStream {
+class ChannelOutputStream implements OutputStream {
   protected
     $name = null,
     $fd   = null;

--- a/src/main/php/io/streams/ConsoleInputStream.class.php
+++ b/src/main/php/io/streams/ConsoleInputStream.class.php
@@ -8,9 +8,8 @@
  * $in= new ConsoleInputStream(STDIN);
  * ```
  */
-class ConsoleInputStream extends \lang\Object implements InputStream {
-  protected
-    $descriptor= null;
+class ConsoleInputStream implements InputStream {
+  protected $descriptor= null;
   
   /**
    * Constructor

--- a/src/main/php/io/streams/ConsoleOutputStream.class.php
+++ b/src/main/php/io/streams/ConsoleOutputStream.class.php
@@ -9,9 +9,8 @@
  * $err= new ConsoleOutputStream(STDERR);
  * ```
  */
-class ConsoleOutputStream extends \lang\Object implements OutputStream {
-  protected
-    $descriptor= null;
+class ConsoleOutputStream implements OutputStream {
+  protected $descriptor= null;
   
   /**
    * Constructor

--- a/src/main/php/io/streams/DeflatingOutputStream.class.php
+++ b/src/main/php/io/streams/DeflatingOutputStream.class.php
@@ -6,7 +6,7 @@
  * @ext   zlib
  * @test  xp://net.xp_framework.unittest.io.streams.DeflatingOutputStreamTest
  */
-class DeflatingOutputStream extends \lang\Object implements OutputStream {
+class DeflatingOutputStream implements OutputStream {
   protected $out= null;
   
   /**

--- a/src/main/php/io/streams/FileInputStream.class.php
+++ b/src/main/php/io/streams/FileInputStream.class.php
@@ -7,7 +7,7 @@ use io\File;
  *
  * @test     xp://net.xp_framework.unittest.io.streams.FileInputStreamTest
  */
-class FileInputStream extends \lang\Object implements InputStream, Seekable {
+class FileInputStream implements InputStream, Seekable {
   protected $file;
   
   /**

--- a/src/main/php/io/streams/FileOutputStream.class.php
+++ b/src/main/php/io/streams/FileOutputStream.class.php
@@ -7,7 +7,7 @@ use io\File;
  *
  * @test  xp://net.xp_framework.unittest.io.streams.FileOutputStreamTest
  */
-class FileOutputStream extends \lang\Object implements OutputStream {
+class FileOutputStream implements OutputStream {
   protected $file;
   
   /**

--- a/src/main/php/io/streams/GzCompressingOutputStream.class.php
+++ b/src/main/php/io/streams/GzCompressingOutputStream.class.php
@@ -9,7 +9,7 @@
  * @see   rfc://1952
  * @test  xp://net.xp_framework.unittest.io.streams.GzCompressingOutputStreamTest
  */
-class GzCompressingOutputStream extends \lang\Object implements OutputStream {
+class GzCompressingOutputStream implements OutputStream {
   protected $out= null;
   protected $md= null;
   protected $length= null;

--- a/src/main/php/io/streams/GzDecompressingInputStream.class.php
+++ b/src/main/php/io/streams/GzDecompressingInputStream.class.php
@@ -9,7 +9,7 @@ use io\IOException;
  * @see   rfc://1952
  * @test  xp://net.xp_framework.unittest.io.streams.GzDecompressingInputStreamTest
  */
-class GzDecompressingInputStream extends \lang\Object implements InputStream {
+class GzDecompressingInputStream implements InputStream {
   private $in, $header;
   public static $wrapped= [];
 
@@ -86,7 +86,7 @@ class GzDecompressingInputStream extends \lang\Object implements InputStream {
     }
 
     // Now, convert stream to file handle and append inflating filter
-    $wri= 'zlib.bounded://'.$in->hashCode();
+    $wri= 'zlib.bounded://'.spl_object_hash($in);
     self::$wrapped[$wri]= $in;
     $this->in= fopen($wri, 'r');
     if (!stream_filter_append($this->in, 'zlib.inflate', STREAM_FILTER_READ)) {

--- a/src/main/php/io/streams/InflatingInputStream.class.php
+++ b/src/main/php/io/streams/InflatingInputStream.class.php
@@ -6,7 +6,7 @@
  * @ext   zlib
  * @test  xp://net.xp_framework.unittest.io.streams.InflatingInputStreamTest
  */
-class InflatingInputStream extends \lang\Object implements InputStream {
+class InflatingInputStream implements InputStream {
   protected $in = null;
   
   /**

--- a/src/main/php/io/streams/MemoryInputStream.class.php
+++ b/src/main/php/io/streams/MemoryInputStream.class.php
@@ -5,7 +5,7 @@
  *
  * @test  xp://net.xp_framework.unittest.io.streams.MemoryInputStreamTest
  */
-class MemoryInputStream extends \lang\Object implements InputStream, Seekable {
+class MemoryInputStream implements InputStream, Seekable {
   protected $pos= 0;
   protected $bytes;
 

--- a/src/main/php/io/streams/MemoryOutputStream.class.php
+++ b/src/main/php/io/streams/MemoryOutputStream.class.php
@@ -5,7 +5,7 @@
  *
  * @test  xp://net.xp_framework.unittest.io.streams.MemoryOutputStreamTest
  */
-class MemoryOutputStream extends \lang\Object implements OutputStream, Seekable {
+class MemoryOutputStream implements OutputStream, Seekable {
   protected $pos= 0;
   protected $bytes= '';
   

--- a/src/main/php/io/streams/Reader.class.php
+++ b/src/main/php/io/streams/Reader.class.php
@@ -9,7 +9,7 @@ use io\IOException;
  * implementation (which works with bytes - for single-byte character
  * sets, there is no difference, obviously).
  */
-abstract class Reader extends \lang\Object implements Closeable {
+abstract class Reader implements Closeable {
   protected $stream= null;
   
   /**

--- a/src/main/php/io/streams/StreamTransfer.class.php
+++ b/src/main/php/io/streams/StreamTransfer.class.php
@@ -17,7 +17,7 @@ use lang\Closeable;
  *
  * @test    xp://net.xp_framework.unittest.io.streams.StreamTransferTest
  */
-class StreamTransfer extends \lang\Object implements Closeable {
+class StreamTransfer implements Closeable {
   protected $in= null;
   protected $out= null;
   

--- a/src/main/php/io/streams/Streams.class.php
+++ b/src/main/php/io/streams/Streams.class.php
@@ -77,8 +77,9 @@ abstract class Streams {
    * @return  resource
    */
   public static function readableFd(InputStream $s) { 
-    self::$streams[$s->hashCode()]= $s;
-    return fopen('iostrr://'.$s->hashCode(), 'rb');
+    $hash= spl_object_hash($s);
+    self::$streams[$hash]= $s;
+    return fopen('iostrr://'.$hash, 'rb');
   }
 
   /**
@@ -88,8 +89,9 @@ abstract class Streams {
    * @return  string
    */
   public static function readableUri(InputStream $s) { 
-    self::$streams[$s->hashCode()]= $s;
-    return 'iostrr://'.$s->hashCode();
+    $hash= spl_object_hash($s);
+    self::$streams[$hash]= $s;
+    return 'iostrr://'.$hash;
   }
 
   /**
@@ -99,8 +101,9 @@ abstract class Streams {
    * @return  resource
    */
   public static function writeableFd(OutputStream $s) { 
-    self::$streams[$s->hashCode()]= $s;
-    return fopen('iostrw://'.$s->hashCode(), 'wb');
+    $hash= spl_object_hash($s);
+    self::$streams[$hash]= $s;
+    return fopen('iostrw://'.$hash, 'wb');
   }
 
   /**
@@ -110,8 +113,9 @@ abstract class Streams {
    * @return  resource
    */
   public static function writeableUri(OutputStream $s) { 
-    self::$streams[$s->hashCode()]= $s;
-    return 'iostrw://'.$s->hashCode();
+    $hash= spl_object_hash($s);
+    self::$streams[$hash]= $s;
+    return 'iostrw://'.$hash;
   }
   
   /**

--- a/src/main/php/io/streams/StringReader.class.php
+++ b/src/main/php/io/streams/StringReader.class.php
@@ -6,7 +6,7 @@
  *
  * @test  xp://net.xp_framework.unittest.io.streams.StringReaderTest
  */
-class StringReader extends \lang\Object implements InputStreamReader {
+class StringReader implements InputStreamReader {
   protected
     $in  = null,
     $buf = '';

--- a/src/main/php/io/streams/StringWriter.class.php
+++ b/src/main/php/io/streams/StringWriter.class.php
@@ -6,9 +6,8 @@
  *
  * @test  xp://net.xp_framework.unittest.io.streams.StringWriterTest
  */
-class StringWriter extends \lang\Object implements OutputStreamWriter {
-  protected
-    $out= null;
+class StringWriter implements OutputStreamWriter {
+  protected $out= null;
   
   /**
    * Constructor

--- a/src/main/php/io/streams/Writer.class.php
+++ b/src/main/php/io/streams/Writer.class.php
@@ -8,7 +8,7 @@ use lang\Closeable;
  * (which works with bytes - for single-byte character sets, there is 
  * no difference, obviously).
  */
-abstract class Writer extends \lang\Object {
+abstract class Writer {
   protected $stream= null;
   
   /**


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/297: This removes the `lang.Object` class as parent for all io.streams classes and the io.Path class.