### PR TITLE
Fixed util.log.LogObserver not accepting LogCategory instances

### DIFF
--- a/src/main/php/util/log/LogObserver.class.php
+++ b/src/main/php/util/log/LogObserver.class.php
@@ -13,7 +13,7 @@ class LogObserver extends \lang\Object implements BoundLogObserver {
    *
    * @param   util.log.LogCategory cat
    */
-  public function __construct(\LogCategory $cat) {
+  public function __construct(LogCategory $cat) {
     $this->cat= $cat;
   }
 


### PR DESCRIPTION
* see https://github.com/xp-framework/logging/commit/e20bc8cb04c063d8f3e5d5a19b947517408c8d6a