### PR TITLE
Type for absolute Namespace

### DIFF
--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -184,6 +184,9 @@ class Type extends Object {
       return TypeUnion::forName($type);
     } else if (false === ($p= strpos($type, '<'))) {
       $normalized= strtr($type, '\\', '.');
+      if (substr($normalized, 0, 1) == '.') {
+        $normalized= substr($normalized, 1);
+      }
       return strstr($normalized, '.') ? XPClass::forName($normalized) : new XPClass($normalized);
     } else if (strstr($type, '?')) {
       return WildcardType::forName($type);


### PR DESCRIPTION
Allows to get a type for an absolute Namespace like:

\foo\bar\baz\ClassName

At this point this class name is translated by $normalized= strtr($type, '\\', '.') to ".foo.bar.baz.ClassName" which isn't valid.

This pull request ist in progress (tests are missing) but already opened for requesting feedback from @thekid 