### PR TITLE
Change lang.XPClass::getClasses() to return an iterator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ XP Framework Core ChangeLog
 
 ### Features
 
+* Code QA: Use `::class` throughout codebase where applicable - @thekid
 * Made test suite run on [AppVeyor](https://ci.appveyor.com/project/thekid/core)
   (@thekid)
 

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -419,13 +419,12 @@ class XPClass extends Type {
   /**
    * Tests whether this class is a subclass of a specified class.
    *
-   * @param   var class either a string or an XPClass object
+   * @param   string|self $class
    * @return  bool
    */
   public function isSubclassOf($class) {
     if (!($class instanceof self)) $class= XPClass::forName($class);
-    if ($class->name == $this->name) return false;   // Catch bordercase (ZE bug?)
-    return $this->reflect()->isSubclassOf($class->reflect());
+    return $class->name === $this->name ? false : $this->reflect()->isSubclassOf($class->reflect());
   }
 
   /**

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -859,12 +859,11 @@ class XPClass extends Type {
    * Returns an array containing class objects representing all the 
    * public classes
    *
-   * @return  lang.XPClass[] class objects
+   * @return  php.Iterator
    */
   public static function getClasses() {
     foreach (\xp::$cl as $class => $loader) {
-      $ret[]= new self(literal($class));
+      yield new self(literal($class));
     }
-    return $ret;
   }
 }

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -493,7 +493,7 @@ class XPClass extends Type {
    */
   public function isEnum() {
     return
-      (class_exists('lang\Enum', false) && $this->reflect()->isSubclassOf('lang\Enum')) ||
+      (class_exists(Enum::class, false) && $this->reflect()->isSubclassOf(Enum::class)) ||
       (class_exists('HH\BuiltinEnum', false) && $this->reflect()->isSubclassOf('HH\BuiltinEnum'))
     ;
   }
@@ -809,7 +809,7 @@ class XPClass extends Type {
     }
     if (!isset($details['class'][DETAIL_GENERIC][1])) {
       $details['class'][DETAIL_GENERIC][1]= array_map(
-        ['lang\Type', 'forName'], 
+        [Type::class, 'forName'], 
         $details['class'][DETAIL_GENERIC][2]
       );
       unset($details['class'][DETAIL_GENERIC][2]);

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -435,7 +435,7 @@ class XPClass extends Type {
    *   XPClass::forName('lang.Object')->isAssignableFrom('util.Date');   // TRUE
    * </code>
    *
-   * @param   var type
+   * @param   string|lang.Type $type
    * @return  bool
    */
   public function isAssignableFrom($type) {

--- a/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/FunctionTypeTest.class.php
@@ -10,8 +10,9 @@ use lang\MapType;
 use lang\ClassCastException;
 use lang\IllegalArgumentException;
 use lang\reflect\TargetInvocationException;
+use unittest\TestCase;
 
-class FunctionTypeTest extends \unittest\TestCase {
+class FunctionTypeTest extends TestCase {
 
   #[@test]
   public function can_create() {
@@ -152,7 +153,7 @@ class FunctionTypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [['lang.XPClass', 'forName']], ['lang.XPClass::forName'],
-  #  [['lang\XPClass', 'forName']]
+  #  [[XPClass::class, 'forName']]
   #])]
   public function array_referencing_static_class_method_is_instance($value) {
     $type= new FunctionType([Primitive::$STRING, XPClass::forName('lang.IClassLoader')], XPClass::forName('lang.XPClass'));
@@ -161,7 +162,7 @@ class FunctionTypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [['lang.XPClass', 'forName']], ['lang.XPClass::forName'],
-  #  [['lang\XPClass', 'forName']]
+  #  [[XPClass::class, 'forName']]
   #])]
   public function array_referencing_static_class_method_is_instance_without_optional_parameter($value) {
     $type= new FunctionType([Primitive::$STRING], XPClass::forName('lang.XPClass'));
@@ -170,7 +171,7 @@ class FunctionTypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [['lang.XPClass', 'forName']], ['lang.XPClass::forName'],
-  #  [['lang\XPClass', 'forName']]
+  #  [[XPClass::class, 'forName']]
   #])]
   public function return_type_verified_for_static_class_methods($value) {
     $type= new FunctionType([Primitive::$STRING], Type::$VOID);
@@ -179,7 +180,7 @@ class FunctionTypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [['lang.XPClass', 'forName']], ['lang.XPClass::forName'],
-  #  [['lang\XPClass', 'forName']]
+  #  [[XPClass::class, 'forName']]
   #])]
   public function parameter_type_verified_for_static_class_methods($value) {
     $type= new FunctionType([XPClass::forName('lang.Object')], XPClass::forName('lang.XPClass'));
@@ -188,7 +189,7 @@ class FunctionTypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [['lang.Object', 'new']], ['lang.Object::new'],
-  #  [['lang\Object', 'new']]
+  #  [[Object::class, 'new']]
   #])]
   public function array_referencing_constructor_is_instance($value) {
     $type= new FunctionType([], XPClass::forName('lang.Object'));
@@ -304,7 +305,7 @@ class FunctionTypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [['lang.XPClass', 'forName']], ['lang.XPClass::forName'],
-  #  [['lang\XPClass', 'forName']]
+  #  [[XPClass::class, 'forName']]
   #])]
   public function create_instances_from_array_referencing_static_class_method($value) {
     $value= (new FunctionType([Primitive::$STRING], XPClass::forName('lang.XPClass')))->newInstance($value);
@@ -313,7 +314,7 @@ class FunctionTypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [['lang.Object', 'new']], ['lang.Object::new'],
-  #  [['lang\Object', 'new']]
+  #  [[Object::class, 'new']]
   #])]
   public function create_instances_from_array_referencing_constructor($value) {
     $new= (new FunctionType([], XPClass::forName('lang.Object')))->newInstance($value);
@@ -322,7 +323,7 @@ class FunctionTypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [['unittest.TestCase', 'new']], ['unittest.TestCase::new'],
-  #  [['unittest\TestCase', 'new']]
+  #  [[TestCase::class, 'new']]
   #])]
   public function create_instances_from_array_referencing_declared_constructor($value) {
     $new= (new FunctionType([Type::$VAR], XPClass::forName('unittest.TestCase')))->newInstance($value);

--- a/src/test/php/net/xp_framework/unittest/core/NamespaceAliasTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/NamespaceAliasTest.class.php
@@ -2,25 +2,27 @@
 
 use lang\Object;
 use lang\ClassLoader;
+use lang\Generic;
+use unittest\TestCase;
 
 /**
  * Tests the XP Framework's optional namespace support
  */
-class NamespaceAliasTest extends \unittest\TestCase {
+class NamespaceAliasTest extends TestCase {
 
   #[@test]
   public function lang_object_class_exists() {
-    $this->assertTrue(class_exists('lang\Object', false));
+    $this->assertTrue(class_exists(Object::class, false));
   }
 
   #[@test]
   public function lang_generic_interface_exists() {
-    $this->assertTrue(interface_exists('lang\Generic', false));
+    $this->assertTrue(interface_exists(Generic::class, false));
   }
 
   #[@test]
   public function unittest_testcase_class_exists() {
-    $this->assertTrue(class_exists('unittest\TestCase', false));
+    $this->assertTrue(class_exists(TestCase::class, false));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/core/ObjectTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ObjectTest.class.php
@@ -13,7 +13,7 @@ class ObjectTest extends \unittest\TestCase {
 
   #[@test]
   public function is_declared_with_qualified_name() {
-    $this->assertTrue(class_exists('lang\Object', false));
+    $this->assertTrue(class_exists(Object::class, false));
   }
 
   #[@test]
@@ -85,6 +85,6 @@ class ObjectTest extends \unittest\TestCase {
 
   #[@test, @expect(class= Error::class, withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
   public function calling_undefined_static_methods_via_call_user_func_array_raises_an_error() {
-    call_user_func_array(['lang\Object', 'undefMethod'], []);
+    call_user_func_array([Object::class, 'undefMethod'], []);
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/XpTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/XpTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
+use lang\Object;
+
 /**
  * Tests the <xp> functions
  */
@@ -88,7 +90,7 @@ class XpTest extends \unittest\TestCase {
 
   #[@test]
   public function literal_of_object() {
-    $this->assertEquals('lang\Object', literal('lang.Object'));
+    $this->assertEquals(Object::class, literal('lang.Object'));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -72,7 +72,7 @@ class TypeTest extends \unittest\TestCase {
 
   #[@test]
   public function objectTypeLiteral() {
-    $this->assertEquals(XPClass::forName('lang.Object'), Type::forName('lang\\Object'));
+    $this->assertEquals(XPClass::forName('lang.Object'), Type::forName(Object::class));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
@@ -312,7 +312,7 @@ class XPClassTest extends \unittest\TestCase {
 
   #[@test]
   public function getClasses_returns_a_list_of_class_objects() {
-    $this->assertInstanceOf('lang.XPClass[]', XPClass::getClasses());
+    $this->assertInstanceOf('lang.XPClass[]', iterator_to_array(XPClass::getClasses()));
   }
   
   #[@test]


### PR DESCRIPTION
Performance and memory usage improvement

No BC break for `foreach` usage' .