### PR TITLE
Generic fields

### DIFF
--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -165,6 +165,12 @@ class GenericTypes {
             $m= $tokens[$i+ 2][1];
             $p= 0;
             $annotations= [$meta[1][$m][DETAIL_ANNOTATIONS], $meta[1][$m][DETAIL_TARGET_ANNO]];
+          } else if (T_VARIABLE === $tokens[$i][0]) {
+            $f= substr($tokens[$i][1], 1);
+            $annotations= $meta[0][$f][DETAIL_ANNOTATIONS];
+            if (isset($annotations['generic']['var'])) {
+              $meta[0][$f][DETAIL_RETURNS]= strtr($annotations['generic']['var'], $placeholders);
+            }
           } else if ('}' === $tokens[$i][0]) {
             $src.= '}';
             break;

--- a/src/test/php/net/xp_framework/unittest/core/generics/InstanceReflectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/InstanceReflectionTest.class.php
@@ -79,11 +79,11 @@ class InstanceReflectionTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @ignore('No longer existant in new implementation')]
-  public function delegateFieldType() {
+  #[@test]
+  public function elementFieldType() {
     $this->assertEquals(
-      'net.xp_framework.unittest.core.generics.Lookup',
-      $this->fixture->getClass()->getField('delegate')->getType()
+      '[:unittest.TestCase]',
+      $this->fixture->getClass()->getField('elements')->getTypeName()
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/generics/Lookup.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/Lookup.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
+use util\Objects;
+
 /**
  * Lookup map
  */
@@ -15,8 +17,7 @@ class Lookup extends AbstractDictionary {
    */
   #[@generic(params= 'K, V')]
   public function put($key, $value) {
-    $offset= $key instanceof \lang\Generic ? $key->hashCode() : serialize($key);
-    $this->elements[$offset]= $value;
+    $this->elements[Objects::hashOf($key)]= $value;
   } 
 
   /**
@@ -28,7 +29,7 @@ class Lookup extends AbstractDictionary {
    */
   #[@generic(params= 'K', return= 'V')]
   public function get($key) {
-    $offset= $key instanceof \lang\Generic ? $key->hashCode() : serialize($key);
+    $offset= Objects::hashOf($key);
     if (!isset($this->elements[$offset])) {
       throw new \util\NoSuchElementException('No such key '.\xp::stringOf($key));
     }

--- a/src/test/php/net/xp_framework/unittest/core/generics/Lookup.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/Lookup.class.php
@@ -7,6 +7,8 @@ use util\Objects;
  */
 #[@generic(self= 'K, V', parent= 'K, V')]
 class Lookup extends AbstractDictionary {
+
+  #[@generic(var= '[:V]')]
   protected $elements= [];
   
   /**

--- a/src/test/php/net/xp_framework/unittest/core/generics/Lookup.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/Lookup.class.php
@@ -7,6 +7,7 @@ use util\Objects;
  */
 #[@generic(self= 'K, V', parent= 'K, V')]
 class Lookup extends AbstractDictionary {
+  protected $size;
 
   #[@generic(var= '[:V]')]
   protected $elements= [];
@@ -20,6 +21,7 @@ class Lookup extends AbstractDictionary {
   #[@generic(params= 'K, V')]
   public function put($key, $value) {
     $this->elements[Objects::hashOf($key)]= $value;
+    $this->size= sizeof($this->elements);
   } 
 
   /**
@@ -47,4 +49,7 @@ class Lookup extends AbstractDictionary {
   public function values() {
     return array_values($this->elements);
   }
+
+  /** @return int */
+  public function size() { return $this->size; }
 }


### PR DESCRIPTION
This pull request implements support for generic fields - see #143 

```php
#[@generic(self= 'T')]
class Test {

  #[@generic(var= 'T[]')]
  public $list;
}
```