### PR TITLE
Fix passing unicode arguments via `Runtime::newInstance()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 before_script:
   - phpenv config-rm xdebug.ini; true
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.3.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.4.0/setup' -O - | php
   - echo "use=." > xp.ini
   - echo "[runtime]" >> xp.ini
   - echo "date.timezone=Europe/Berlin" >> xp.ini

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ XP Framework Core ChangeLog
 
 ## 7.4.0 / 2016-06-04
 
+### Bugfixes
+
+* Fixed passing unicode arguments via `Runtime::newInstance()`
+  (@thekid)
+
 ### Features
 
 * Extended `lang.FunctionType`'s constructor to accept type names in

--- a/src/main/php/lang/Runtime.class.php
+++ b/src/main/php/lang/Runtime.class.php
@@ -304,7 +304,7 @@ class Runtime {
       $include.= PATH_SEPARATOR.implode(PATH_SEPARATOR, $cp); 
     }
     $cmdline= array_merge(
-      $options->withSetting('include_path', $include)->withSetting('encoding', 'utf-7')->asArguments(),
+      $options->withSetting('include_path', $include)->asArguments(),
       $bootstrap ? [$this->bootstrapScript($bootstrap)] : [],
       $class ? [$class] : []
     );

--- a/src/main/php/lang/Runtime.class.php
+++ b/src/main/php/lang/Runtime.class.php
@@ -304,7 +304,7 @@ class Runtime {
       $include.= PATH_SEPARATOR.implode(PATH_SEPARATOR, $cp); 
     }
     $cmdline= array_merge(
-      $options->withSetting('include_path', $include)->asArguments(),
+      $options->withSetting('include_path', $include)->withSetting('encoding', 'utf-7')->asArguments(),
       $bootstrap ? [$this->bootstrapScript($bootstrap)] : [],
       $class ? [$class] : []
     );
@@ -316,6 +316,7 @@ class Runtime {
     }
 
     // Finally, fork executable
-    return $this->getExecutable()->newInstance(array_merge($cmdline, $arguments), $cwd, $env);
+    $pass= array_map(function($arg) { return iconv(\xp::ENCODING, 'utf-7', $arg); }, $arguments);
+    return $this->getExecutable()->newInstance(array_merge($cmdline, $pass), $cwd, $env);
   }
 }

--- a/src/main/php/lang/Runtime.class.php
+++ b/src/main/php/lang/Runtime.class.php
@@ -304,7 +304,7 @@ class Runtime {
       $include.= PATH_SEPARATOR.implode(PATH_SEPARATOR, $cp); 
     }
     $cmdline= array_merge(
-      $options->withSetting('include_path', $include)->asArguments(),
+      $options->withSetting('include_path', $include)->withSetting('encoding', null)->asArguments(),
       $bootstrap ? [$this->bootstrapScript($bootstrap)] : [],
       $class ? [$class] : []
     );

--- a/src/main/php/lang/RuntimeOptions.class.php
+++ b/src/main/php/lang/RuntimeOptions.class.php
@@ -69,7 +69,9 @@ class RuntimeOptions extends Object {
    */
   public function withSetting($setting, $value, $add= false) {
     $key= 'd'.$setting;
-    if ($add && isset($this->backing[$key])) {
+    if (null === $value) {
+      unset($this->backing[$key]);
+    } else if ($add && isset($this->backing[$key])) {
       $this->backing[$key]= array_merge($this->backing[$key], (array)$value); 
     } else {
       $this->backing[$key]= (array)$value; 

--- a/src/test/php/net/xp_framework/unittest/core/RuntimeInstantiationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/RuntimeInstantiationTest.class.php
@@ -189,11 +189,23 @@ class RuntimeInstantiationTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [[], '1: xp.runtime.Evaluate'],
-  #  [['test'], '2: xp.runtime.Evaluate test'],
+  #  [['test'], '2: xp.runtime.Evaluate test']
+  #])]
+  public function pass_arguments($args, $expected) {
+    $out= $this->runInNewRuntime(
+      Runtime::getInstance()->startupOptions(),
+      'echo sizeof($argv), ": ", implode(" ", $argv);',
+      0,
+      $args
+    );
+    $this->assertEquals($expected, $out);
+  }
+
+  #[@test, @action(new IgnoredOnHHVM()), @values([
   #  [['mysql+x://test@127.0.0.1/test'], '2: xp.runtime.Evaluate mysql+x://test@127.0.0.1/test'],
   #  [['über', '€uro'], '3: xp.runtime.Evaluate über €uro']
   #])]
-  public function pass_arguments($args, $expected) {
+  public function pass_arguments_which_need_encoding($args, $expected) {
     $out= $this->runInNewRuntime(
       Runtime::getInstance()->startupOptions(),
       'echo sizeof($argv), ": ", implode(" ", $argv);',

--- a/src/test/php/net/xp_framework/unittest/core/RuntimeInstantiationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/RuntimeInstantiationTest.class.php
@@ -201,7 +201,7 @@ class RuntimeInstantiationTest extends \unittest\TestCase {
     $this->assertEquals($expected, $out);
   }
 
-  #[@test, @action(new IgnoredOnHHVM()), @values([
+  #[@test, @values([
   #  [['mysql+x://test@127.0.0.1/test'], '2: xp.runtime.Evaluate mysql+x://test@127.0.0.1/test'],
   #  [['über', '€uro'], '3: xp.runtime.Evaluate über €uro']
   #])]

--- a/src/test/php/net/xp_framework/unittest/core/RuntimeOptionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/RuntimeOptionsTest.class.php
@@ -81,6 +81,14 @@ class RuntimeOptionsTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function removeSetting() {
+    $options= new RuntimeOptions();
+    $options->withSetting('encoding', 'utf-8');
+    $options->withSetting('encoding', null);
+    $this->assertNull($options->getSetting('encoding'));
+  }
+
+  #[@test]
   public function chainingSwitch() {
     $options= new RuntimeOptions();
     $this->assertTrue($options === $options->withSwitch('q'));


### PR DESCRIPTION
Passes arguments using binary-safe `utf-7` encoding - see [Command.cs from xp-runners/reference](https://github.com/xp-runners/reference/blob/847e89345b18585d733d61cecf95bc659f9861ec/src/xp.runner/Command.cs#L91) and [class-main.php from xp-runners/main](https://github.com/xp-runners/main/blob/2223c46ad462455615a60fd39e103af2af44bada/src/class-main.php#L88)