### PR TITLE
Fixed issue that __static method would be called twice when using MockProxyBuilder

### DIFF
--- a/src/main/php/unittest/mock/MockProxyBuilder.class.php
+++ b/src/main/php/unittest/mock/MockProxyBuilder.class.php
@@ -212,6 +212,8 @@ class MockProxyBuilder extends \lang\Object {
   private function generateBaseClassMethods($baseClass) {
     $bytes= '';
 
+    $bytes.= 'static function __static() {}';
+
     $reservedMethods= \lang\XPClass::forName('lang.Generic')->getMethods();
     $reservedMethodNames= array_map(function($i) { return $i->getName(); }, $reservedMethods);
     

--- a/src/test/php/net/xp_framework/unittest/tests/mock/MockProxyBuilderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/tests/mock/MockProxyBuilderTest.class.php
@@ -29,6 +29,16 @@ class MockProxyBuilderTest extends TestCase {
     }');
     $this->iteratorClass= \lang\XPClass::forName('util.XPIterator');
     $this->observerClass= \lang\XPClass::forName('util.Observer');
+    $this->staticInitializerClass= newinstance('lang.Object', [], '{
+      private static $counter= 0;
+      static function __static() {
+        self::$counter++;
+      }
+
+      public function counter() {
+        return self::$counter;
+      }
+    }');
   }
 
   /**
@@ -152,6 +162,14 @@ class MockProxyBuilderTest extends TestCase {
     $proxy->overloaded('foo', 'bar');
     $this->assertEquals(array('foo'), $this->handler->invocations['overloaded_1']);
     $this->assertEquals(array('foo', 'bar'), $this->handler->invocations['overloaded_2']);
+  }
+
+  #[@test]
+  public function static_initializer_gets_overwritten() {
+    $class= (new MockProxyBuilder())->createProxyClass(\lang\ClassLoader::getDefault(), [], $this->staticInitializerClass->getClass());
+    $obj= $class->newInstance(null);
+
+    $this->assertEquals(1, $obj->counter());
   }
 
   #[@test]


### PR DESCRIPTION
* the problem was that the initialize() method in \rdbms\criterion\SimpleExpression was called twice during a test and produced a warning
* the solution is to overwrite __static with an empty method body for all classes created by MockProxyBuilder