### PR TITLE
Create util.Random class: A random number generator

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -509,6 +509,8 @@ define('MODIFIER_PUBLIC',     256);
 define('MODIFIER_PROTECTED',  512);
 define('MODIFIER_PRIVATE',   1024);
 
+defined('PHP_INT_MIN') || define('PHP_INT_MIN', ~PHP_INT_MAX);
+
 xp::$loader= new xp();
 
 // Paths are passed via class loader API from *-main.php. Retaining BC:

--- a/src/main/php/util/Random.class.php
+++ b/src/main/php/util/Random.class.php
@@ -1,0 +1,170 @@
+<?php namespace util;
+
+use io\IOException;
+use lang\IllegalArgumentException;
+
+/**
+ * This random generator uses PHP's `random_bytes()` and `random_int()`
+ * functions if available (PHP >= 7.0) and provides alternatives if
+ * necessary.
+ *
+ * _Note_: This RNG prefers secure pseudo-random sources. This may be
+ * slow; for considerably faster results, use Random::MTRAND (which
+ * uses the Mersenne Twister algorithm)
+ *
+ * @see   http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
+ * @see   http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/
+ * @test  xp://net.xp_framework.unittest.util.RandomTest
+ */
+class Random {
+  const DEFAULT = null;
+  const OPENSSL = 'openssl';
+  const MCRYPT  = 'mcrypt';
+  const URANDOM = 'urandom';
+  const MTRAND  = 'mtrand';
+
+  private static $default;
+  private $bytes, $ints;
+
+  static function __static() {
+    if (function_exists('random_bytes')) {
+      self::$default= ['bytes' => 'random_bytes', 'ints' => 'random_int'];
+    } else if (function_exists('openssl_random_pseudo_bytes')) {
+      self::$default= ['bytes' => [__CLASS__, self::OPENSSL], 'ints' => null];
+    } else if (function_exists('mcrypt_create_iv')) {
+      self::$default= ['bytes' => [__CLASS__, self::MCRYPT], 'ints' => null];
+    } else if (is_readable('/dev/urandom')) {
+      self::$default= ['bytes' => [__CLASS__, self::URANDOM], 'ints' => null];
+    } else {
+      self::$default= ['bytes' => [__CLASS__, self::MTRAND], 'ints' => 'mt_rand'];
+    }
+  }
+
+  /**
+   * Creates a new random
+   *
+   * @param  string $source Optionally select source: DEFAULT, OPENSSL, MCRYPT, URANDOM, MTRAND
+   */
+  public function __construct($source= self::DEFAULT) {
+    if ($source) {
+      $this->bytes= [__CLASS__, $source];
+      $this->ints= [$this, 'random'];
+    } else {
+      $this->bytes= self::$default['bytes'];
+      $this->ints= self::$default['ints'] ?: [$this, 'random'];
+    }
+  }
+
+  /**
+   * Implementation using OpenSSL
+   *
+   * @param  int $limit
+   * @return string $bytes
+   */
+  private static function openssl($limit) {
+    return openssl_random_pseudo_bytes($limit);
+  }
+
+  /**
+   * Implementation using MCrypt
+   *
+   * @param  int $limit
+   * @return string $bytes
+   */
+  private static function mcrypt($limit) {
+    return mcrypt_create_iv($limit, MCRYPT_DEV_URANDOM);
+  }
+
+  /**
+   * Implementation reading from `/dev/urandom`
+   *
+   * @param  int $limit
+   * @return string $bytes
+   */
+  private static function urandom($limit) {
+    if (!($f= fopen('/dev/urandom', 'r'))) {
+      $e= new IOException('Cannot access /dev/urandom');
+      \xp::gc(__FILE__);
+      throw $e;
+    }
+
+    // HHVM does not have stream_set_read_buffer()!
+    function_exists('stream_set_read_buffer') && stream_set_read_buffer($f, 0);
+    $bytes= fread($f, $limit);
+    fclose($f);
+    return $bytes;
+  }
+
+  /**
+   * Implementation using `mt_rand()`
+   *
+   * @param  int $limit
+   * @return string $bytes
+   */
+  private static function mtrand($limit) {
+    $bytes= '';
+    for ($i= 0; $i < $limit; $i++) {
+      $bytes.= chr((mt_rand() ^ mt_rand()) % 0xFF);
+    }
+    return $bytes;
+  }
+
+  /**
+   * Uses source to fetch random bytes and calculates a random int from
+   * that within the given minimum and maximum limits.
+   *
+   * @param  int $min
+   * @param  int $max
+   * @return int
+   */
+  private function random($min, $max) {
+    $range= $max - $min;
+
+    // How many bytes do we need to represent the range?
+    $bits= (int)ceil(log($range, 2));
+    $bytes= (int)ceil($bits / 8);
+    $mask= 2 ** $bits - 1;
+
+    do {
+      for ($random= $this->bytes($bytes), $result= 0, $i= 0; $i < $bytes; $i++) {
+        $result |= ord($random{$i}) << ($i * 8);
+      }
+
+      // Wrap around if negative
+      $result &= $mask;
+    } while ($result > $range);
+
+    return $result + $min;
+  }
+
+  /**
+   * Returns a number of random bytes
+   *
+   * @param  int $amount
+   * @return util.Bytes
+   * @throws lang.IllegalArgumentException
+   */
+  public function bytes($amount) {
+    if ($amount <= 0) {
+      throw new IllegalArgumentException('Amount must be greater than 0');
+    }
+    $f= $this->bytes;
+    return new Bytes($f($amount));
+  }
+
+  /**
+   * Returns a random integer between the given min and max, both inclusive
+   *
+   * @param  int $min
+   * @param  int $max
+   * @return int
+   * @throws lang.IllegalArgumentException
+   */
+  public function int($min= 0, $max= PHP_INT_MAX) {
+    if ($min >= $max) {
+      throw new IllegalArgumentException('Minimum value must be lower than max');
+    }
+    $f= $this->ints;
+    return $f($min, $max);
+  }
+}

--- a/src/main/php/util/Random.class.php
+++ b/src/main/php/util/Random.class.php
@@ -188,6 +188,9 @@ class Random {
     if ($min >= $max) {
       throw new IllegalArgumentException('Minimum value must be lower than max');
     }
+    if ($min < PHP_INT_MIN || $max > PHP_INT_MAX) {
+      throw new IllegalArgumentException('Boundaries ['.$min.'..'.$max.'] out of range for integers');
+    }
     $f= $this->ints;
     return $f($min, $max);
   }

--- a/src/main/php/util/Random.class.php
+++ b/src/main/php/util/Random.class.php
@@ -107,17 +107,17 @@ class Random {
    * @throws io.IOException if there is a problem accessing the urandom character device
    */
   private static function urandom($limit) {
-
-    // See http://man7.org/linux/man-pages/man2/stat.2.html
-    $stat= stat('/dev/urandom');
-    if (($stat['mode'] & 0170000) !== 020000) {
-      throw new IOException('Not a character device: /dev/urandom');
-    }
-
     if (!($f= fopen('/dev/urandom', 'r'))) {
       $e= new IOException('Cannot access /dev/urandom');
       \xp::gc(__FILE__);
       throw $e;
+    }
+
+    // See http://man7.org/linux/man-pages/man2/stat.2.html
+    $stat= fstat($f);
+    if (($stat['mode'] & 0170000) !== 020000) {
+      fclose($f);
+      throw new IOException('Not a character device: /dev/urandom');
     }
 
     // HHVM does not have stream_set_read_buffer()!

--- a/src/main/php/util/Random.class.php
+++ b/src/main/php/util/Random.class.php
@@ -17,7 +17,7 @@ use lang\IllegalArgumentException;
  * @test  xp://net.xp_framework.unittest.util.RandomTest
  */
 class Random {
-  const DEFAULT = null;
+  const BEST    = null;
   const OPENSSL = 'openssl';
   const MCRYPT  = 'mcrypt';
   const URANDOM = 'urandom';
@@ -43,15 +43,15 @@ class Random {
   /**
    * Creates a new random
    *
-   * @param  string $source Optionally select source: DEFAULT, OPENSSL, MCRYPT, URANDOM, MTRAND
+   * @param  string $source Optionally select source: BEST, OPENSSL, MCRYPT, URANDOM, MTRAND
    */
-  public function __construct($source= self::DEFAULT) {
-    if ($source) {
-      $this->bytes= [__CLASS__, $source];
-      $this->ints= [$this, 'random'];
-    } else {
+  public function __construct($source= self::BEST) {
+    if (self::BEST === $source) {
       $this->bytes= self::$default['bytes'];
       $this->ints= self::$default['ints'] ?: [$this, 'random'];
+    } else {
+      $this->bytes= [__CLASS__, $source];
+      $this->ints= [$this, 'random'];
     }
   }
 

--- a/src/main/php/util/Random.class.php
+++ b/src/main/php/util/Random.class.php
@@ -37,8 +37,11 @@ class Random {
     if (function_exists('mcrypt_create_iv')) {
       self::$sources[self::MCRYPT]= ['bytes' => [__CLASS__, self::MCRYPT], 'ints' => null];
     }
+    if (strncasecmp(PHP_OS, 'Win', 3) !== 0 && is_readable('/dev/urandom')) {
+      self::$sources[self::URANDOM]= ['bytes' => [__CLASS__, self::URANDOM], 'ints' => null];
+    }
 
-    // Both of these above are secure pseudo-random sources
+    // All of these above are secure pseudo-random sources
     if (!empty(self::$sources)) {
       self::$sources[self::SECURE]= &self::$sources[key(self::$sources)];
     }
@@ -50,10 +53,6 @@ class Random {
       if (!isset(self::$sources[self::SECURE]) && version_compare(PHP_VERSION, '5.6.12', 'ge')) {
         self::$sources[self::SECURE]= &self::$sources[self::OPENSSL];
       }
-    }
-
-    if (strncasecmp(PHP_OS, 'Win', 3) !== 0 && is_readable('/dev/urandom')) {
-      self::$sources[self::URANDOM]= ['bytes' => [__CLASS__, self::URANDOM], 'ints' => null];
     }
 
     // The Mersenne Twister algorithm is always available

--- a/src/test/config/unittest/util.ini
+++ b/src/test/config/unittest/util.ini
@@ -71,3 +71,6 @@ class="net.xp_framework.unittest.util.PlainTextSecretTest"
 
 [bytes]
 class="net.xp_framework.unittest.util.BytesTest"
+
+[random]
+class="net.xp_framework.unittest.util.RandomTest"

--- a/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
@@ -13,13 +13,49 @@ class RandomTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function can_create_with_source() {
+    new Random(Random::FAST);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function unknown_source() {
+    new Random('unknown');
+  }
+
+  #[@test]
+  public function best_is_default_source() {
+    $this->assertEquals(Random::BEST, (new Random())->source());
+  }
+
+  #[@test]
+  public function passing_more_than_one_source_selects_first_available() {
+    $this->assertEquals(Random::FAST, (new Random(['unknown', Random::FAST]))->source());
+  }
+
+  #[@test]
   public function bytes() {
     $this->assertEquals(20, (new Random())->bytes(20)->size());
   }
 
   #[@test]
-  public function default_bytes() {
+  public function best_bytes() {
     $this->assertEquals(20, (new Random(Random::BEST))->bytes(20)->size());
+  }
+
+  #[@test]
+  public function fast_bytes() {
+    $this->assertEquals(20, (new Random(Random::FAST))->bytes(20)->size());
+  }
+
+  #[@test, @action(new VerifyThat(function() {
+  #  return (
+  #    function_exists('random_bytes') ||
+  #    function_exists('openssl_random_pseudo_bytes') ||
+  #    function_exists('mcrypt_create_iv')
+  #  );
+  #}))]
+  public function secure_bytes() {
+    $this->assertEquals(20, (new Random(Random::SECURE))->bytes(20)->size());
   }
 
   #[@test, @action(new ExtensionAvailable('openssl'))]

--- a/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
@@ -130,12 +130,16 @@ class RandomTest extends \unittest\TestCase {
     (new Random())->int($min, 10);
   }
 
-  #[@test, @expect(IllegalArgumentException::class)]
+  #[@test, @expect(IllegalArgumentException::class), @action(new VerifyThat(function() {
+  #  return 0x7FFFFFFF === PHP_INT_MAX;
+  #}))]
   public function max_cannot_be_larger_than_int_max() {
     (new Random())->int(0, PHP_INT_MAX + 1);
   }
 
-  #[@test, @expect(IllegalArgumentException::class)]
+  #[@test, @expect(IllegalArgumentException::class), @action(new VerifyThat(function() {
+  #  return 0x7FFFFFFF === PHP_INT_MAX;
+  #}))]
   public function min_cannot_be_smaller_than_int_min() {
     (new Random())->int(PHP_INT_MIN - 1, 0);
   }

--- a/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
@@ -129,4 +129,14 @@ class RandomTest extends \unittest\TestCase {
   public function min_cannot_be_larger_or_equal_to_max($min) {
     (new Random())->int($min, 10);
   }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function max_cannot_be_larger_than_int_max() {
+    (new Random())->int(0, PHP_INT_MAX + 1);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function min_cannot_be_smaller_than_int_min() {
+    (new Random())->int(PHP_INT_MIN - 1, 0);
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
@@ -1,0 +1,96 @@
+<?php namespace net\xp_framework\unittest\util;
+
+use util\Random;
+use unittest\actions\ExtensionAvailable;
+use unittest\actions\VerifyThat;
+use lang\IllegalArgumentException;
+
+class RandomTest extends \unittest\TestCase {
+
+  #[@test]
+  public function can_create() {
+    new Random();
+  }
+
+  #[@test]
+  public function bytes() {
+    $this->assertEquals(20, (new Random())->bytes(20)->size());
+  }
+
+  #[@test]
+  public function default_bytes() {
+    $this->assertEquals(20, (new Random(Random::DEFAULT))->bytes(20)->size());
+  }
+
+  #[@test, @action(new ExtensionAvailable('openssl'))]
+  public function openssl_bytes() {
+    $this->assertEquals(20, (new Random(Random::OPENSSL))->bytes(20)->size());
+  }
+
+  #[@test, @action(new ExtensionAvailable('mcrypt'))]
+  public function mcrypt_bytes() {
+    $this->assertEquals(20, (new Random(Random::MCRYPT))->bytes(20)->size());
+  }
+
+  #[@test, @action(new VerifyThat(function() { return is_readable('/dev/urandom'); }))]
+  public function urandom_bytes() {
+    $this->assertEquals(20, (new Random(Random::URANDOM))->bytes(20)->size());
+  }
+
+  #[@test]
+  public function mtrand_bytes() {
+    $this->assertEquals(20, (new Random(Random::MTRAND))->bytes(20)->size());
+  }
+
+  #[@test, @expect(IllegalArgumentException::class), @values([-1, 0])]
+  public function cannot_use_limit_smaller_than_one($limit) {
+    (new Random())->bytes($limit);
+  }
+
+  #[@test]
+  public function int() {
+    $random= (new Random())->int(0, 10);
+    $this->assertTrue($random >= 0 && $random <= 10);
+  }
+
+  #[@test]
+  public function negative_int() {
+    $random= (new Random())->int(-10, -1);
+    $this->assertTrue($random >= -10 && $random <= -1);
+  }
+
+  #[@test]
+  public function limits_default_to_zero_to_int_max() {
+    $random= (new Random())->int();
+    $this->assertTrue($random >= 0 && $random <= PHP_INT_MAX);
+  }
+
+  #[@test, @action(new ExtensionAvailable('openssl'))]
+  public function openssl_int() {
+    $random= (new Random(Random::OPENSSL))->int(0, 10);
+    $this->assertTrue($random >= 0 && $random <= 10);
+  }
+
+  #[@test, @action(new ExtensionAvailable('mcrypt'))]
+  public function mcrypt_int() {
+    $random= (new Random(Random::MCRYPT))->int(0, 10);
+    $this->assertTrue($random >= 0 && $random <= 10);
+  }
+
+  #[@test, @action(new VerifyThat(function() { return is_readable('/dev/urandom'); }))]
+  public function urandom_int() {
+    $random= (new Random(Random::URANDOM))->int(0, 10);
+    $this->assertTrue($random >= 0 && $random <= 10);
+  }
+
+  #[@test]
+  public function mtrand_int() {
+    $random= (new Random(Random::MTRAND))->int(0, 10);
+    $this->assertTrue($random >= 0 && $random <= 10);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class), @values([10, 11])]
+  public function min_cannot_be_larger_or_equal_to_max($min) {
+    (new Random())->int($min, 10);
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
@@ -19,7 +19,7 @@ class RandomTest extends \unittest\TestCase {
 
   #[@test]
   public function default_bytes() {
-    $this->assertEquals(20, (new Random(Random::DEFAULT))->bytes(20)->size());
+    $this->assertEquals(20, (new Random(Random::BEST))->bytes(20)->size());
   }
 
   #[@test, @action(new ExtensionAvailable('openssl'))]

--- a/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
@@ -50,7 +50,7 @@ class RandomTest extends \unittest\TestCase {
   #[@test, @action(new VerifyThat(function() {
   #  return (
   #    function_exists('random_bytes') ||
-  #    function_exists('openssl_random_pseudo_bytes') ||
+  #    version_compare(PHP_VERSION, '5.6.12', 'ge') && function_exists('openssl_random_pseudo_bytes') ||
   #    function_exists('mcrypt_create_iv')
   #  );
   #}))]


### PR DESCRIPTION
Implements feature suggested in #142 - a RNG in the framework.

## About
This RNG prefers secure pseudo-random sources:

* random_bytes() / random_int() (PHP 7)
* mcrypt_create_iv(..., MCRYPT_DEV_URANDOM) (ext/mcrypt)
* /dev/urandom (on Un*x based systems)
* openssl_random_pseudo_bytes() (ext/openssl)

...and degrades to using the Mersenne Twister algorithm (mt_rand())

## Example

```php
use util\Random;

$random= new Random();
$bytes= $random->bytes(20);  // util.Bytes instance with 20 random bytes

$one= $random->int();        // Between 0 and PHP_INT_MAX
$two= $random->int(5, 10);   // Between 5 and 10, inclusive
```

## Performance vs. security

By default, the implementation will use secure pseudo-random sources. This can have the downside of being slow. If you don't care for cryptographically secure randoms, use the following:

```php
$random= new Random(Random::FAST);
```

However, if you do need the security, use the following selector:

```php
// Will raise an exception if environment doesn't have a suitable CSPRNG available
$random= new Random(Random::SECURE);
```

Read up on https://timoh6.github.io/2013/11/05/Secure-random-numbers-for-PHP-developers.html