### PR TITLE
Implement iterable type

### DIFF
--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -8,10 +8,7 @@
  * @test   xp://net.xp_framework.unittest.reflection.TypeTest 
  */
 class Type extends Object {
-  public static $VAR;
-  public static $VOID;
-  public static $ARRAY;
-  public static $CALLABLE;
+  public static $VAR, $VOID, $ARRAY, $CALLABLE, $ITERABLE;
   public $name;
   public $default;
 
@@ -48,6 +45,22 @@ class Type extends Object {
         return $type instanceof self || $type instanceof FunctionType;
       }
     } return new NativeCallableType("callable", null);');
+
+    self::$ITERABLE= eval('namespace lang; class NativeIterableType extends Type {
+      static function __static() { }
+      public function isInstance($value) { return $value instanceof \Traversable || is_array($value); }
+      public function newInstance($value= null) {
+        if ($value instanceof \Traversable || is_array($value)) return $value;
+        throw new IllegalAccessException("Cannot instantiate iterable type from ".\xp::typeOf($value));
+      }
+      public function cast($value) {
+        if (null === $value || $value instanceof \Traversable || is_array($value)) return $value;
+        throw new ClassCastException("Cannot cast ".\xp::typeOf($value)." to the iterable type");
+      }
+      public function isAssignableFrom($type) {
+        return $type instanceof self;
+      }
+    } return new NativeIterableType("callable", null);');
   }
 
   /**
@@ -166,6 +179,8 @@ class Type extends Object {
       return self::$ARRAY;
     } else if ('callable' === $type) {
       return self::$CALLABLE;
+    } else if ('iterable' === $type) {
+      return self::$ITERABLE;
     } else if (0 === substr_compare($type, 'function(', 0, 9)) {
       return FunctionType::forName($type);
     } else if (0 === substr_compare($type, '[]', -2)) {

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -56,6 +56,11 @@ class TypeTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function iterableTypeUnion() {
+    $this->assertEquals(Type::$ITERABLE, Type::forName('iterable'));
+  }
+
+  #[@test]
   public function arrayOfString() {
     $this->assertEquals(ArrayType::forName('string[]'), Type::forName('string[]'));
   }
@@ -293,6 +298,11 @@ class TypeTest extends \unittest\TestCase {
     $this->assertEquals(null, Type::$CALLABLE->default);
   }
 
+  #[@test]
+  public function native_iterable_default() {
+    $this->assertEquals(null, Type::$ITERABLE->default);
+  }
+
   #[@test, @values([
   #  [[]],
   #  [[1, 2, 3]],
@@ -333,6 +343,7 @@ class TypeTest extends \unittest\TestCase {
   }
 
   #[@test, @values([
+  #  [null],
   #  [1], [1.5], [true], ['Test'],
   #  [[]],
   #  [[1, 2, 3]],
@@ -370,6 +381,7 @@ class TypeTest extends \unittest\TestCase {
   }
 
   #[@test, @values([
+  #  [null],
   #  ['strlen'],
   #  ['xp::gc'],
   #  [['xp', 'gc']],
@@ -398,5 +410,45 @@ class TypeTest extends \unittest\TestCase {
   #[@test]
   public function callable_type_union_is_not_assignable_from_this() {
     $this->assertFalse(Type::$CALLABLE->isAssignableFrom($this->getClass()));
+  }
+
+  #[@test, @values([
+  #  [[]],
+  #  [[1, 2, 3]],
+  #  [['key' => 'value']],
+  #  [new \ArrayObject(['hello', 'world'])],
+  #  [new \ArrayIterator(['hello', 'world'])]
+  #])]
+  public function iterable_type_union_isInstance($value) {
+    $this->assertTrue(Type::$ITERABLE->isInstance($value));
+  }
+
+  #[@test]
+  public function iterable_type_union_generator_isInstance() {
+    $gen= function() { yield 'Test'; };
+    $this->assertTrue(Type::$ITERABLE->isInstance($gen()));
+  }
+
+  #[@test, @values([
+  #  [[]],
+  #  [[1, 2, 3]],
+  #  [['key' => 'value']],
+  #  [new \ArrayObject(['hello', 'world'])],
+  #  [new \ArrayIterator(['hello', 'world'])]
+  #])]
+  public function iterable_type_union_newInstance($value) {
+    $this->assertEquals($value, Type::$ITERABLE->newInstance($value));
+  }
+
+  #[@test, @values([
+  #  [null],
+  #  [[]],
+  #  [[1, 2, 3]],
+  #  [['key' => 'value']],
+  #  [new \ArrayObject(['hello', 'world'])],
+  #  [new \ArrayIterator(['hello', 'world'])]
+  #])]
+  public function iterable_type_union_cast($value) {
+    $this->assertEquals($value, Type::$ITERABLE->cast($value));
   }
 }


### PR DESCRIPTION
This pull request adds `lang.Type::$ITERABLE` to represent the `iterable` type introduced in PHP 7.1 (see https://wiki.php.net/rfc/iterable). 

*Please note this pull request does not require PHP 7.1 as it does not use `is_iterable()` but reimplements it.*