### PR TITLE
Make adding property file expansions easy to use

### DIFF
--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -10,6 +10,7 @@ use io\streams\FileInputStream;
 use io\streams\TextReader;
 use lang\FormatException;
 use lang\IllegalStateException;
+use lang\ElementNotFoundException;
 
 /**
  * An interface to property-files (aka "ini-files")
@@ -33,17 +34,41 @@ use lang\IllegalStateException;
  * @see     php://parse_ini_file
  */
 class Properties extends \lang\Object implements PropertyAccess {
-  public
-    $_file    = '',
-    $_data    = null;
+  private static $env;
+  public $_file, $_data;
+  private $expansion= null;
+
+  static function __static() {
+    self::$env= (new PropertyExpansion())->expand('env', 'getenv');
+  }
 
   /**
-   * Creates a new properties instance from a given file
+   * Constructor
    *
-   * @param   string filename
+   * @param  string $filename
    */
   public function __construct($filename= null) {
     $this->_file= $filename;
+  }
+
+  /**
+   * Add expansion `${kind.X}` with a given expansion function `f(X)`
+   *
+   * @param  string $kind
+   * @param  [:var]|function(string): string $expansion
+   * @return self
+   */
+  public function expanding($kind, $expansion) {
+    $this->expansion= $this->expansion ?: clone self::$env;
+
+    if ($expansion instanceof \ArrayAccess || (is_array($expansion) && 0 !== key($expansion))) {
+      $func= function($name) use($expansion) { return isset($expansion[$name]) ? $expansion[$name] : null; };
+    } else {
+      $func= cast($expansion, 'function(string): string');
+    }
+
+    $this->expansion->expand($kind, $func);
+    return $this;
   }
 
   /**
@@ -51,16 +76,16 @@ class Properties extends \lang\Object implements PropertyAccess {
    *
    * @param   io.streams.InputStream|io.Channel|string $in
    * @param   string $charset the charset the stream is encoded in or NULL to trigger autodetection by BOM
-   * @param   util.PropertyExpansion $expansion
    * @return  self
    * @throws  io.IOException
    * @throws  lang.FormatException
    */
-  public function load($in, $charset= null, $expansion= null) {
+  public function load($in, $charset= null) {
     $reader= new TextReader($in, $charset);
-    $expansion || $expansion= new PropertyExpansion();
+    $expansion= $this->expansion ?: self::$env;
     $this->_data= [];
     $section= null;
+
     while (null !== ($t= $reader->readLine())) {
       $trimmedToken= trim($t);
       if ('' === $trimmedToken) continue;                   // Empty lines
@@ -599,6 +624,11 @@ class Properties extends \lang\Object implements PropertyAccess {
     } else {
       return Objects::equal($this->_data, $cmp->_data);
     }
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return $this->_file.serialize($this->_data);
   }
 
   /**

--- a/src/main/php/util/PropertyExpansion.class.php
+++ b/src/main/php/util/PropertyExpansion.class.php
@@ -12,28 +12,24 @@ class PropertyExpansion {
   private $impl= [];
 
   /**
-   * Creates an instance 
-   */
-  public function __construct() {
-    $this->impl['env']= function($name, $default= null) {
-      if (false === ($value= getenv($name))) {
-        if (null === ($value= $default)) {
-          throw new ElementNotFoundException('Environment variable "'.$name.'" doesn\'t exist');
-        }
-      }
-      return $value;
-    };
-  }
-
-  /**
    * Register an expansion implementation
    *
-   * @param  string $name
-   * @param  function(string, string): string $impl
+   * @param  string $kind
+   * @param  function(string, string): string $func
    * @return self
    */
-  public function expand($name, $impl) {
-    $this->impl[$name]= $impl;
+  public function expand($kind, callable $func) {
+    $this->impl[$kind]= function($name, $default= null) use($kind, $func) {
+      $expanded= $func($name);
+      if (false === $expanded || null === $expanded) {
+        if (null === $default) {
+          throw new ElementNotFoundException('Cannot expand '.$kind.' '.$name);
+        }
+        return $default;
+      } else {
+        return $expanded;
+      }
+    };
     return $this;
   }
 

--- a/src/main/php/util/RegisteredPropertySource.class.php
+++ b/src/main/php/util/RegisteredPropertySource.class.php
@@ -28,7 +28,7 @@ class RegisteredPropertySource extends \lang\Object implements PropertySource {
    * @return bool
    */
   public function provides($name) {
-    return $name === $this->name;
+    return $name == $this->name;
   }
 
   /**

--- a/src/test/config/unittest/util.ini
+++ b/src/test/config/unittest/util.ini
@@ -21,6 +21,9 @@ class="net.xp_framework.unittest.util.PropertyWritingTest"
 [propertymanager]
 class="net.xp_framework.unittest.util.PropertyManagerTest"
 
+[propertyexpansion]
+class="net.xp_framework.unittest.util.PropertyExpansionTest"
+
 [compositeproperties]
 class="net.xp_framework.unittest.util.CompositePropertiesTest"
 

--- a/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
@@ -377,7 +377,7 @@ abstract class AbstractPropertiesTest extends \unittest\TestCase {
   }
 
   #[@test, @expect(ElementNotFoundException::class)]
-  public function resolve_non_existant_senvironment_variable() {
+  public function resolve_non_existant_environment_variable() {
     putenv('TEST');
     $this->fixture('test=${env.TEST}');
   }

--- a/src/test/php/net/xp_framework/unittest/util/PropertyExpansionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/PropertyExpansionTest.class.php
@@ -1,0 +1,54 @@
+<?php namespace net\xp_framework\unittest\util;
+
+use util\Properties;
+use lang\ElementNotFoundException;
+
+class PropertyExpansionTest extends \unittest\TestCase {
+
+  /**
+   * Returns a fixture which expands `lookup.*` with a given expansion
+   *
+   * @param  [:var]|function(string): string $expansion
+   * @return util.Properties
+   */
+  private function newFixture($expansion) {
+    return (new Properties())
+      ->expanding('lookup', $expansion)
+      ->load("[section]\n".'test=${lookup.TEST}')
+    ;
+  }
+
+  #[@test]
+  public function closure_lookup() {
+    $prop= $this->newFixture(function($name) { return strtolower($name); });
+    $this->assertEquals('test', $prop->readString('section', 'test'));
+  }
+
+  #[@test]
+  public function callable_lookup() {
+    $prop= $this->newFixture('strtolower');
+    $this->assertEquals('test', $prop->readString('section', 'test'));
+  }
+
+  #[@test]
+  public function map_lookup() {
+    $prop= $this->newFixture(['TEST' => 'test']);
+    $this->assertEquals('test', $prop->readString('section', 'test'));
+  }
+
+  #[@test]
+  public function arrayaccess_lookup() {
+    $prop= $this->newFixture(newinstance(\ArrayAccess::class, [], [
+      'offsetExists' => function($key) { return true; },
+      'offsetGet'    => function($key) { return 'test'; },
+      'offsetSet'    => function($key, $value) { /* Not implemented */ },
+      'offsetUnset'  => function($key) { /* Not implemented */ }
+    ]));
+    $this->assertEquals('test', $prop->readString('section', 'test'));
+  }
+
+  #[@test, @expect(ElementNotFoundException::class), @values([null, false])]
+  public function non_existant_lookup($return) {
+    $this->newFixture(function($name) use($return) { return $return; })->readString('section', 'test');
+  }
+}


### PR DESCRIPTION
Instead of an optional expansion parameter to load() - which is usually not called directly but by means of lazy loading - add an expanding() instance method to util.Properties

```php
$prop= (new Properties('file.ini'))->expanding('credentials', function($name) {
  // TBI ...
});
```

Will be released in 7.8.0 and then merged to XP8