### PR TITLE
Environment class

### DIFF
--- a/src/main/php/lang/Environment.class.php
+++ b/src/main/php/lang/Environment.class.php
@@ -3,7 +3,7 @@
 /**
  * User environment
  *
- * @test  xp://net.xp_framework.unittest.core.EnvironmentTest:
+ * @test  xp://net.xp_framework.unittest.core.EnvironmentTest
  */
 abstract class Environment {
 
@@ -45,10 +45,12 @@ abstract class Environment {
   }
 
   /**
-   * Gets the value of an environment variable
+   * Gets the value of an environment variable. Accepts an optional default,
+   * which can either be a closure to be executed or any other value to be 
+   * returned when none of the given names is found.
    *
    * @param  string|string[] $arg One or more names to test
-   * @param  (string|function(string|string[]): string)... $default Pass a default, including NULL
+   * @param  var... $default Optional default
    * @return string
    * @throws lang.IllegalArgumentException If none of the names is found
    */

--- a/src/main/php/lang/Environment.class.php
+++ b/src/main/php/lang/Environment.class.php
@@ -158,15 +158,12 @@ abstract class Environment {
       return $bundle;
     }
 
-    parse_str(getenv('XP_ENVIRONMENT'), $env);
-    if ($env) {
-      $file= dirname($env['exe']).DIRECTORY_SEPARATOR.'ca-bundle.crt';
+    if ($env= getenv('XP_EXE')) {
+      $file= dirname($env).DIRECTORY_SEPARATOR.'ca-bundle.crt';
       if (is_file($file)) return $file;
-      $tested[]= '$(dirname '.$env['exe'].')/ca-bundle.crt';
     }
 
     if (null !== $default) return $default;
     throw new SystemException('No ca-bundle.crt found', 2);
   }
-
 }

--- a/src/main/php/lang/Environment.class.php
+++ b/src/main/php/lang/Environment.class.php
@@ -1,0 +1,170 @@
+<?php namespace lang;
+
+/**
+ * User environment
+ *
+ * @test  xp://net.xp_framework.unittest.core.EnvironmentTest:
+ */
+abstract class Environment {
+
+  /**
+   * Checks whether the environment is XDG compliant
+   *
+   * @see    https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+   * @return bool
+   */
+  private static function xdgCompliant() {
+    foreach ($_ENV as $name => $value) {
+      if (0 === strncmp($name, 'XDG_', 4)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Gets all variables. Accepts either a regular expression to search for
+   * or an array of names as optional filter argument.
+   *
+   * @see     php://preg_match
+   * @param   string|string[] $filter Optional filter on names
+   * @return  [:string]
+   */
+  public static function variables($filter= null) {
+    if (null === $filter) return $_ENV;
+
+    $r= [];
+    if (is_array($filter)) {
+      foreach ($filter as $name) {
+        isset($_ENV[$name]) && $r[$name]= $_ENV[$name];
+      }
+    } else {
+      foreach ($_ENV as $name => $value) {
+        preg_match($filter, $name) && $r[$name]= $value;
+      }
+    }
+    return $r;
+  }
+
+  /**
+   * Gets the value of an environment variable
+   *
+   * @param  string|string[] $arg One or more names to test
+   * @param  (string|function(string|string[]): string)... $default Pass a default, including NULL
+   * @return string
+   * @throws lang.IllegalArgumentException If none of the names is found
+   */
+  public static function variable($arg, ... $default) {
+    foreach ((array)$arg as $name) {
+      if (false === ($env= getenv($name))) continue;
+      return $env;
+    }
+
+    if (empty($default)) {
+      throw new IllegalArgumentException(is_array($arg)
+        ? 'None of the variables [$'.implode(', $', $arg).'] exists'
+        : 'No such environment variable $'.$name
+      );
+    } else if ($default[0] instanceof \Closure) {
+      return $default[0]($arg);
+    } else {
+      return $default[0];
+    }
+  }
+
+  /**
+   * Exports given environment variables
+   *
+   * @param  [:string] $names
+   * @return void
+   */
+  public static function export($variables) {
+    foreach ($variables as $name => $value) {
+      if (null === $value) {
+        putenv($name);
+        unset($_ENV[$name]);
+      } else {
+        putenv($name.'='.$value);
+        $_ENV[$name]= $value;
+      }
+    }
+  }
+
+  /**
+   * Retrieve location of temporary directory. This method looks at the 
+   * environment variables TEMP, TMP, TMPDIR and TEMPDIR and, if these 
+   * cannot be found, uses PHP's builtin functionality.
+   *
+   * @see     php://sys_get_temp_dir
+   * @return  string
+   */
+  public static function tempDir() {
+    $dir= self::variable(['TEMP', 'TMP', 'TMPDIR', 'TEMPDIR'], function() {
+      return sys_get_temp_dir();
+    });
+
+    return rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+  }
+
+  /**
+   * Returns current user's home directory
+   *
+   * @return string
+   */
+  public static function homeDir() {
+    return rtrim(self::variable(['HOME', 'USERPROFILE']), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+  }
+
+  /**
+   * Returns current user's configuration directory
+   *
+   * - $LOCALAPPDATA/{Named} on Windows
+   * - $XDG_CONFIG_HOME/{named} inside an XDG environment
+   * - $HOME/.{named} otherwise
+   *
+   * @param  string $named Pass NULL to retrieve configuration base directory
+   * @return string
+   */
+  public static function configDir($named= null) {
+    $home= getenv('HOME');
+    if (false === $home) {
+      $base= getenv('LOCALAPPDATA');
+      $dir= ucfirst($named);
+    } else if (self::xdgCompliant()) {
+      $base= getenv('XDG_CONFIG_HOME') ?: $home.DIRECTORY_SEPARATOR.'.config';
+      $dir= $named;
+    } else {
+      $base= $home;
+      $dir= '.'.$named;
+    }
+    return rtrim($named ? $base.DIRECTORY_SEPARATOR.$dir : $base, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+  }
+
+  /**
+   * Returns certificates trusted by this system.
+   *
+   * @see    https://github.com/xp-framework/core/issues/150
+   * @see    https://github.com/xp-runners/cert
+   * @param  string $default
+   * @return string
+   * @throws lang.SystemException If nothing is found and no default is given
+   */
+  public static function trustedCertificates($default= null) {
+    if (is_file($certs= getenv('SSL_CERT_FILE'))) {
+      return $certs;
+    }
+
+    if (is_file($bundle= self::configDir('xp').'ca-bundle.crt')) {
+      return $bundle;
+    }
+
+    parse_str(getenv('XP_ENVIRONMENT'), $env);
+    if ($env) {
+      $file= dirname($env['exe']).DIRECTORY_SEPARATOR.'ca-bundle.crt';
+      if (is_file($file)) return $file;
+      $tested[]= '$(dirname '.$env['exe'].')/ca-bundle.crt';
+    }
+
+    if (null !== $default) return $default;
+    throw new SystemException('No ca-bundle.crt found', 2);
+  }
+
+}

--- a/src/main/php/lang/System.class.php
+++ b/src/main/php/lang/System.class.php
@@ -7,6 +7,8 @@ define('SYSTEM_RETURN_CMDNOTEXECUTABLE',   126);
 /**
  * The System class contains several useful class fields and methods. 
  * It cannot be instantiated.
+ *
+ * @deprecated  Replaced by lang.Environment and lang.Process
  */
 class System extends Object {
 

--- a/src/test/config/unittest/core.ini
+++ b/src/test/config/unittest/core.ini
@@ -275,3 +275,6 @@ class="net.xp_framework.unittest.runtime.RenderMarkdownTest"
 
 [hhvm:hack]
 class="net.xp_framework.unittest.reflection.HackLanguageSupportTest"
+
+[environment]
+class="net.xp_framework.unittest.core.EnvironmentTest"

--- a/src/test/php/net/xp_framework/unittest/core/EnvironmentSet.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnvironmentSet.class.php
@@ -1,0 +1,44 @@
+<?php namespace net\xp_framework\unittest\core;
+
+/**
+ * Creates a block within which certain environment variables are set
+ * to a specified value; and reset when the block is exited.
+ *
+ * @see  php://putenv
+ */
+class EnvironmentSet implements \lang\Closeable {
+  private $name;
+  private $original= [];
+
+  /**
+   * Use environment variables and values. Use `NULL` to indicate
+   * values which should be removed from the environment.
+   *
+   * @param  [:string] $variables
+   */
+  public function __construct($variables) {
+    foreach ($variables as $name => $value) {
+      $this->original[$name]= getenv($name);
+      if (null === $value) {
+        putenv($name);
+        unset($_ENV[$name]);
+      } else {
+        putenv($name.'='.$value);
+        $_ENV[$name]= $value;
+      }
+    }
+  }
+
+  /** @return void */
+  public function close() {
+    foreach ($this->original as $name => $value) {
+      if (false === $value) {
+        putenv($name);
+        unset($_ENV[$name]);
+      } else {
+        putenv($name.'='.$value);
+        $_ENV[$name]= $value;
+      }
+    }
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/core/EnvironmentTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnvironmentTest.class.php
@@ -1,0 +1,163 @@
+<?php namespace net\xp_framework\unittest\core;
+
+use lang\Environment;
+use lang\IllegalArgumentException;
+use lang\IllegalStateException;
+
+class EnvironmentTest extends \unittest\TestCase {
+
+  #[@test]
+  public function variable() {
+    with (new EnvironmentSet(['HOME' => '/home/test']), function() {
+      $this->assertEquals('/home/test', Environment::variable('HOME'));
+    });
+  }
+
+  #[@test]
+  public function variable_with_alternatives() {
+    with (new EnvironmentSet(['USERPROFILE' => null, 'HOME' => '/home/test']), function() {
+      $this->assertEquals('/home/test', Environment::variable(['USERPROFILE', 'HOME']));
+    });
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function non_existant_variable() {
+    with (new EnvironmentSet(['HOME' => null]), function() {
+      Environment::variable('HOME');
+    });
+  }
+
+  #[@test, @values(['/home/default', null])]
+  public function default_used_for_non_existant_variable($default) {
+    with (new EnvironmentSet(['HOME' => null]), function() use($default) {
+      $this->assertEquals($default, Environment::variable('HOME', $default));
+    });
+  }
+
+  #[@test]
+  public function default_function_not_invoked_for_existant_variable() {
+    with (new EnvironmentSet(['HOME' => '/home/test']), function() {
+      $this->assertEquals('/home/test', Environment::variable('HOME', function() {
+        throw new IllegalStateException('Never reached');
+      }));
+    });
+  }
+
+  #[@test]
+  public function default_function_invoked_for_non_existant_variable() {
+    with (new EnvironmentSet(['HOME' => null]), function() {
+      $this->assertEquals('/home/called', Environment::variable('HOME', function() {
+        return '/home/called';
+      }));
+    });
+  }
+
+  #[@test]
+  public function export() {
+    with (new EnvironmentSet(['HOME' => null]), function() {
+      Environment::export(['HOME' => '/home/test']);
+      $this->assertEquals('/home/test', Environment::variable('HOME'));
+    });
+  }
+
+  #[@test]
+  public function unset_variable_by_exporting_with_null() {
+    with (new EnvironmentSet(['HOME' => '/home/test']), function() {
+      Environment::export(['HOME' => null]);
+      $this->assertEquals('/home/default', Environment::variable('HOME', '/home/default'));
+    });
+  }
+
+  #[@test]
+  public function variables() {
+    with (new EnvironmentSet(['HOME' => '/home/test']), function() {
+      $this->assertEquals('/home/test', Environment::variables()['HOME']);
+    });
+  }
+
+  #[@test, @values(['/^WITH_.+/', '/^with_.$/i'])]
+  public function variables_filtered_by($pattern) {
+    with (new EnvironmentSet(['WITH_A' => 'a', 'WITH_B' => 'b', 'NOT_C' => 'c']), function() use($pattern) {
+      $this->assertEquals(
+        ['WITH_A' => 'a', 'WITH_B' => 'b'],
+        Environment::variables($pattern)
+      );
+    });
+  }
+
+  #[@test]
+  public function variables_by_names() {
+    with (new EnvironmentSet(['OS' => 'Windows_NT', 'HOME' => '/home/test']), function() {
+      $this->assertEquals(
+        ['OS' => 'Windows_NT', 'HOME' => '/home/test'],
+        Environment::variables(['HOME', 'OS'])
+      );
+    });
+  }
+
+  #[@test, @values([
+  #  [['TEMP' => 'tmp', 'TMP' => null, 'TMPDIR' => null, 'TEMPDIR' => null]],
+  #  [['TEMP' => null, 'TMP' => 'tmp', 'TMPDIR' => null, 'TEMPDIR' => null]],
+  #  [['TEMP' => null, 'TMP' => null, 'TMPDIR' => 'tmp', 'TEMPDIR' => null]],
+  #  [['TEMP' => null, 'TMP' => null, 'TMPDIR' => null, 'TEMPDIR' => 'tmp']]
+  #])]
+  public function temp_dir_via_variables($environment) {
+    with (new EnvironmentSet($environment), function() {
+      $this->assertEquals('tmp'.DIRECTORY_SEPARATOR, Environment::tempDir());
+    });
+  }
+
+  #[@test]
+  public function temp_dir_default() {
+    $environment= ['TEMP' => null, 'TMP' => null, 'TMPDIR' => null, 'TEMPDIR' => null];
+    with (new EnvironmentSet($environment), function() {
+      $this->assertNotEquals('', Environment::tempDir());
+    });
+  }
+
+  #[@test, @values([
+  #  [['HOME' => null, 'LOCALAPPDATA' => 'dir', 'XDG_CONFIG_HOME' => null]],
+  #  [['HOME' => 'dir', 'LOCALAPPDATA' => null, 'XDG_CONFIG_HOME' => null]],
+  #  [['HOME' => 'home', 'LOCALAPPDATA' => null, 'XDG_CONFIG_HOME' => 'dir']]
+  #])]
+  public function config_dir_via_variables($environment) {
+    with (new EnvironmentSet($environment), function() {
+      $this->assertEquals('dir'.DIRECTORY_SEPARATOR, Environment::configDir());
+    });
+  }
+
+  #[@test]
+  public function unix_named_config_dir() {
+    with (new EnvironmentSet(['HOME' => 'dir']), function() {
+      $this->assertEquals('dir'.DIRECTORY_SEPARATOR.'.test'.DIRECTORY_SEPARATOR, Environment::configDir('test'));
+    });
+  }
+
+  #[@test]
+  public function cygwin_named_config_dir() {
+    with (new EnvironmentSet(['HOME' => 'dir', 'LOCALAPPDATA' => 'local']), function() {
+      $this->assertEquals('dir'.DIRECTORY_SEPARATOR.'.test'.DIRECTORY_SEPARATOR, Environment::configDir('test'));
+    });
+  }
+
+  #[@test]
+  public function windows_named_config_dir() {
+    with (new EnvironmentSet(['HOME' => null, 'LOCALAPPDATA' => 'dir']), function() {
+      $this->assertEquals('dir'.DIRECTORY_SEPARATOR.'Test'.DIRECTORY_SEPARATOR, Environment::configDir('test'));
+    });
+  }
+
+  #[@test]
+  public function xdg_named_config_dir() {
+    with (new EnvironmentSet(['HOME' => 'home', 'XDG_CONFIG_HOME' => 'dir']), function() {
+      $this->assertEquals('dir'.DIRECTORY_SEPARATOR.'test'.DIRECTORY_SEPARATOR, Environment::configDir('test'));
+    });
+  }
+
+  #[@test]
+  public function xdg_config_dir_default() {
+    with (new EnvironmentSet(['HOME' => 'dir', 'XDG_RUNTIME_DIR' => '/run/user/1000']), function() {
+      $this->assertEquals('dir'.DIRECTORY_SEPARATOR.'.config'.DIRECTORY_SEPARATOR, Environment::configDir());
+    });
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/core/EnvironmentTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnvironmentTest.class.php
@@ -3,7 +3,9 @@
 use lang\Environment;
 use lang\IllegalArgumentException;
 use lang\IllegalStateException;
+use net\xp_framework\unittest\IgnoredOnHHVM;
 
+#[@action(new IgnoredOnHHVM())]
 class EnvironmentTest extends \unittest\TestCase {
 
   #[@test]


### PR DESCRIPTION
This pull request adds a new `lang.Environment` class with implements access to environment variables and settings depending on the environment in a OS-independent matter. Supports Cygwin on Windows and [XDG](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on Unix.

## API

```php
public abstract class lang.Environment {
  public static [:string] variables(string|string[] $filter)
  public static string variable(string|string[] $arg, var... $default)
  public static void export([:string] $variables)
  public static string tempDir()
  public static string homeDir()
  public static string configDir(string $named)
  public static string trustedCertificates(string $default)
}
```

## System class deprecation

The `lang.System` class can now be considered deprecated. **It will be removed in XP 8.0.**

## Consistent SSL

The `trustedCertificates()` method implements xp-framework/core#150