### PR TITLE
Refactor Properties I/O

### DIFF
--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -38,13 +38,14 @@ class Properties extends \lang\Object implements PropertyAccess {
   /**
    * Load from an input stream, e.g. a file
    *
-   * @param   io.streams.InputStream $in
+   * @param   io.streams.InputStream|io.Channel|string $in
    * @param   string $charset the charset the stream is encoded in or NULL to trigger autodetection by BOM
    * @param   util.PropertyExpansion $expansion
+   * @return  self
    * @throws  io.IOException
    * @throws  lang.FormatException
    */
-  public function load(InputStream $in, $charset= null, $expansion= null) {
+  public function load($in, $charset= null, $expansion= null): self {
     $reader= new TextReader($in, $charset);
     $expansion || $expansion= new PropertyExpansion();
     $this->_data= [];
@@ -102,6 +103,7 @@ class Properties extends \lang\Object implements PropertyAccess {
         throw new FormatException('Invalid line "'.$t.'"');
       }
     }
+    return $this;
   }
 
   /**
@@ -141,33 +143,6 @@ class Properties extends \lang\Object implements PropertyAccess {
       $out->write("\n");
     }
   }
-  
-  /**
-   * Create a property file from an io.File object
-   *
-   * @deprecated  Use load() method instead
-   * @param   io.File file
-   * @return  util.Properties
-   * @throws  io.IOException in case the file given does not exist
-   */
-  public static function fromFile(File $file) {
-    $self= new self($file->getURI());
-    $self->load($file->getInputStream());
-    return $self;
-  }
-
-  /**
-   * Create a property file from a string
-   *
-   * @deprecated  Use load() method instead
-   * @param   string str
-   * @return  util.Properties
-   */
-  public static function fromString($str) {
-    $self= new self(null);
-    $self->load(new MemoryInputStream($str));
-    return $self;
-  }
 
   /** Retrieves the file name containing the properties */
   public function getFilename() { return $this->_file; }
@@ -196,32 +171,21 @@ class Properties extends \lang\Object implements PropertyAccess {
    * @param   bool force default FALSE
    * @throws  io.IOException
    */
-  protected function _load($force= false) {
-    if (!$force && null !== $this->_data) return;
-    $this->load(new FileInputStream($this->_file));
+  private function _load($force= false) {
+    if ($force || null === $this->_data) {
+      $this->load(new FileInputStream($this->_file));
+    }
   }
   
   /**
    * Reload all data from the file
    *
-   * @return return void
+   * @return void
    */
   public function reset() {
     $this->_load(true);
   }
   
-  /**
-   * Save properties to the file
-   *
-   * @deprecated  Use store() method instead
-   * @throws  io.IOException if the property file could not be written
-   */
-  public function save() {
-    $fd= new File($this->_file);
-    $this->store($fd->getOutputStream());
-    $fd->close();
-  }
-
   /**
    * Get the first configuration section
    *

--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -185,10 +185,18 @@ class Properties extends \lang\Object implements PropertyAccess {
   public function reset() {
     $this->_load(true);
   }
+
+  /** Returns sections */
+  public function sections(): \Iterator {
+    foreach ($this->_data as $section => $_) {
+      yield $section;
+    }
+  }
   
   /**
    * Get the first configuration section
    *
+   * @deprecated Use sections() iterator instead
    * @see     xp://util.Properties#getNextSection
    * @return  string the first section's name
    */
@@ -208,6 +216,7 @@ class Properties extends \lang\Object implements PropertyAccess {
    *   } while ($section= $prop->getNextSection());
    * </code>
    *
+   * @deprecated Use sections() iterator instead
    * @see     xp://util.Properties#getFirstSection
    * @return  var string section or FALSE if this was the last section
    */

--- a/src/test/config/unittest/util.ini
+++ b/src/test/config/unittest/util.ini
@@ -12,6 +12,9 @@ class="net.xp_framework.unittest.util.FileBasedPropertiesTest"
 [properties:fromstring]
 class="net.xp_framework.unittest.util.StringBasedPropertiesTest"
 
+[properties:fromstream]
+class="net.xp_framework.unittest.util.StreamBasedPropertiesTest"
+
 [properties:fromresource]
 class="net.xp_framework.unittest.util.ResourcePropertySourceTest"
 

--- a/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
@@ -13,13 +13,8 @@ use lang\ElementNotFoundException;
  */
 abstract class AbstractPropertiesTest extends \unittest\TestCase {
 
-  /**
-   * Create a new properties object from a string source
-   *
-   * @param   string $source
-   * @return  util.Properties
-   */
-  protected abstract function newPropertiesFrom($source);
+  /** Create a new properties object from a string source */
+  protected abstract function newPropertiesFrom(string $source): Properties;
 
   /**
    * Gets a fixture
@@ -258,7 +253,7 @@ abstract class AbstractPropertiesTest extends \unittest\TestCase {
   #  ["[section\nfoo=bar", 'section missing closing bracket']
   #])]
   public function malformed_property_file($source) {
-    $this->newPropertiesFrom($source);
+    $this->newPropertiesFrom($source)->reset();
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
@@ -253,7 +253,7 @@ abstract class AbstractPropertiesTest extends \unittest\TestCase {
   #  ["[section\nfoo=bar", 'section missing closing bracket']
   #])]
   public function malformed_property_file($source) {
-    $this->newPropertiesFrom($source)->reset();
+    $this->newPropertiesFrom($source);
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
@@ -226,6 +226,7 @@ abstract class AbstractPropertiesTest extends \unittest\TestCase {
     $this->assertFalse($this->fixture('')->hasSection('nonexistant'));
   }
 
+  /** @deprecated */
   #[@test]
   public function iterate_sections_with_first_and_next() {
     $p= $this->newPropertiesFrom('
@@ -245,6 +246,24 @@ abstract class AbstractPropertiesTest extends \unittest\TestCase {
     $this->assertEquals('next', $p->getNextSection());
     $this->assertEquals('empty', $p->getNextSection());     
     $this->assertEquals('final', $p->getNextSection());
+  }
+
+  #[@test]
+  public function iterate_sections() {
+    $p= $this->newPropertiesFrom('
+      [section]
+      foo=bar
+
+      [next]
+      foo=bar
+
+      [empty]
+
+      [final]
+      foo=bar
+    ');
+    
+    $this->assertEquals(['section', 'next', 'empty', 'final'], iterator_to_array($p->sections()));
   }
 
   #[@test, @expect(FormatException::class), @values([

--- a/src/test/php/net/xp_framework/unittest/util/CompositePropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/CompositePropertiesTest.class.php
@@ -44,7 +44,7 @@ class CompositePropertiesTest extends \unittest\TestCase {
     $c= new CompositeProperties([new Properties(null)]);
     $this->assertEquals(1, $c->length());
 
-    $c->add(Properties::fromString('[section]'));
+    $c->add(new Properties('a.ini'));
     $this->assertEquals(2, $c->length());
   }
 
@@ -60,19 +60,15 @@ class CompositePropertiesTest extends \unittest\TestCase {
 
   #[@test]
   public function addingEqualPropertiesIsIdempotent() {
-    $c= new CompositeProperties([Properties::fromString('[section]
-a=b
-b=c')]);
+    $c= new CompositeProperties([(new Properties())->load("[section]\na=b\nb=c")]);
     $this->assertEquals(1, $c->length());
 
-    $c->add(Properties::fromString('[section]
-a=b
-b=c'));
+    $c->add((new Properties())->load("[section]\na=b\nb=c"));
     $this->assertEquals(1, $c->length());
   }
 
   protected function fixture() {
-    return new CompositeProperties([Properties::fromString('[section]
+    return new CompositeProperties([(new Properties())->load('[section]
 str="string..."
 b1=true
 arr1="foo|bar"
@@ -84,7 +80,7 @@ range1=1..3
 
 [read]
 key=value'),
-      Properties::fromString('[section]
+      (new Properties())->load('[section]
 str="Another thing"
 str2="Another thing"
 b1=false
@@ -346,7 +342,7 @@ anotherkey="is there, too"
   #[@test]
   public function addingToCompositeResetsIterationPointer() {
     $fixture= $this->getThirdSection();
-    $fixture->add(Properties::fromString('[unknown]'));
+    $fixture->add(new Properties());
 
     $this->assertEquals(null, $fixture->getNextSection());
   }

--- a/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
@@ -11,17 +11,13 @@ use util\Properties;
  * @test  xp://net.xp_framework.unittest.util.FilesystemPropertySourceTest
  */
 class FileBasedPropertiesTest extends AbstractPropertiesTest {
-  private static $files= [];
 
   /** Create a new properties object from a string source */
   protected function newPropertiesFrom(string $source): Properties {
-    if (!isset(self::$files[$source])) {
-      $t= new TempFile();
-      $t->out()->write($source);
-      $t->close();
-      self::$files[$source]= $t;
-    }
-    return (new Properties())->load(self::$files[$source]);
+    $t= new TempFile();
+    $t->out()->write($source);
+    $t->close();
+    return (new Properties())->load($t);
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FileBasedPropertiesTest.class.php
@@ -14,9 +14,11 @@ class FileBasedPropertiesTest extends AbstractPropertiesTest {
 
   /** Create a new properties object from a string source */
   protected function newPropertiesFrom(string $source): Properties {
-    $t= new TempFile();
-    $t->out()->write($source);
-    $t->close();
+    with ($t= new TempFile()); {
+      $t->out()->write($source);
+      $t->close();
+    }
+
     return (new Properties())->load($t);
   }
 

--- a/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
@@ -65,7 +65,7 @@ class PropertyManagerTest extends \unittest\TestCase {
   public function registerProperties() {
     $fixture= $this->fixture();
     $this->assertFalse($fixture->hasProperties('props'));
-    $fixture->register('props', Properties::fromString('[section]'));
+    $fixture->register('props', (new Properties())->load('[section]'));
     
     $this->assertTrue($fixture->hasProperties('props'));
   }
@@ -92,7 +92,7 @@ class PropertyManagerTest extends \unittest\TestCase {
   #[@test]
   public function registerOverwritesExistingProperties() {
     $fixture= $this->preconfigured();
-    $fixture->register('example', Properties::fromString('[any-section]'));
+    $fixture->register('example', (new Properties())->load('[any-section]'));
     $this->assertEquals('any-section', $fixture->getProperties('example')->getFirstSection());
   }
 
@@ -180,7 +180,7 @@ class PropertyManagerTest extends \unittest\TestCase {
     $fixture= $this->preconfigured();
 
     // Register new Properties, with some value in existing section
-    $fixture->register('example', Properties::fromString('[section]
+    $fixture->register('example', (new Properties())->load('[section]
 dynamic-value=whatever'));
 
     $prop= $fixture->getProperties('example');
@@ -200,7 +200,7 @@ dynamic-value=whatever'));
 
     $this->assertEquals('value', $fixture->getProperties('example')->readString('section', 'key'));
 
-    $fixture->register('example', Properties::fromString('[section]
+    $fixture->register('example', (new Properties())->load('[section]
 key="overwritten value"'));
     $this->assertEquals('overwritten value', $fixture->getProperties('example')->readString('section', 'key'));
   }

--- a/src/test/php/net/xp_framework/unittest/util/StreamBasedPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/StreamBasedPropertiesTest.class.php
@@ -1,14 +1,14 @@
 <?php namespace net\xp_framework\unittest\util;
 
 use util\Properties;
+use io\streams\MemoryInputStream;
 
 /**
  * Testcase for util.Properties class.
  *
  * @see   xp://net.xp_framework.unittest.util.AbstractPropertiesTest
- * @see   xp://util.Properties#fromString
  */
-class StringBasedPropertiesTest extends AbstractPropertiesTest {
+class StreamBasedPropertiesTest extends AbstractPropertiesTest {
 
   /**
    * Create a new properties object from a string source
@@ -17,6 +17,6 @@ class StringBasedPropertiesTest extends AbstractPropertiesTest {
    * @return  util.Properties
    */
   protected function newPropertiesFrom(string $source): Properties {
-    return (new Properties())->load($source);
+    return (new Properties())->load(new MemoryInputStream($source));
   }
 }


### PR DESCRIPTION
* [x] Remove deprecated `fromString()`, `fromFile()` and `save()` methods
* [x] Created fluent interface to load properties via `(new Properties())->load($input)`
* [x] Changed `load()` to also accept strings and io.Channel (e.g. a File) instances.
* [x] Deprecate getFirstSection() / getNextSection() in favor of `sections()` iterator