### PR TITLE
Make adding property file expansions easy to use

### DIFF
--- a/src/main/php/util/PropertyExpansion.class.php
+++ b/src/main/php/util/PropertyExpansion.class.php
@@ -8,32 +8,28 @@ use lang\FormatException;
  *
  * @see  xp://util.Properties
  */
-class PropertyExpansion extends \lang\Enum {
-  protected $impl= [];
-
-  /**
-   * Creates an instance 
-   */
-  public function __construct() {
-    $this->impl['env']= function($name, $default= null) {
-      if (false === ($value= getenv($name))) {
-        if (null === ($value= $default)) {
-          throw new ElementNotFoundException('Environment variable "'.$name.'" doesn\'t exist');
-        }
-      }
-      return $value;
-    };
-  }
+class PropertyExpansion {
+  private $impl= [];
 
   /**
    * Register an expansion implementation
    *
-   * @param  string $name
-   * @param  function(string, string: string) $impl
+   * @param  string $kind
+   * @param  function(string, string: string) $func
    * @return self
    */
-  public function expand($name, $impl) {
-    $this->impl[$name]= $impl;
+  public function expand($kind, callable $func) {
+    $this->impl[$kind]= function($name, $default= null) use($kind, $func) {
+      $expanded= $func($name);
+      if (false === $expanded || null === $expanded) {
+        if (null === $default) {
+          throw new ElementNotFoundException('Cannot expand '.$kind.' '.$name);
+        }
+        return $default;
+      } else {
+        return $expanded;
+      }
+    };
     return $this;
   }
 

--- a/src/main/php/util/RegisteredPropertySource.class.php
+++ b/src/main/php/util/RegisteredPropertySource.class.php
@@ -28,7 +28,7 @@ class RegisteredPropertySource extends \lang\Object implements PropertySource {
    * @return  bool
    */
   public function provides($name) {
-    return $name == $this->name;
+    return $name === $this->name;
   }
 
   /**
@@ -38,7 +38,7 @@ class RegisteredPropertySource extends \lang\Object implements PropertySource {
    * @return  util.PropertyAccess
    */
   public function fetch($name) {
-    if (!$name == $this->name)
+    if ($name !== $this->name)
       throw new \lang\IllegalArgumentException('Access to property source under wrong name "'.$name.'"');
 
     return $this->prop;
@@ -50,7 +50,7 @@ class RegisteredPropertySource extends \lang\Object implements PropertySource {
    * @return  string
    */
   public function hashCode() {
-    return md5($this->name.serialize($this->prop));
+    return md5($this->name.$this->prop->hashCode());
   }
 
   /**

--- a/src/test/config/unittest/util.ini
+++ b/src/test/config/unittest/util.ini
@@ -27,6 +27,9 @@ class="net.xp_framework.unittest.util.PropertyWritingTest"
 [propertymanager]
 class="net.xp_framework.unittest.util.PropertyManagerTest"
 
+[propertyexpansion]
+class="net.xp_framework.unittest.util.PropertyExpansionTest"
+
 [compositeproperties]
 class="net.xp_framework.unittest.util.CompositePropertiesTest"
 

--- a/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
@@ -382,7 +382,7 @@ abstract class AbstractPropertiesTest extends \unittest\TestCase {
   }
 
   #[@test, @expect(ElementNotFoundException::class)]
-  public function resolve_non_existant_senvironment_variable() {
+  public function resolve_non_existant_environment_variable() {
     putenv('TEST');
     $this->fixture('test=${env.TEST}');
   }

--- a/src/test/php/net/xp_framework/unittest/util/PropertyExpansionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/PropertyExpansionTest.class.php
@@ -1,0 +1,54 @@
+<?php namespace net\xp_framework\unittest\util;
+
+use util\Properties;
+use lang\ElementNotFoundException;
+
+class PropertyExpansionTest extends \unittest\TestCase {
+
+  /**
+   * Returns a fixture which expands `lookup.*` with a given expansion
+   *
+   * @param  [:var]|function(string): string $expansion
+   * @return util.Properties
+   */
+  private function newFixture($expansion) {
+    return (new Properties())
+      ->expanding('lookup', $expansion)
+      ->load("[section]\n".'test=${lookup.TEST}')
+    ;
+  }
+
+  #[@test]
+  public function closure_lookup() {
+    $prop= $this->newFixture(function($name) { return strtolower($name); });
+    $this->assertEquals('test', $prop->readString('section', 'test'));
+  }
+
+  #[@test]
+  public function callable_lookup() {
+    $prop= $this->newFixture('strtolower');
+    $this->assertEquals('test', $prop->readString('section', 'test'));
+  }
+
+  #[@test]
+  public function map_lookup() {
+    $prop= $this->newFixture(['TEST' => 'test']);
+    $this->assertEquals('test', $prop->readString('section', 'test'));
+  }
+
+  #[@test]
+  public function arrayaccess_lookup() {
+    $prop= $this->newFixture(newinstance(\ArrayAccess::class, [], [
+      'offsetExists' => function($key) { return true; },
+      'offsetGet'    => function($key) { return 'test'; },
+      'offsetSet'    => function($key, $value) { /* Not implemented */ },
+      'offsetUnset'  => function($key) { /* Not implemented */ }
+    ]));
+    $this->assertEquals('test', $prop->readString('section', 'test'));
+  }
+
+  #[@test, @expect(ElementNotFoundException::class), @values([null, false])]
+  public function non_existant_lookup($return) {
+    $this->newFixture(function($name) use($return) { return $return; })->readString('section', 'test');
+  }
+}


### PR DESCRIPTION
Instead of an optional expansion parameter to load() - which is usually not called directly but by means of lazy loading - add an expanding() instance method to util.Properties