### PR TITLE
OS Version handling for systems with /etc/os-release

### DIFF
--- a/src/main/php/xp/runtime/Version.class.php
+++ b/src/main/php/xp/runtime/Version.class.php
@@ -18,11 +18,16 @@ class Version {
 
   /** @return string */
   private function osVersion() {
-    if ('Linux' == PHP_OS && is_executable('/usr/bin/lsb_release')) {
-      return 'Linux/'.strtr(`/usr/bin/lsb_release -scd`, "\n", ' ');
-    } else {
-      return PHP_OS.'/'.php_uname('v');
+    if ('Linux' === PHP_OS) {
+      if (is_file('/etc/os-release')) {
+        $rel= parse_ini_file('/etc/os-release');
+        return 'Linux/'.(ucfirst($rel['ID']).' '.$rel['VERSION']);
+      } else is_executable('/usr/bin/lsb_release')) {
+        return 'Linux/'.strtr(`/usr/bin/lsb_release -scd`, "\n", ' ');
+      }
     }
+
+    return PHP_OS.'/'.php_uname('v');
   }
 
   /**

--- a/src/main/php/xp/runtime/Version.class.php
+++ b/src/main/php/xp/runtime/Version.class.php
@@ -21,7 +21,7 @@ class Version {
     if ('Linux' === PHP_OS) {
       if (is_file('/etc/os-release')) {
         $rel= parse_ini_file('/etc/os-release');
-        return 'Linux/'.(ucfirst($rel['ID']).' '.$rel['VERSION']);
+        return 'Linux/'.($rel['PRETTY_NAME'] ?: $rel['NAME'].' '.$rel['VERSION']);
       } else is_executable('/usr/bin/lsb_release')) {
         return 'Linux/'.strtr(`/usr/bin/lsb_release -scd`, "\n", ' ');
       }


### PR DESCRIPTION
Uses parse_ini_file() on the file /etc/os-release, described in http://0pointer.de/public/systemd-man/os-release.html

```sh
$ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"
NAME="Debian GNU/Linux"
VERSION_ID="7"
VERSION="7 (wheezy)"
ID=debian
ANSI_COLOR="1;31"
HOME_URL="http://www.debian.org/"
SUPPORT_URL="http://www.debian.org/support/"
BUG_REPORT_URL="http://bugs.debian.org/"
```

See also http://0pointer.de/blog/projects/os-release.html and #131