### PR TITLE
Enable running scripts from files

### DIFF
--- a/src/main/php/xp/runtime/Evaluate.class.php
+++ b/src/main/php/xp/runtime/Evaluate.class.php
@@ -22,6 +22,8 @@ class Evaluate {
       $code= new Code(file_get_contents('php://stdin'));
     } else if ('--' === $args[0]) {
       $code= new Code(file_get_contents('php://stdin'));
+    } else if (is_file($args[0])) {
+      $code= new Code(file_get_contents($args[0]));
     } else {
       $code= new Code($args[0]);
     }

--- a/src/main/resources/xp/runtime/eval.md
+++ b/src/main/resources/xp/runtime/eval.md
@@ -1,0 +1,21 @@
+# Evaluates code
+
+* Evaluate code from a command line argument
+  ```sh
+  $ xp -e 'echo PHP_BINARY'
+  ```
+* Evaluate code from standard input
+  ```sh
+  $ echo 'var_dump(1 + 2)' | xp -e
+  ```
+* Use `--` to separate arguments when piping from standard input
+  ```sh
+  $ echo 'var_dump($argv[1])' | xp -e -- -a
+  ```
+* Running [scripts](https://github.com/xp-framework/core/pull/127)
+  ```sh
+  $ xp -e AgeInDays.script.php 1977-12-24
+  ```
+
+Arguments are accessible via *$argv*: `$argv[0]` is the entry point
+class, `$argv[1]` is the first argument on the command line, etcetera.

--- a/src/main/resources/xp/runtime/xp.md
+++ b/src/main/resources/xp/runtime/xp.md
@@ -4,7 +4,7 @@
   ```sh
   $ xp -v
   ```
-* Evaluate code
+* Evaluate code. More details [available](xp help eval)
   ```sh
   $ xp -e 'var_dump(1 + 2)'
   ```


### PR DESCRIPTION
Scripts do not have an enclosing class, but rather just start with the code right away (after some optional `use` statements). 

### Example

```php
<?php
use util\{Date, DateUtil};
use util\cmd\Console;

$span= DateUtil::timespanBetween(new Date($argv[1]), Date::now());
Console::writeLine("Hey, you are ", $span->getDays(), " days old");
```

```sh
$ xp -e AgeInDays.script.php 1977-12-14
Hey, you are 13920 days old            
```

*This feature should also be backported to XP6*