### PR TITLE
Implement object type union

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -273,6 +273,10 @@ function is($type, $object) {
     return is_bool($object);
   } else if ('var' === $type) {
     return true;
+  } else if ('array' === $type) {
+    return is_array($object);
+  } else if ('object' === $type) {
+    return is_object($object) && !($object instanceof \Closure);
   } else if ('callable' === $type) {
     return is_callable($object);
   } else if ('iterable' === $type) {

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -8,7 +8,7 @@
  * @test   xp://net.xp_framework.unittest.reflection.TypeTest 
  */
 class Type extends Object {
-  public static $VAR, $VOID, $ARRAY, $CALLABLE, $ITERABLE;
+  public static $VAR, $VOID, $ARRAY, $OBJECT, $CALLABLE, $ITERABLE;
   public $name;
   public $default;
 
@@ -29,6 +29,22 @@ class Type extends Object {
         return $type instanceof self || $type instanceof ArrayType || $type instanceof MapType;
       }
     } return new NativeArrayType("array", []);');
+
+    self::$OBJECT= eval('namespace lang; class NativeObjectType extends Type {
+      static function __static() { }
+      public function isInstance($value) { return is_object($value) && !$value instanceof \Closure; }
+      public function newInstance($value= null) {
+        if (is_object($value) && !$value instanceof \Closure) return clone $value;
+        throw new IllegalAccessException("Cannot instantiate ".\xp::typeOf($value));
+      }
+      public function cast($value) {
+        if (null === $value || is_object($value) && !$value instanceof \Closure) return $value;
+        throw new ClassCastException("Cannot cast ".\xp::typeOf($value)." to the object type");
+      }
+      public function isAssignableFrom($type) {
+        return $type instanceof self || $type instanceof XPClass;
+      }
+    } return new NativeObjectType("object", null);');
 
     self::$CALLABLE= eval('namespace lang; class NativeCallableType extends Type {
       static function __static() { }
@@ -177,6 +193,8 @@ class Type extends Object {
       return self::$VOID;
     } else if ('array' === $type) {
       return self::$ARRAY;
+    } else if ('object' === $type) {
+      return self::$OBJECT;
     } else if ('callable' === $type) {
       return self::$CALLABLE;
     } else if ('iterable' === $type) {

--- a/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
@@ -268,6 +268,7 @@ class IsTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [function() { }],
+  #  [function() { yield 'Test'; }],
   #  ['strlen'],
   #  ['xp::gc'],
   #  [['xp', 'gc']],
@@ -286,5 +287,21 @@ class IsTest extends \unittest\TestCase {
   #])]
   public function iterable($val) {
     $this->assertTrue(is('iterable', $val));
+  }
+
+  #[@test, @values([
+  #  [new Object()],
+  #  [new \ArrayObject([])]
+  #])]
+  public function object($val) {
+    $this->assertTrue(is('object', $val));
+  }
+
+  #[@test, @values([
+  #  [function() { }],
+  #  [function() { yield 'Test'; }]
+  #])]
+  public function closures_are_not_objects($val) {
+    $this->assertFalse(is('object', $val));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
@@ -274,8 +274,17 @@ class IsTest extends \unittest\TestCase {
   #  [['xp', 'gc']],
   #  [[new Object(), 'toString']]
   #])]
-  public function callable($val) {
+  public function is_callable($val) {
     $this->assertTrue(is('callable', $val));
+  }
+
+  #[@test, @values([
+  #  [[]],
+  #  [[1, 2, 3]],
+  #  [['key' => 'value']],
+  #])]
+  public function is_array($val) {
+    $this->assertTrue(is('array', $val));
   }
 
   #[@test, @values([
@@ -285,7 +294,7 @@ class IsTest extends \unittest\TestCase {
   #  [new \ArrayObject([])],
   #  [new \ArrayIterator([])]
   #])]
-  public function iterable($val) {
+  public function is_iterable($val) {
     $this->assertTrue(is('iterable', $val));
   }
 
@@ -293,7 +302,7 @@ class IsTest extends \unittest\TestCase {
   #  [new Object()],
   #  [new \ArrayObject([])]
   #])]
-  public function object($val) {
+  public function is_object($val) {
     $this->assertTrue(is('object', $val));
   }
 

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -61,6 +61,11 @@ class TypeTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function objectTypeUnion() {
+    $this->assertEquals(Type::$OBJECT, Type::forName('object'));
+  }
+
+  #[@test]
   public function arrayOfString() {
     $this->assertEquals(ArrayType::forName('string[]'), Type::forName('string[]'));
   }
@@ -450,5 +455,45 @@ class TypeTest extends \unittest\TestCase {
   #])]
   public function iterable_type_union_cast($value) {
     $this->assertEquals($value, Type::$ITERABLE->cast($value));
+  }
+
+  #[@test, @values([
+  #  [new Object()],
+  #  [new \ArrayObject([])],
+  #])]
+  public function object_type_union_isInstance($value) {
+    $this->assertTrue(Type::$OBJECT->isInstance($value));
+  }
+
+  #[@test, @values([
+  #  [null],
+  #  [new Object()],
+  #  [new \ArrayObject([])],
+  #])]
+  public function object_type_union_cast($value) {
+    $this->assertEquals($value, Type::$OBJECT->cast($value));
+  }
+
+  #[@test, @values([
+  #  [new Object()],
+  #  [new \ArrayObject([])],
+  #])]
+  public function object_type_union_newInstance($value) {
+    $this->assertInstanceOf(typeof($value), Type::$OBJECT->newInstance($value));
+  }
+
+  #[@test]
+  public function object_type_union_isAssignableFrom_self() {
+    $this->assertTrue(Type::$OBJECT->isAssignableFrom(Type::$OBJECT));
+  }
+
+  #[@test]
+  public function object_type_union_isAssignableFrom_this_class() {
+    $this->assertTrue(Type::$OBJECT->isAssignableFrom(typeof($this)));
+  }
+
+  #[@test, @values([Primitive::$INT, Type::$VOID, Type::$VAR, new ArrayType('var'), new MapType('var')])]
+  public function object_type_union_is_not_assignable_from($type) {
+    $this->assertFalse(Type::$OBJECT->isAssignableFrom($type));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -459,16 +459,24 @@ class TypeTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  [new Object()],
-  #  [new \ArrayObject([])],
+  #  [new \ArrayObject([])]
   #])]
   public function object_type_union_isInstance($value) {
     $this->assertTrue(Type::$OBJECT->isInstance($value));
   }
 
   #[@test, @values([
+  #  [function() { }],
+  #  [function() { yield 'Test'; }]
+  #])]
+  public function closures_are_not_instances_of_the_object_type_union($value) {
+    $this->assertFalse(Type::$OBJECT->isInstance($value));
+  }
+
+  #[@test, @values([
   #  [null],
   #  [new Object()],
-  #  [new \ArrayObject([])],
+  #  [new \ArrayObject([])]
   #])]
   public function object_type_union_cast($value) {
     $this->assertEquals($value, Type::$OBJECT->cast($value));


### PR DESCRIPTION
## In a nutshell

This pull request extends the XP Framework's type system to include `lang.Type::$OBJECT`. This type union represents any object: Those from the framework, foreign ones as well as PHP builtins, except closures.

### Overview

| Instance | Represents |
|-------------------------- | ------------------------ |
| `lang.Type::$VAR`          | Any type |
| `lang.Type::$VOID`         | No type, see also https://wiki.php.net/rfc/void_return_type |
| `lang.Type::$ARRAY`        | Arrays type union - zero-based or key/value pairs |
| `lang.Type::$CALLABLE`     | See http://php.net/manual/en/language.types.callable.php |
| `lang.Type::$ITERABLE`     | See https://github.com/xp-framework/core/pull/154 |
| `lang.Primitive::$INT`     | integers |
| `lang.Primitive::$DOUBLE`  | floating point numbers |
| `lang.Primitive::$STRING`  | strings |
| `lang.Primitive::$BOOL`    | true or false |
| `new lang.FunctionType`        | See https://github.com/xp-framework/rfc/issues/286 |
| `new lang.ArrayType`           | Zero-based list of values |
| `new lang.MapType`             | Key/value pairs |
| `new lang.XPClass`             | Value types |
| `new lang.TypeUnion`           | See https://github.com/xp-framework/core/pull/76 |
| | |
| `lang.Type::$OBJECT` | ➕ **Object type union** *(this PR)* |

## Example of where this is useful

```php
class Injector {

  /**
   * Creates a new instance of a given class. If the constructor uses
   * injection, the arguments are compiled from the relevant annotations.
   * Otherwise, optional constructor arguments may be passed.
   *
   * @param   lang.XPClass $class
   * @param   [:var] $named Named arguments
   * @return  object
   * @throws  inject.ProvisionException
   */
  public function newInstance(XPClass $class, $named= []) {
    // ...
  }
}
```

Currently, the method's return type hint would need to be `var`. In other situations, generics would be helpful, whereas here, they wouldn't, as the XP Framework doesn't support generic methods.

## TODO

* [x] Create `Type::$OBJECT` and tests
* [x] Add support in `is()` core functionality