### PR TITLE
Refactor date serialization

### DIFF
--- a/src/main/php/util/Date.class.php
+++ b/src/main/php/util/Date.class.php
@@ -8,99 +8,69 @@ use lang\IllegalArgumentException;
  * @test  xp://net.xp_framework.unittest.util.DateTest
  */
 class Date implements \lang\Value {
-  protected $date= null;
-  
-  const
-    DEFAULT_FORMAT    = 'Y-m-d H:i:sO',
-    SERIALIZE_FORMAT  = 'Y-m-d H:i:sO';
+  const DEFAULT_FORMAT= 'Y-m-d H:i:sO';
+
+  /** @type php.DateTime */
+  private $handle;
 
   /**
    * Constructor. Creates a new date object through either a
-   * <ul>
-   *   <li>integer - interpreted as timestamp</li>
-   *   <li>string - parsed into a date</li>
-   *   <li>php.DateTime object - will be used as is</li>
-   *   <li>NULL - creates a date representing the current instance</li>
-   *  </ul>
+   *
+   * - integer - interpreted as timestamp
+   * - string - parsed into a date
+   * - php.DateTime object - will be used as is
+   * - NULL - creates a date representing the current instance
    *
    * Timezone assignment works through these rules:
-   * . If the time is given as string and contains a parseable timezone identifier
+   *
+   * - If the time is given as string and contains a parseable timezone identifier
    *   that one is used.
-   * . If no timezone could be determined, the timezone given by the
+   * - If no timezone could be determined, the timezone given by the
    *   second parameter is used
-   * . If no timezone has been given as second parameter, the system's default
+   * - If no timezone has been given as second parameter, the system's default
    *   timezone is used.
    *
-   * @param   var in default NULL either a string or a Unix timestamp or DateTime object, defaulting to now
-   * @param   string timezone default NULL string of timezone
-   * @throws  lang.IllegalArgumentException in case the date is unparseable
+   * @param  int|string|php.DateTime $in
+   * @param  string $timezone default NULL string of timezone
+   * @throws lang.IllegalArgumentException in case the date is unparseable
    */
   public function __construct($in= null, TimeZone $timezone= null) {
     if ($in instanceof \DateTime) {
-      $this->date= $in;
+      $this->handle= $in;
     } else if ((string)(int)$in === (string)$in) {
       
       // Specially mark timestamps for parsing (we assume here that strings
       // containing only digits are timestamps)
-      $this->date= date_create('@'.$in, timezone_open('UTC'));
-      date_timezone_set($this->date, $timezone ? $timezone->getHandle() : timezone_open(date_default_timezone_get()));
+      $this->handle= date_create('@'.$in, timezone_open('UTC'));
+      date_timezone_set($this->handle, $timezone ? $timezone->getHandle() : timezone_open(date_default_timezone_get()));
     } else {
       try {
-        $this->date= $timezone ? new \DateTime($in, $timezone->getHandle()) : new \DateTime($in);
+        $this->handle= $timezone ? new \DateTime($in, $timezone->getHandle()) : new \DateTime($in);
       } catch (\Throwable $e) {
         throw new IllegalArgumentException('Given argument is neither a timestamp nor a well-formed timestring: '.\xp::stringOf($in));
       }
     }
   }
 
-  /**
-   * Returns a hashcode for this object
-   *
-   * @return  string
-   */
-  public function hashCode() {
-    return (string)$this->date->format('U');
+  /** Returns a hashcode for this object */
+  public function hashCode(): string {
+    return $this->handle->format('U');
   }
 
-  /**
-   * Retrieve handle of underlying DateTime object.
-   *
-   * @return  php.DateTime
-   */
-  public function getHandle() {
-    return clone $this->date;
+  /** Retrieve handle of underlying DateTime object. */
+  public function getHandle(): \DateTime {
+    return clone $this->handle;
   }
   
-  /**
-   * Sleep method.
-   *
-   * @return  string[]
-   */
+  /** @return string[] */
   public function __sleep() {
-    $this->value= date_format($this->date, self::SERIALIZE_FORMAT);
+    $this->value= date_format($this->handle, self::DEFAULT_FORMAT);
     return ['value'];
   }
   
-  /**
-   * Wakup method - reconstructs object after deserialization.
-   *
-   */
+  /** @return void */
   public function __wakeup() {
-    
-    // First check for new serialization format
-    if (isset($this->value)) {
-      $this->date= date_create($this->value);
-      return;
-    }
-
-    // Check for legacy serialization format
-    if (isset($this->_utime)) {
-      $this->date= date_create('@'.$this->_utime);
-      unset($this->_utime, $this->seconds, $this->minutes, $this->hours, $this->mday,
-        $this->wday, $this->mon, $this->year, $this->yday, $this->weekday, $this->month
-      );
-      return;
-    }
+    $this->handle= date_create_from_format(self::DEFAULT_FORMAT, $this->value);
   }
   
   /**
@@ -108,16 +78,16 @@ class Date implements \lang\Value {
    * the date will be set into that zone - defaulting to the system's
    * default timezone of none is given.
    *
-   * @param   int year
-   * @param   int month
-   * @param   int day
-   * @param   int hour
-   * @param   int minute
-   * @param   int second
-   * @param   util.TimeZone tz default NULL
-   * @return  util.Date
+   * @param  int $year
+   * @param  int $month
+   * @param  int $day
+   * @param  int $hour
+   * @param  int $minute
+   * @param  int $second
+   * @param  util.TimeZone $tz default NULL
+   * @return self
    */
-  public static function create($year, $month, $day, $hour, $minute, $second, TimeZone $tz= null) {
+  public static function create($year, $month, $day, $hour, $minute, $second, TimeZone $tz= null): self {
     $date= date_create();
     if ($tz) {
       date_timezone_set($date, $tz->getHandle());
@@ -140,176 +110,79 @@ class Date implements \lang\Value {
     return new self($date);
   }
   
-  /**
-   * Indicates whether the date to compare equals this date.
-   *
-   * @param   util.Date cmp
-   * @return  bool TRUE if dates are equal
-   */
-  public function equals($cmp) {
-    return ($cmp instanceof self) && ($this->getTime() === $cmp->getTime());
+  /** Indicates whether another values equals this date. */
+  public function equals($cmp): bool {
+    return $cmp instanceof self && $this->getTime() === $cmp->getTime();
   }
   
-  /**
-   * Static method to get current date/time
-   *
-   * @param   util.TimeZone tz default NULL
-   * @return  util.Date
-   */
-  public static function now(TimeZone $tz= null) {
+  /** Static method to get current date/time */
+  public static function now(TimeZone $tz= null): self {
     return new self(null, $tz);
   }
   
-  /**
-   * Compare this date to another date
-   *
-   * @param   var $cmp
-   * @return  int equal: 0, date before $this: less than 0, date after $this: greater than zero
-   */
-  public function compareTo($cmp) {
+  /** Compare this date to another date */
+  public function compareTo($cmp): int {
     return $cmp instanceof self ? $cmp->getTime() - $this->getTime() : -1;
   }
   
-  /**
-   * Checks whether this date is before a given date
-   *
-   * @param   util.Date date
-   * @return  bool
-   */
-  public function isBefore(Date $date) {
+  /** Checks whether this date is before a given date */
+  public function isBefore(Date $date): bool {
     return $this->getTime() < $date->getTime();
   }
 
-  /**
-   * Checks whether this date is after a given date
-   *
-   * @param   util.Date date
-   * @return  bool
-   */
-  public function isAfter(Date $date) {
+  /** Checks whether this date is after a given date */
+  public function isAfter(Date $date): bool {
     return $this->getTime() > $date->getTime();
   }
   
-  /**
-   * Retrieve Unix-Timestamp for this date
-   *
-   * @return  int Unix-Timestamp
-   */
-  public function getTime() {
-    return (int)$this->date->format('U');
-  }
+  /** Retrieve Unix-Timestamp for this date */
+  public function getTime(): int { return date_timestamp_get($this->handle); }
 
-  /**
-   * Get seconds
-   *
-   * @return  int
-   */
-  public function getSeconds() {
-    return (int)$this->date->format('s');
-  }
+  /** Get seconds */
+  public function getSeconds(): int { return $this->handle->format('s'); }
 
-  /**
-   * Get minutes
-   *
-   * @return  int
-   */
-  public function getMinutes() {
-    return (int)$this->date->format('i');
-  }
+  /** Get minutes */
+  public function getMinutes(): int { return $this->handle->format('i'); }
 
-  /**
-   * Get hours
-   *
-   * @return  int
-   */
-  public function getHours() {
-    return (int)$this->date->format('G');
-  }
+  /** Get hours */
+  public function getHours(): int { return $this->handle->format('G'); }
 
-  /**
-   * Get day
-   *
-   * @return  int
-   */
-  public function getDay() {
-    return (int)$this->date->format('d');
-  }
+  /** Get day */
+  public function getDay(): int { return $this->handle->format('d'); }
 
-  /**
-   * Get month
-   *
-   * @return  int
-   */
-  public function getMonth() {
-    return (int)$this->date->format('m');
-  }
+  /** Get month */
+  public function getMonth(): int { return $this->handle->format('m'); }
 
-  /**
-   * Get year
-   *
-   * @return  int
-   */
-  public function getYear() {
-    return (int)$this->date->format('Y');
-  }
+  /** Get year */
+  public function getYear(): int { return $this->handle->format('Y'); }
 
-  /**
-   * Get day of year
-   *
-   * @return  int
-   */
-  public function getDayOfYear() {
-    return (int)$this->date->format('z');
-  }
+  /** Get day of year */
+  public function getDayOfYear(): int { return $this->handle->format('z'); }
 
-  /**
-   * Get day of week
-   *
-   * @return  int
-   */
-  public function getDayOfWeek() {
-    return (int)$this->date->format('w');
-  }
+  /** Get day of week */
+  public function getDayOfWeek(): int { return $this->handle->format('w'); }
   
-  /**
-   * Get timezone offset to UTC in "+MMSS" notation
-   *
-   * @return  string
-   */
-  public function getOffset() {
-    return $this->date->format('O');
-  }
+  /** Get timezone offset to UTC in "+MMSS" notation */
+  public function getOffset(): string { return $this->handle->format('O'); }
   
-  /**
-   * Get timezone offset to UTC in seconds
-   *
-   * @return  int
-   */
-  public function getOffsetInSeconds() {
-    return (int)$this->date->format('Z');
-  }
+  /** Get timezone offset to UTC in seconds */
+  public function getOffsetInSeconds(): int { return date_offset_get($this->handle); }
   
-  /**
-   * Retrieve timezone object associated with this date
-   *
-   * @return  util.TimeZone
-   */
-  public function getTimeZone() {
-    return new TimeZone(date_timezone_get($this->date));
+  /** Retrieve timezone object associated with this date */
+  public function getTimeZone(): Timezone {
+    return new TimeZone(date_timezone_get($this->handle));
   }
   
   /**
    * Create a string representation
    *
-   * @see     php://date
-   * @param   string format default Date::DEFAULT_FORMAT format-string
-   * @param   util.TimeZone outtz default NULL
-   * @return  string the formatted date
+   * @see    php://date
+   * @param  string $format default Date::DEFAULT_FORMAT format-string
+   * @param  util.TimeZone $outtz default NULL
+   * @return string the formatted date
    */
-  public function toString($format= self::DEFAULT_FORMAT, TimeZone $outtz= null) {
-    if (null === $outtz) return date_format($this->date, $format);
-
-    return date_format($outtz->translate($this)->date, $format);
+  public function toString(string $format= self::DEFAULT_FORMAT, TimeZone $outtz= null): string {
+    return date_format(($outtz === null ? $this : $outtz->translate($this))->handle, $format);
   }
   
   /**
@@ -318,67 +191,47 @@ class Date implements \lang\Value {
    * These format tokens are not supported intentionally:
    * %a, %A, %b, %B, %c, %h, %p, %U, %x, %X
    *
-   * @see     php://strftime
-   * @param   string format
-   * @param   util.TimeZone outtz default NULL
-   * @return  string
-   * @throws  lang.IllegalArgumentException if unsupported token has been given
+   * @see    php://strftime
+   * @param  string $format
+   * @param  util.TimeZone $outtz default NULL
+   * @return string
+   * @throws lang.IllegalArgumentException if unsupported token has been given
    */
-  public function format($format, TimeZone $outtz= null) {
-    return preg_replace_callback(
-      '#%([a-zA-Z%])#', 
-      [($outtz === null ? $this : $outtz->translate($this)), 'formatCallback'], $format
-    );
-  }
-  
-  /**
-   * Format callback function.
-   *
-   * @param   string[] matches
-   * @return  string
-   * @throws  lang.IllegalArgumentException if unsupported token has been given
-   */
-  protected function formatCallback($matches) {
-    static $rep= ['t' => "\t", 'n' => "\n", '%' => '%'];
-    static $map= [
-      'd' => 'd',
-      'm' => 'm',
-      'Y' => 'Y',
-      'H' => 'H',
-      'S' => 's',
-      'w' => 'w',
-      'G' => 'o',
-      'D' => 'm/d/Y',
-      'T' => 'H:i:s',
-      'z' => 'O',
-      'Z' => 'e',
-      'G' => 'o',
-      'V' => 'W',
-      'C' => 'y',
-      'e' => 'j',
-      'G' => 'o',
-      'H' => 'H',
-      'I' => 'h',
-      'j' => 'z',
-      'M' => 'i',
-      'r' => 'h:i:sa',
-      'R' => 'H:i:s',
-      'u' => 'N',
-      'V' => 'W',
-      'W' => 'W',
-      'w' => 'w',
-      'y' => 'y',
-      'Z' => 'O'
+  public function format(string $format, TimeZone $outtz= null): string {
+    static $replace= [
+      '%d' => 'd',
+      '%m' => 'm',
+      '%Y' => 'Y',
+      '%H' => 'H',
+      '%S' => 's',
+      '%w' => 'w',
+      '%G' => 'o',
+      '%D' => 'm/d/Y',
+      '%T' => 'H:i:s',
+      '%z' => 'O',
+      '%Z' => 'e',
+      '%G' => 'o',
+      '%V' => 'W',
+      '%C' => 'y',
+      '%e' => 'j',
+      '%G' => 'o',
+      '%H' => 'H',
+      '%I' => 'h',
+      '%j' => 'z',
+      '%M' => 'i',
+      '%r' => 'h:i:sa',
+      '%R' => 'H:i:s',
+      '%u' => 'N',
+      '%V' => 'W',
+      '%W' => 'W',
+      '%w' => 'w',
+      '%y' => 'y',
+      '%Z' => 'O',
+      '%t' => "\t",
+      '%n' => "\n",
+      '%%' => '%'
     ];
-    
-    if (isset($map[$matches[1]])) return date_format($this->date, $map[$matches[1]]);
-    if (isset($rep[$matches[1]])) return $rep[$matches[1]];
-    
-    // Other tokens that are actually supported by strftime() have been
-    // left out intentionally, because either they are
-    // a) hard to implement and never / seldom used in the framework
-    // b) locale-dependent, this should not be supported in any
-    //    way by the framework.
-    throw new IllegalArgumentException('Illegal date format token: "'.$matches[1].'"');
+
+    return date_format(($outtz === null ? $this : $outtz->translate($this))->handle, strtr($format, $replace));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
@@ -201,18 +201,6 @@ class DateTest extends \unittest\TestCase {
   }
   
   #[@test]
-  public function serializationOfLegacyDates() {
-    $serialized= 'O:9:"util\Date":12:{s:6:"_utime";i:1185310311;s:7:"seconds";i:51;s:7:"minutes";i:51;s:5:"hours";i:22;s:4:"mday";i:24;s:4:"wday";i:2;s:3:"mon";i:7;s:4:"year";i:2007;s:4:"yday";i:204;s:7:"weekday";s:7:"Tuesday";s:5:"month";s:4:"July";s:4:"__id";N;}';
-
-    $date= unserialize($serialized);
-    $this->assertDateEquals('2007-07-24T20:51:51+00:00', $date);
-
-    // Only __id may be set, all the other "old" public members 
-    // should have been removed here
-    $this->assertEquals(['__id' => null], get_object_vars($date));
-  }
-
-  #[@test]
   public function handlingOfTimezone() {
     $date= new Date('2007-07-18T09:42:08 Europe/Athens');
 
@@ -259,9 +247,9 @@ class DateTest extends \unittest\TestCase {
     $this->assertEquals($expect, $this->refDate->format($input));
   }
   
-  #[@test, @expect(IllegalArgumentException::class)]
+  #[@test]
   public function unsupportedFormatToken() {
-    $this->refDate->format('%b');
+    $this->assertEquals('%b', $this->refDate->format('%b'));
   }
   
   #[@test]


### PR DESCRIPTION
* Removes legacy serialization (*has been deprecated since October 2011, see xp-framework/rfc#115*)
* Speeds up format() by replacing `preg_replace_callback` and helper method with `strtr`
* Uses new XP8 syntax (including [compact apidoc](https://github.com/xp-framework/rfc/issues/310#issuecomment-242978257))