### PR TITLE
Add util.URI class

### DIFF
--- a/src/main/php/util/Authority.class.php
+++ b/src/main/php/util/Authority.class.php
@@ -1,0 +1,113 @@
+<?php namespace util;
+
+use lang\{Value, FormatException};
+
+/**
+ * Many URI schemes include a hierarchical element for a naming authority.
+ * 
+ * ```
+ * authority   = [ userinfo "@" ] host [ ":" port ]
+ * ```
+ * 
+ * @see   xp://util.URI#authority
+ * @see   https://tools.ietf.org/html/rfc3986#section-3.2
+ */
+class Authority implements Value {
+  public static $EMPTY;
+
+  private $host, $port, $user, $password;
+
+  static function __static() {
+    self::$EMPTY= new self(null);
+  }
+
+  /**
+   * Creates a new authority
+   *
+   * @param  string $host
+   * @param  int $port
+   * @param  string $user
+   * @param  util.Secret $password
+   */
+  public function __construct($host, $port= null, $user= null, Secret $password= null) {
+    $this->host= $host;
+    $this->port= $port;
+    $this->user= $user;
+    $this->password= $password;
+  }
+
+  /**
+   * Parse a given input string 
+   *
+   * @param  string $input
+   * @return self
+   * @throws lang.FormatException
+   */
+  public static function parse($input) {
+    if (!preg_match('!^(([^:@]+)(:([^@]+))?@)?([a-zA-Z0-9\.-]+|\[[^\]]+\])(:([0-9]+))?$!', $input, $matches)) {
+      throw new FormatException('Cannot parse "'.$input.'": Authority malformed');
+    }
+
+    return new self(
+      $matches[5],
+      isset($matches[7]) ? (int)$matches[7] : null,
+      $matches[2] === '' ? null : rawurldecode($matches[2]),
+      $matches[4] === '' ? null : new Secret(rawurldecode($matches[4]))
+    );
+  }
+
+  /** @return string */
+  public function host() { return $this->host; }
+
+  /** @return int */
+  public function port() { return $this->port; }
+
+  /** @return string */
+  public function user() { return $this->user; }
+
+  /** @return util.Secret */
+  public function password() { return $this->password; }
+
+  /**
+   * Helper to create a string representations.
+   *
+   * @param  bool $reveal Whether to reveal password, if any
+   * @return string
+   */
+  public function asString($reveal) {
+    $s= '';
+    isset($this->user) && $s.= (
+      rawurlencode($this->user).
+      (isset($this->password) ? ':'.($reveal ? rawurlencode($this->password->reveal()) : '********') : '').
+      '@'
+    );
+    isset($this->host) && $s.= $this->host;
+    isset($this->port) && $s.= ':'.$this->port;
+    return $s;
+  }
+
+  /** @return string */
+  public function __toString() {
+    return $this->asString(true);
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'<'.$this->asString(false).'>';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return md5($this->asString(true));
+  }
+
+  /**
+   * Compare to another value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? $this->asString(true) <=> $value->asString(true) : 1;
+  }
+}

--- a/src/main/php/util/Authority.class.php
+++ b/src/main/php/util/Authority.class.php
@@ -53,7 +53,7 @@ class Authority implements Value {
    */
   public static function parse($input) {
     if (!preg_match('!^(([^:@]+)(:([^@]+))?@)?([a-zA-Z0-9\.-]+|\[[^\]]+\])(:([0-9]+))?$!', $input, $matches)) {
-      throw new FormatException('Cannot parse "'.$input.'": Authority malformed');
+      throw new FormatException('Authority "'.$input.'" malformed');
     }
 
     return new self(

--- a/src/main/php/util/Authority.class.php
+++ b/src/main/php/util/Authority.class.php
@@ -11,6 +11,7 @@ use lang\{Value, FormatException};
  * 
  * @see   xp://util.URI#authority
  * @see   https://tools.ietf.org/html/rfc3986#section-3.2
+ * @test  xp://net.xp_framework.unittest.util.AuthorityTest
  */
 class Authority implements Value {
   public static $EMPTY;
@@ -27,13 +28,20 @@ class Authority implements Value {
    * @param  string $host
    * @param  int $port
    * @param  string $user
-   * @param  util.Secret $password
+   * @param  string|util.Secret $password
    */
-  public function __construct($host, $port= null, $user= null, Secret $password= null) {
+  public function __construct($host, $port= null, $user= null, $password= null) {
     $this->host= $host;
     $this->port= $port;
     $this->user= $user;
-    $this->password= $password;
+
+    if (null === $password) {
+      $this->password= null;
+    } else if ($password instanceof Secret) {
+      $this->password= $password;
+    } else {
+      $this->password= new Secret($password);
+    }
   }
 
   /**

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -51,27 +51,12 @@ class URI implements Value {
     }
   }
 
-  private function resolve0($authority, $path, $query, $fragment) {
-    if ($authority) {
-      $this->authority= $authority;
-      $this->path= $path;
-    } else if (null === $path) {
-      // Do not change this instance's path
-    } else if ('/' === $path{0}) {
-      $this->path= $path;
-    } else if (null === $this->path) {
-      $this->path= '/'.$path;
-    } else if ('/' === $this->path{strlen($this->path)- 1}) {
-      $this->path= $this->path.$path;
-    } else {
-      $this->path= substr($this->path, 0, strpos($this->path, '/')).'/'.$path;
-    }
-
-    $this->query= $query;
-    $this->fragment= $fragment;
-    return $this;
-  }
-
+  /**
+   * Parse relative URI into authority, path, query and fragment
+   *
+   * @param  string $relative
+   * @return var[]
+   */
   private function parse($relative) {
     if (0 === strlen($relative)) {
       throw new FormatException('Cannot parse empty input');
@@ -90,6 +75,35 @@ class URI implements Value {
     $fragment= isset($matches[7]) && '' !== $matches[7] ? substr($matches[7], 1) : null;
 
     return [$authority, $path, $query, $fragment];
+  }
+
+  /**
+   * Resolve authority, path, query and fragment against this URI
+   *
+   * @param  util.Authority $authority
+   * @param  string $path
+   * @param  string $query
+   * @param  string $fragment
+   * @return void
+   */
+  private function resolve0($authority, $path, $query, $fragment) {
+    if ($authority) {
+      $this->authority= $authority;
+      $this->path= $path;
+    } else if (null === $path) {
+      // Do not change this instance's path
+    } else if ('/' === $path{0}) {
+      $this->path= $path;
+    } else if (null === $this->path) {
+      $this->path= '/'.$path;
+    } else if ('/' === $this->path{strlen($this->path)- 1}) {
+      $this->path= $this->path.$path;
+    } else {
+      $this->path= substr($this->path, 0, strpos($this->path, '/')).'/'.$path;
+    }
+
+    $this->query= $query;
+    $this->fragment= $fragment;
   }
 
   /**
@@ -167,7 +181,9 @@ class URI implements Value {
     if ($uri->scheme) {
       return $uri;
     } else {
-      return (clone $this)->resolve0($uri->authority, $uri->path, $uri->query, $uri->fragment);
+      $result= clone $this;
+      $result->resolve0($uri->authority, $uri->path, $uri->query, $uri->fragment);
+      return $result;
     }
   }
 

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -1,0 +1,151 @@
+<?php namespace util;
+
+use lang\{Value, FormatException};
+
+/**
+ * A Uniform Resource Identifier (URI) is a compact sequence of
+ * characters that identifies an abstract or physical resource.
+ *
+ * ```
+ *   foo://example.com:8042/over/there?name=ferret#nose
+ *   \_/   \______________/\_________/ \_________/ \__/
+ *    |           |            |            |        |
+ * scheme     authority       path        query   fragment
+ *    |   _____________________|__
+ *   / \ /                        \
+ *   urn:example:animal:ferret:nose
+ * ```
+ *
+ * @see   https://tools.ietf.org/html/rfc3986
+ * @test  xp://net.xp_framework.unittest.util.URITest
+ */
+class URI implements Value {
+  private $scheme, $authority, $path, $query, $fragment;
+
+  /**
+   * Creates a URI instance, either by parsing a string or by using a
+   * given `URICreation` instance, which offers a fluent interface.
+   *
+   * @param  string|util.URICreation $arg
+   * @throws lang.FormatException if string argument cannot be parsed
+   */
+  public function __construct($arg) {
+    if ($arg instanceof URICreation) {
+      $this->scheme= $arg->scheme;
+      $this->authority= $arg->authority;
+      $this->path= $arg->path;
+      $this->query= $arg->query;
+      $this->fragment= $arg->fragment;
+    } else {
+      $this->parse($arg);
+    }
+  }
+
+  /**
+   * Use a fluent interface to create a URI
+   *
+   * ```php
+   * $uri= URI::with()
+   *   ->scheme('http')
+   *   ->authority('example.com')
+   *   ->path('/index')
+   * ;
+   * ```
+   */
+  public static function with(): URICreation { return new URICreation(); }
+
+  /**
+   * Parses a given input string
+   *
+   * @see    https://tools.ietf.org/html/rfc3986#section-1.1.2
+   * @param  string $input
+   * @return void
+   * @throws lang.FormatException if string argument cannot be parsed
+   */
+  private function parse($input) {
+    if (!preg_match('!^([a-zA-Z][a-zA-Z0-9\+]*):(//([^/?#]*)(/[^?#]*)?|([^?#]+))(\?[^#]*)?(#.*)?!', $input, $matches)) {
+      throw new FormatException('Cannot parse "'.$input.'"');
+    }
+
+    $this->scheme= $matches[1];
+
+    if (isset($matches[5]) && '' !== $matches[5]) {   // E.g. mailto:test@example.com
+      $this->authority= null;
+      $this->path= $matches[5];
+    } else if ('' === $matches[3]) {                  // E.g. file:///usr/local/etc/php.ini
+      $this->authority= Authority::$EMPTY;
+      $this->path= $matches[4];
+    } else {                                          // E.g. http://example.com/
+      $this->authority= Authority::parse($matches[3]);
+      $this->path= $matches[4] ?? null;
+    }
+
+    $this->query= isset($matches[6]) && '' !== $matches[6] ? substr($matches[6], 1) : null;
+    $this->fragment= isset($matches[7]) && '' !== $matches[7] ? substr($matches[7], 1) : null;
+  }
+
+  /** @return bool */
+  public function isOpaque() { return null === $this->authority; }
+
+  /** @return string */
+  public function scheme() { return $this->scheme; }
+
+  /** @return util.Authority */
+  public function authority($default= null) { return $this->authority ?? $default; }
+
+  /** @return string */
+  public function path($default= null) { return $this->path ?? $default; }
+
+  /** @return string */
+  public function query($default= null) { return $this->query ?? $default; }
+
+  /** @return string */
+  public function fragment($default= null) { return $this->fragment ?? $default; }
+
+  /** @return self */
+  public function canonicalize() { return (new URICanonicalization())->canonicalize($this); }
+
+  /** @return util.URICreation */
+  public function using() { return new URICreation($this); }
+
+  /**
+   * Helper to create a string representations.
+   *
+   * @see    https://tools.ietf.org/html/rfc3986#section-5.3
+   * @param  bool $reveal Whether to reveal password, if any
+   * @return string
+   */
+  public function asString($reveal) {
+    $s= $this->scheme.':';
+    isset($this->authority) && $s.= '//'.$this->authority->asString($reveal);
+    isset($this->path) && $s.= $this->path;
+    isset($this->query) && $s.= '?'.$this->query;
+    isset($this->fragment) && $s.= '#'.$this->fragment;
+    return $s;
+  }
+
+  /** @return string */
+  public function __toString() {
+    return $this->asString(true);
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'<'.$this->asString(false).'>';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return md5($this->asString(true));
+  }
+
+  /**
+   * Compare to another value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? $this->asString(true) <=> $value->asString(true) : 1;
+  }
+}

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -49,6 +49,7 @@ class URI implements Value {
    *   ->scheme('http')
    *   ->authority('example.com')
    *   ->path('/index')
+   *   ->create();
    * ;
    * ```
    */
@@ -84,6 +85,9 @@ class URI implements Value {
     $this->fragment= isset($matches[7]) && '' !== $matches[7] ? substr($matches[7], 1) : null;
   }
 
+  /** @return util.URICreation */
+  public function using() { return new URICreation($this); }
+
   /** @return bool */
   public function isOpaque() { return null === $this->authority; }
 
@@ -116,9 +120,6 @@ class URI implements Value {
 
   /** @return self */
   public function canonicalize() { return (new URICanonicalization())->canonicalize($this); }
-
-  /** @return util.URICreation */
-  public function using() { return new URICreation($this); }
 
   /**
    * Helper to create a string representations.

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -41,7 +41,7 @@ class URI implements Value {
       $this->path= $base->path;
       $this->query= $base->query;
       $this->fragment= $base->fragment;
-    } else if (preg_match('/^([a-zA-Z][a-zA-Z0-9\+]*):(.+)/', $base, $matches)) {
+    } else if (preg_match('/^([a-zA-Z][a-zA-Z0-9\+\-\.]*):(.+)/', $base, $matches)) {
       $this->scheme= $matches[1];
       list($this->authority, $this->path, $this->query, $this->fragment)= $this->parse($matches[2]);
     } else {
@@ -83,6 +83,7 @@ class URI implements Value {
   /**
    * Resolve authority, path, query and fragment against this URI
    *
+   * @see    https://tools.ietf.org/html/rfc3986#section-5.2.2
    * @param  util.Authority $authority
    * @param  string $path
    * @param  string $query

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -16,6 +16,9 @@ use lang\{Value, FormatException};
  *   urn:example:animal:ferret:nose
  * ```
  *
+ * This class implements a URI reference, which is either a
+ * URI or a relative reference.
+ *
  * @see   https://tools.ietf.org/html/rfc3986
  * @test  xp://net.xp_framework.unittest.util.URITest
  */

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -143,7 +143,7 @@ class URI implements Value {
   public function scheme() { return $this->scheme; }
 
   /** @return util.Authority */
-  public function authority($default= null) { return $this->authority ?? $default; }
+  public function authority() { return $this->authority; }
 
   /** @return string */
   public function host() { return $this->authority ? $this->authority->host() : null; }
@@ -158,13 +158,13 @@ class URI implements Value {
   public function password() { return $this->authority ? $this->authority->password() : null; }
 
   /** @return string */
-  public function path($default= null) { return $this->path ?? $default; }
+  public function path() { return $this->path; }
 
   /** @return string */
-  public function query($default= null) { return $this->query ?? $default; }
+  public function query() { return $this->query; }
 
   /** @return string */
-  public function fragment($default= null) { return $this->fragment ?? $default; }
+  public function fragment() { return $this->fragment; }
 
   /** @return self */
   public function canonicalize() { return (new URICanonicalization())->canonicalize($this); }

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -94,7 +94,7 @@ class URI implements Value {
       $this->authority= $authority;
       $this->path= $path;
     } else if (null === $path) {
-      // Do not change this instance's path
+      if (null === $query) $query= $this->query;
     } else if ('/' === $path{0}) {
       $this->path= $path;
     } else if (null === $this->path) {

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -41,9 +41,12 @@ class URI implements Value {
       $this->path= $base->path;
       $this->query= $base->query;
       $this->fragment= $base->fragment;
-    } else if (preg_match('/^([a-zA-Z][a-zA-Z0-9\+\-\.]*):(.+)/', $base, $matches)) {
-      $this->scheme= $matches[1];
-      list($this->authority, $this->path, $this->query, $this->fragment)= $this->parse($matches[2]);
+    } else if (false !== ($p= strpos($base, ':'))) {
+      $this->scheme= substr($base, 0, $p);
+      if (!preg_match('!^([a-zA-Z][a-zA-Z0-9+.-]*)$!', $this->scheme)) {
+        throw new FormatException('Scheme "'.$this->scheme.'" malformed');
+      }
+      list($this->authority, $this->path, $this->query, $this->fragment)= $this->parse(substr($base, $p + 1));
     } else {
       $this->scheme= null;
       list($this->authority, $this->path, $this->query, $this->fragment)= $this->parse($base);

--- a/src/main/php/util/URI.class.php
+++ b/src/main/php/util/URI.class.php
@@ -94,6 +94,18 @@ class URI implements Value {
   public function authority($default= null) { return $this->authority ?? $default; }
 
   /** @return string */
+  public function host() { return $this->authority ? $this->authority->host() : null; }
+
+  /** @return int */
+  public function port() { return $this->authority ? $this->authority->port() : null; }
+
+  /** @return string */
+  public function user() { return $this->authority ? $this->authority->user() : null; }
+
+  /** @return util.Secret */
+  public function password() { return $this->authority ? $this->authority->password() : null; }
+
+  /** @return string */
   public function path($default= null) { return $this->path ?? $default; }
 
   /** @return string */

--- a/src/main/php/util/URICanonicalization.class.php
+++ b/src/main/php/util/URICanonicalization.class.php
@@ -9,7 +9,6 @@ class URICanonicalization {
     'https' => 443,
   ];
 
-
   private function normalize($segment, $default) {
     if (null === $segment) return $default;
 

--- a/src/main/php/util/URICanonicalization.class.php
+++ b/src/main/php/util/URICanonicalization.class.php
@@ -1,0 +1,106 @@
+<?php namespace util;
+
+/**
+ * @test  xp://net.xp_framework.unittest.util.URICanonicalizationTest
+ */
+class URICanonicalization {
+  private static $defaults= [
+    'http'  => 80,
+    'https' => 443,
+  ];
+
+
+  private function normalize($segment, $default) {
+    if (null === $segment) return $default;
+
+    // Normalize escape sequences - https://tools.ietf.org/html/rfc3986#section-2.3
+    $segment= preg_replace_callback(
+      '/%([0-9a-zA-Z]{2})/',
+      function($match) {
+        $code= hexdec($match[1]);
+        if (
+          $code >= 65 && $code <= 90 ||                                 // A-Z
+          $code >= 97 && $code <= 122 ||                                // a-z
+          $code >= 48 && $code <= 57 ||                                 // 0-9
+          95 === $code || 45 === $code || 46 === $code || 126 === $code // -._~
+        ) {
+          return chr($code);
+        } else {
+          return strtoupper($match[0]);
+        }
+      },
+      $segment
+    );
+
+    // Remove Dot Segments - https://tools.ietf.org/html/rfc3986#section-5.2.4
+    $output= '';
+    while ('' !== $segment) {
+
+      // A. If the input begins with a prefix of "../" or "./", then remove
+      // that prefix from the input buffer; otherwise,
+      if (preg_match('!^(\.\./|\./)!', $segment)) {
+        $segment= preg_replace('!^(\.\./|\./)!', '', $segment);
+      }
+
+      // B. if the input buffer begins with a prefix of "/./" or "/.",
+      // where "." is a complete path segment, then replace that
+      // prefix with "/" in the input buffer; otherwise,
+      else if (preg_match('!^(/\./|/\.$)!', $segment, $matches)) {
+        $segment= preg_replace('!^'.$matches[1].'!', '/', $segment);
+      }
+
+      // C. if the input buffer begins with a prefix of "/../" or "/..",
+      // where ".." is a complete path segment, then replace that
+      // prefix with "/" in the input buffer and remove the last
+      // segment and its preceding "/" (if any) from the output
+      // buffer; otherwise,
+      else if (preg_match('!^(/\.\./|/\.\.$)!', $segment, $matches)) {
+        $segment= preg_replace('!^'.preg_quote($matches[1], '!').'!', '/', $segment);
+        $output= preg_replace('!/([^/]+)$!', '', $output);
+      }
+
+      // D. if the input buffer consists only of "." or "..", then remove
+      // that from the input buffer; otherwise,
+      else if (preg_match('!^(\.|\.\.)$!', $segment)) {
+        $segment= preg_replace('!^(\.|\.\.)$!', '', $segment);
+      }
+
+      // E. move the first path segment in the input buffer to the end of
+      // the output buffer, including the initial "/" character (if
+      // any) and any subsequent characters up to, but not including,
+      // the next "/" character or the end of the input buffer.
+      else if (preg_match('!(/*[^/]*)!', $segment, $matches)) {
+        $segment= preg_replace('/^'.preg_quote($matches[1], '/').'/', '', $segment, 1);
+        $output.= $matches[1];
+      }
+    }
+    return $output;
+  }
+
+  /**
+   * Canonicalize a given URI, returning a new one
+   *
+   * @param  util.URI $uri
+   * @return util.URI
+   */
+  public function canonicalize(URI $uri) {
+    sscanf($uri->scheme(), '%[^+]', $scheme);
+
+    $creation= (new URICreation($uri))
+      ->scheme(strtolower($scheme))
+      ->path($this->normalize($uri->path(), '/'))
+      ->query($this->normalize($uri->query(), null))
+      ->fragment($this->normalize($uri->fragment(), null))
+    ;
+
+    if ($authority= $uri->authority()) {
+      $creation->authority(new Authority(
+        strtolower($authority->host()),
+        $authority->port() === (self::$defaults[$scheme] ?? null) ? null : $authority->port(),
+        $authority->user(),
+        $authority->password()
+      ));
+    }
+    return $creation->create();
+  }
+}

--- a/src/main/php/util/URICreation.class.php
+++ b/src/main/php/util/URICreation.class.php
@@ -2,6 +2,13 @@
 
 use lang\IllegalStateException;
 
+/**
+ * Creates URI instances 
+ *
+ * @see   xp://util.URI#using
+ * @see   xp://util.URI#with
+ * @test  xp://net.xp_framework.unittest.util.URICreationTest
+ */
 class URICreation {
   public $scheme    = null;
   public $authority = null;
@@ -9,6 +16,16 @@ class URICreation {
   public $query     = null;
   public $fragment  = null;
 
+  private $host      = null;
+  private $port      = null;
+  private $user      = null;
+  private $password  = null;
+
+  /**
+   * Initialize creation instance
+   *
+   * @param  util.URI $uri Optional value to modify
+   */
   public function __construct($uri= null) {
     if (null === $uri) return;
 
@@ -45,6 +62,47 @@ class URICreation {
   }
 
   /**
+   * Sets host
+   *
+   * @param  string $value
+   * @return self
+   */
+  public function host($value) { $this->host= $value; return $this; }
+
+  /**
+   * Sets port
+   *
+   * @param  string $value
+   * @return self
+   */
+  public function port($value) { $this->port= $value; return $this; }
+
+  /**
+   * Sets user
+   *
+   * @param  string $value
+   * @return self
+   */
+  public function user($value) { $this->user= $value; return $this; }
+
+  /**
+   * Sets password
+   *
+   * @param  string|util.Secret $value
+   * @return self
+   */
+  public function password($value) {
+    if (null === $value) {
+      $this->password= null;
+    } else if ($value instanceof Secret) {
+      $this->password= $value;
+    } else {
+      $this->password= new Secret($value);
+    }
+    return $this;
+  }
+
+  /**
    * Sets path (use NULL to remove)
    *
    * @param  string $value
@@ -75,6 +133,18 @@ class URICreation {
    * @throws lang.IllegalStateException
    */
   public function create() {
+
+    // If host, port, user or password was set directly, merge
+    if (null !== $this->host || null !== $this->port || null !== $this->user || null !== $this->password) {
+      $this->authority= new Authority(
+        $this->host ?? ($this->authority ? $this->authority->host() : null),
+        $this->port ?? ($this->authority ? $this->authority->port() : null),
+        $this->user ?? ($this->authority ? $this->authority->user() : null),
+        $this->password ?? ($this->authority ? $this->authority->password() : null)
+      );
+    }
+
+    // Sanity check
     if (null === $this->scheme) {
       throw new IllegalStateException('Cannot create URI without scheme');
     } else if (null === $this->authority && null === $this->path) {

--- a/src/main/php/util/URICreation.class.php
+++ b/src/main/php/util/URICreation.class.php
@@ -1,0 +1,86 @@
+<?php namespace util;
+
+use lang\IllegalStateException;
+
+class URICreation {
+  public $scheme    = null;
+  public $authority = null;
+  public $path      = null;
+  public $query     = null;
+  public $fragment  = null;
+
+  public function __construct($uri= null) {
+    if (null === $uri) return;
+
+    $this->scheme= $uri->scheme();
+    $this->authority= $uri->authority();
+    $this->path= $uri->path();
+    $this->query= $uri->query();
+    $this->fragment= $uri->fragment();
+  }
+
+  /**
+   * Sets scheme - mandatory!
+   *
+   * @param  string $value
+   * @return self
+   */
+  public function scheme($value) { $this->scheme= $value; return $this; }
+
+  /**
+   * Sets authority (use NULL to remove)
+   *
+   * @param  string|util.Authority $value
+   * @return self
+   */
+  public function authority($value) {
+    if (null === $value) {
+      $this->authority= null;
+    } else if ($value instanceof Authority) {
+      $this->authority= $value;
+    } else {
+      $this->authority= Authority::parse($value);
+    }
+    return $this;
+  }
+
+  /**
+   * Sets path (use NULL to remove)
+   *
+   * @param  string $value
+   * @return self
+   */
+  public function path($value) { $this->path= $value; return $this; }
+
+  /**
+   * Sets query (use NULL to remove)
+   *
+   * @param  string $value
+   * @return self
+   */
+  public function query($value) { $this->query= $value; return $this; }
+
+  /**
+   * Sets fragment (use NULL to remove)
+   *
+   * @param  string $value
+   * @return self
+   */
+  public function fragment($value) { $this->fragment= $value; return $this; }
+
+  /**
+   * Creates the URI
+   *
+   * @return util.URI
+   * @throws lang.IllegalStateException
+   */
+  public function create() {
+    if (null === $this->scheme) {
+      throw new IllegalStateException('Cannot create URI without scheme');
+    } else if (null === $this->authority && null === $this->path) {
+      throw new IllegalStateException('Need either authority or path to create URI');
+    }
+
+    return new URI($this);
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/util/AuthorityTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AuthorityTest.class.php
@@ -1,0 +1,103 @@
+<?php namespace net\xp_framework\unittest\util;
+
+use util\{Authority, Secret};
+use lang\FormatException;
+
+class AuthorityTest extends \unittest\TestCase {
+
+  /** @return iterable */
+  private function hosts() {
+    yield 'example.com';
+    yield '127.0.0.1';
+    yield '[::1]';
+  }
+
+  #[@test]
+  public function can_create() {
+    new Authority('example.com');
+  }
+
+  #[@test]
+  public function host() {
+    $this->assertEquals('example.com', (new Authority('example.com'))->host());
+  }
+
+  #[@test]
+  public function port() {
+    $this->assertEquals(80, (new Authority('example.com', 80))->port());
+  }
+
+  #[@test]
+  public function port_defaults_to_null() {
+    $this->assertNull((new Authority('example.com'))->port());
+  }
+
+  #[@test]
+  public function user() {
+    $this->assertEquals('test', (new Authority('example.com', 80, 'test'))->user());
+  }
+
+  #[@test]
+  public function user_defaults_to_null() {
+    $this->assertNull((new Authority('example.com'))->user());
+  }
+
+  #[@test, @values([['secret'], [new Secret('secret')]])]
+  public function password($password) {
+    $this->assertEquals('secret', (new Authority('example.com', 80, 'test', $password))->password()->reveal());
+  }
+
+  #[@test]
+  public function password_defaults_to_null() {
+    $this->assertNull((new Authority('example.com'))->password());
+  }
+
+  #[@test, @values('hosts')]
+  public function parse_host_only($host) {
+    $this->assertEquals(new Authority($host), Authority::parse($host));
+  }
+
+  #[@test, @values('hosts')]
+  public function parse_host_and_port($host) {
+    $this->assertEquals(new Authority($host, 443), Authority::parse($host.':443'));
+  }
+
+  #[@test, @values('hosts')]
+  public function parse_host_and_user($host) {
+    $this->assertEquals(new Authority($host, null, 'test'), Authority::parse('test@'.$host));
+  }
+
+  #[@test, @values('hosts')]
+  public function parse_host_and_credentials($host) {
+    $this->assertEquals(new Authority($host, null, 'test', 'secret'), Authority::parse('test:secret@'.$host));
+  }
+
+  #[@test, @values('hosts')]
+  public function parse_urlencoded_credentials($host) {
+    $this->assertEquals(new Authority($host, null, '@test:', 'sec ret'), Authority::parse('%40test%3A:sec%20ret@'.$host));
+  }
+
+  #[@test, @expect(FormatException::class)]
+  public function parse_empty() {
+    Authority::parse('');
+  }
+
+  #[@test, @expect(FormatException::class), @values([
+  #  'user:',
+  #  'user@',
+  #  'user:password@',
+  #  'user@:8080',
+  #  'user:password@:8080',
+  #  ':8080',
+  #  ':foo',
+  #  ':123foo',
+  #  ':foo123',
+  #  'example.com:foo',
+  #  'example.com:123foo',
+  #  'example.com:foo123',
+  #  'example$'
+  #])]
+  public function parse_malformed($arg) {
+    Authority::parse($arg);
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/util/URICanonicalizationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URICanonicalizationTest.class.php
@@ -1,0 +1,81 @@
+<?php namespace net\xp_framework\unittest\util;
+
+use util\{URI, URICanonicalization};
+
+class URICanonicalizationTest extends \unittest\TestCase {
+
+  /**
+   * Assertion helper
+   *
+   * @param  string $expected
+   * @param  string $input
+   * @throws unittest.AssertionFailedError
+   */
+  private function assertCanonical($expected, $input) {
+    $this->assertEquals(new URI($expected), (new URICanonicalization())->canonicalize(new URI($input)));
+  }
+
+  #[@test]
+  public function scheme_is_lowercased() {
+    $this->assertCanonical('http://localhost/', 'HTTP://localhost/');
+  }
+
+  #[@test]
+  public function works_without_authority() {
+    $this->assertCanonical('mailto:test@example.com', 'mailto:test@example.com');
+  }
+
+  #[@test]
+  public function scheme_argument_is_removed() {
+    $this->assertCanonical('https://localhost/', 'https+v3://localhost/');
+  }
+
+  #[@test]
+  public function host_is_lowercased() {
+    $this->assertCanonical('http://localhost/', 'http://LOCALHOST/');
+  }
+
+  #[@test]
+  public function path_defaults_to_root() {
+    $this->assertCanonical('http://localhost/', 'http://localhost');
+  }
+
+  #[@test, @values([
+  #  ['http://example.com:80/', 'http://example.com/'],
+  #  ['https://example.com:443/', 'https://example.com/'],
+  #  ['ftp://example.com:22/', 'ftp://example.com:22/'],
+  #  ['http://example.com:8080/', 'http://example.com:8080/'],
+  #  ['https://example.com:8443/', 'https://example.com:8443/']
+  #])]
+  public function http_and_https_default_ports_are_removed($input, $expected) {
+    $this->assertCanonical($expected, $input);
+  }
+
+  #[@test]
+  public function escape_sequence_handling_in_path() {
+    $this->assertCanonical('http://localhost/a%C2%B1b-._~%FC', 'http://localhost/a%c2%b1b%2D%2E%5F%7E%FC');
+  }
+
+  #[@test]
+  public function escape_sequence_handling_in_query() {
+    $this->assertCanonical('http://localhost/?param=a%C2%B1b-._~%FC', 'http://localhost/?param=a%c2%b1b%2D%2E%5F%7E%FC');
+  }
+
+  #[@test]
+  public function escape_sequence_handling_in_fragment() {
+    $this->assertCanonical('http://localhost/#a%C2%B1b-._~%FC', 'http://localhost/#a%c2%b1b%2D%2E%5F%7E%FC');
+  }
+
+  #[@test, @values([
+  #  ['http://localhost/.', 'http://localhost/'],
+  #  ['http://localhost/..', 'http://localhost/'],
+  #  ['http://localhost/a/./b', 'http://localhost/a/b'],
+  #  ['http://localhost/a/././b', 'http://localhost/a/b'],
+  #  ['http://localhost/a/../b', 'http://localhost/b'],
+  #  ['http://localhost/a/./.././b', 'http://localhost/b'],
+  #  ['http://localhost/a/b/c/./../../d', 'http://localhost/a/d'],
+  #])]
+  public function removing_dot_sequences_from_path($input, $expected) {
+    $this->assertCanonical($expected, $input);
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/util/URICreationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URICreationTest.class.php
@@ -1,0 +1,96 @@
+<?php namespace net\xp_framework\unittest\util;
+
+use util\{URI, URICreation, Authority, Secret};
+
+class URICreationTest extends \unittest\TestCase {
+
+  #[@test]
+  public function can_create() {
+    new URICreation();
+  }
+
+  #[@test]
+  public function can_create_with_uri() {
+    new URICreation(new URI('http://example.com'));
+  }
+
+  #[@test]
+  public function opaque_uri() {
+    $this->assertEquals(
+      new URI('mailto:test@example.com'),
+      (new URICreation())->scheme('mailto')->path('test@example.com')->create()
+    );
+  }
+
+  #[@test, @values([['test@example.com:22'], [new Authority('example.com', 22, 'test')]])]
+  public function hierarchical_uri($authority) {
+    $this->assertEquals(
+      new URI('ssh://test@example.com:22'),
+      (new URICreation())->scheme('ssh')->authority($authority)->create()
+    );
+  }
+
+  #[@test]
+  public function file_uri_requires_empty_authority() {
+    $this->assertEquals(
+      new URI('file:///usr/local/etc/php.ini'),
+      (new URICreation())->scheme('file')->authority(Authority::$EMPTY)->path('/usr/local/etc/php.ini')->create()
+    );
+  }
+
+  #[@test]
+  public function host() {
+    $this->assertEquals(
+      new URI('http://example.com'),
+      (new URICreation())->scheme('http')->host('example.com')->create()
+    );
+  }
+
+  #[@test]
+  public function port() {
+    $this->assertEquals(
+      new URI('http://example.com:80'),
+      (new URICreation())->scheme('http')->host('example.com')->port(80)->create()
+    );
+  }
+
+  #[@test]
+  public function user() {
+    $this->assertEquals(
+      new URI('http://test@example.com'),
+      (new URICreation())->scheme('http')->host('example.com')->user('test')->create()
+    );
+  }
+
+  #[@test, @values([['secret'], [new Secret('secret')]])]
+  public function password($password) {
+    $this->assertEquals(
+      new URI('http://test:secret@example.com'),
+      (new URICreation())->scheme('http')->host('example.com')->user('test')->password($password)->create()
+    );
+  }
+
+  #[@test]
+  public function query() {
+    $this->assertEquals(
+      new URI('mailto:test@example.com?Subject=Hello'),
+      (new URICreation())->scheme('mailto')->path('test@example.com')->query('Subject=Hello')->create()
+    );
+  }
+
+  #[@test]
+  public function fragment() {
+    $this->assertEquals(
+      new URI('http://example.com#home'),
+      (new URICreation())->scheme('http')->host('example.com')->fragment('home')->create()
+    );
+  }
+
+  #[@test]
+  public function modify_uri_given_to_constructor() {
+    $this->assertEquals(
+      new URI('https://example.com:443'),
+      (new URICreation(new URI('http://example.com')))->scheme('https')->port(443)->create()
+    );
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/util/URITest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URITest.class.php
@@ -349,6 +349,9 @@ class URITest extends \unittest\TestCase {
   }
 
   #[@test, @values([
+  #  [new URI('/'), 'index.html', new URI('/index.html')],
+  #  [new URI('/home/'), 'index.html', new URI('/home/index.html')],
+  #  [new URI('file:///var/www-data/'), 'index.html', new URI('file:///var/www-data/index.html')],
   #  [new URI('http://localhost'), 'index.html', new URI('http://localhost/index.html')],
   #  [new URI('http://localhost'), '?a=b', new URI('http://localhost?a=b')],
   #  [new URI('http://localhost'), '#top', new URI('http://localhost#top')],

--- a/src/test/php/net/xp_framework/unittest/util/URITest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URITest.class.php
@@ -355,6 +355,7 @@ class URITest extends \unittest\TestCase {
   #  [new URI('http://localhost'), 'index.html', new URI('http://localhost/index.html')],
   #  [new URI('http://localhost'), '?a=b', new URI('http://localhost?a=b')],
   #  [new URI('http://localhost'), '#top', new URI('http://localhost#top')],
+  #  [new URI('http://localhost?a=b'), '#top', new URI('http://localhost?a=b#top')],
   #  [new URI('http://localhost'), 'index.html?a=b', new URI('http://localhost/index.html?a=b')],
   #  [new URI('http://localhost'), 'index.html#top', new URI('http://localhost/index.html#top')],
   #  [new URI('http://localhost/home.html'), 'index.html', new URI('http://localhost/index.html')],

--- a/src/test/php/net/xp_framework/unittest/util/URITest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URITest.class.php
@@ -309,4 +309,34 @@ class URITest extends \unittest\TestCase {
       (new URI('ftp://cnn.example.com&story=breaking_news@10.0.0.1/top_story.htm'))->authority()->user()
     );
   }
+
+  #[@test, @values([
+  #  [new URI('http://localhost', 'index.html')],
+  #  [new URI('http://localhost/', 'index.html')],
+  #  [new URI('http://localhost/.', 'index.html')],
+  #  [new URI('http://localhost/./', 'index.html')],
+  #  [new URI('http://localhost/home', '../index.html')],
+  #  [new URI('http://localhost/home/', '../index.html')]
+  #])]
+  public function with_relative_part($uri) {
+    $this->assertEquals(new URI('http://localhost/index.html'), $uri->canonicalize());
+  }
+
+  #[@test, @values([
+  #  [new URI('http://localhost', '?a=b')],
+  #  [new URI('http://localhost/', '?a=b')],
+  #  [new URI('http://localhost/.', '?a=b')]
+  #])]
+  public function with_relative_part_including_query($uri) {
+    $this->assertEquals(new URI('http://localhost/?a=b'), $uri->canonicalize());
+  }
+
+  #[@test, @values([
+  #  [new URI('http://localhost', '#top')],
+  #  [new URI('http://localhost/', '#top')],
+  #  [new URI('http://localhost/.', '#top')]
+  #])]
+  public function with_relative_part_including_fragment($uri) {
+    $this->assertEquals(new URI('http://localhost/#top'), $uri->canonicalize());
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/util/URITest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URITest.class.php
@@ -294,7 +294,7 @@ class URITest extends \unittest\TestCase {
     new URI('');
   }
 
-  #[@test, @expect(FormatException::class), @values([
+  #[@test, @expect(class= FormatException::class, withMessage= '/Scheme .+ malformed/'), @values([
   #  '://example.com',
   #  '0://example.com',
   #  '-://example.com',
@@ -306,13 +306,14 @@ class URITest extends \unittest\TestCase {
   #  '.http://example.com',
   #  'http\\://example.com',
   #  'http$://example.com',
-  #  '1234://example.com'
+  #  '1234://example.com',
+  #  'mailto!:test@example.com'
   #])]
-  public function malformed_scheme() {
-    new URI('');
+  public function malformed_scheme($arg) {
+    new URI($arg);
   }
 
-  #[@test, @expect(class= FormatException::class, withMessage= '/Authority malformed/'), @values([
+  #[@test, @expect(class= FormatException::class, withMessage= '/Authority .+ malformed/'), @values([
   #  'http://user:',
   #  'http://user@',
   #  'http://user:password@',

--- a/src/test/php/net/xp_framework/unittest/util/URITest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URITest.class.php
@@ -213,6 +213,10 @@ class URITest extends \unittest\TestCase {
   #  'http://example.com/path/with%2Fslashes',
   #  'http://example.com/path?param=value&ie=utf8#fragment',
   #  'https://example.com',
+  #  'svn+ssh://example.com/repo/trunk',
+  #  'ms-help://section/path/file.htm',
+  #  'h323:seconix.com:1740',
+  #  'soap.beep://stockquoteserver.example.com/StockQuote',
   #  'https://[::1]:443',
   #  'ftp://example.com',
   #  'file:///usr/local/etc/php.ini',
@@ -287,6 +291,24 @@ class URITest extends \unittest\TestCase {
 
   #[@test, @expect(FormatException::class)]
   public function empty_input() {
+    new URI('');
+  }
+
+  #[@test, @expect(FormatException::class), @values([
+  #  '://example.com',
+  #  '0://example.com',
+  #  '-://example.com',
+  #  '+://example.com',
+  #  '.://example.com',
+  #  '0http://example.com',
+  #  '-http://example.com',
+  #  '+http://example.com',
+  #  '.http://example.com',
+  #  'http\\://example.com',
+  #  'http$://example.com',
+  #  '1234://example.com'
+  #])]
+  public function malformed_scheme() {
     new URI('');
   }
 

--- a/src/test/php/net/xp_framework/unittest/util/URITest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URITest.class.php
@@ -13,6 +13,14 @@ class URITest extends \unittest\TestCase {
     yield 'urn:isbn:096139210x';
   }
 
+  /** @return iterable */
+  private function hierarchicalUris() {
+    yield 'http://example.com';
+    yield 'http://127.0.0.1:8080';
+    yield 'http://user:pass@[::1]';
+    yield 'ldap://example.com/c=GB?objectClass?one';
+  }
+
   #[@test, @values('opaqueUris')]
   public function opaque_uris($uri) {
     $this->assertTrue((new URI($uri))->isOpaque());
@@ -21,6 +29,16 @@ class URITest extends \unittest\TestCase {
   #[@test, @values('opaqueUris')]
   public function opaque_uris_have_no_authority($uri) {
     $this->assertNull((new URI($uri))->authority());
+  }
+
+  #[@test, @values('hierarchicalUris')]
+  public function hierarchical_uris($uri) {
+    $this->assertFalse((new URI($uri))->isOpaque());
+  }
+
+  #[@test, @values('hierarchicalUris')]
+  public function hierarchical_uris_have_authority($uri) {
+    $this->assertInstanceOf(Authority::class, (new URI($uri))->authority());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/util/URITest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URITest.class.php
@@ -1,0 +1,284 @@
+<?php namespace net\xp_framework\unittest\util;
+
+use util\{URI, Authority};
+use lang\{Primitive, FormatException};
+
+class URITest extends \unittest\TestCase {
+
+  /** @return iterable */
+  private function opaqueUris() {
+    yield 'mailto:fred@example.com';
+    yield 'news:comp.infosystems.www.servers.unix';
+    yield 'tel:+1-816-555-1212';
+    yield 'urn:isbn:096139210x';
+  }
+
+  #[@test, @values('opaqueUris')]
+  public function opaque_uris($uri) {
+    $this->assertTrue((new URI($uri))->isOpaque());
+  }
+
+  #[@test, @values('opaqueUris')]
+  public function opaque_uris_have_no_authority($uri) {
+    $this->assertNull((new URI($uri))->authority());
+  }
+
+  #[@test]
+  public function scheme() {
+    $this->assertEquals('http', (new URI('http://example.com'))->scheme());
+  }
+
+  #[@test]
+  public function authority() {
+    $this->assertEquals(new Authority('example.com', 8080), (new URI('http://example.com:8080'))->authority());
+  }
+
+  #[@test, @values([
+  #  'http://127.0.0.1',
+  #  'http://127.0.0.1:8080',
+  #  'http://user:pass@127.0.0.1',
+  #  'ldap://127.0.0.1/c=GB?objectClass?one'
+  #])]
+  public function ipv4_address_as_host($uri) {
+    $this->assertEquals('127.0.0.1', (new URI($uri))->authority()->host());
+  }
+
+  #[@test, @values([
+  #  'http://[::1]',
+  #  'http://[::1]:8080',
+  #  'http://user:pass@[::1]',
+  #  'ldap://[::1]/c=GB?objectClass?one'
+  #])]
+  public function ipv6_address_as_host($uri) {
+    $this->assertEquals('[::1]', (new URI($uri))->authority()->host());
+  }
+
+  #[@test]
+  public function without_port() {
+    $this->assertEquals(null, (new URI('http://example.com'))->authority()->port());
+  }
+
+  #[@test]
+  public function with_port() {
+    $this->assertEquals(8080, (new URI('http://example.com:8080'))->authority()->port());
+  }
+
+  #[@test]
+  public function without_path() {
+    $this->assertEquals(null, (new URI('http://example.com'))->path());
+  }
+
+  #[@test]
+  public function with_empty_path() {
+    $this->assertEquals('/', (new URI('http://example.com/'))->path());
+  }
+
+  #[@test]
+  public function with_path() {
+    $this->assertEquals('/a/b/c', (new URI('http://example.com/a/b/c'))->path());
+  }
+
+  #[@test]
+  public function file_url_path() {
+    $this->assertEquals('/usr/local/etc/php.ini', (new URI('file:///usr/local/etc/php.ini'))->path());
+  }
+
+  #[@test, @values([
+  #  'http://api@example.com',
+  #  'http://api:secret@example.com',
+  #  'http://api:secret@example.com:8080',
+  #])]
+  public function with_user($uri) {
+    $this->assertEquals('api', (new URI($uri))->authority()->user());
+  }
+
+  #[@test]
+  public function without_user() {
+    $this->assertEquals(null, (new URI('http://example.com'))->authority()->user());
+  }
+
+  #[@test]
+  public function urlencoded_user() {
+    $this->assertEquals('u:root', (new URI('http://u%3Aroot@example.com'))->authority()->user());
+  }
+
+  #[@test, @values([
+  #  'http://api:secret@example.com',
+  #  'http://api:secret@example.com:8080'
+  #])]
+  public function with_password($uri) {
+    $this->assertEquals('secret', (new URI($uri))->authority()->password()->reveal());
+  }
+
+  #[@test]
+  public function without_password() {
+    $this->assertEquals(null, (new URI('http://example.com'))->authority()->password());
+  }
+
+  #[@test]
+  public function urlencoded_password() {
+    $this->assertEquals('p:secret', (new URI('http://u%3Aroot:p%3Asecret@example.com'))->authority()->password()->reveal());
+  }
+
+  #[@test]
+  public function without_query() {
+    $this->assertEquals(null, (new URI('http://example.com'))->query());
+  }
+
+  #[@test, @values([
+  #  'http://example.com?a=b&c=d',
+  #  'http://example.com/?a=b&c=d',
+  #  'http://example.com/path?a=b&c=d',
+  #  'http://example.com/?a=b&c=d#',
+  #  'http://example.com/?a=b&c=d#fragment'
+  #])]
+  public function with_query($uri) {
+    $this->assertEquals('a=b&c=d', (new URI($uri))->query());
+  }
+
+  #[@test]
+  public function query_for_opaque_uri() {
+    $this->assertEquals('Subject=Hello%20World', (new URI('mailto:fred@example.com?Subject=Hello%20World'))->query());
+  }
+
+  #[@test]
+  public function query_with_question_mark() {
+    $this->assertEquals('objectClass?one', (new URI('ldap://[2001:db8::7]/c=GB?objectClass?one'))->query());
+  }
+
+  #[@test]
+  public function without_fragment() {
+    $this->assertEquals(null, (new URI('http://example.com'))->fragment());
+  }
+
+  #[@test, @values([
+  #  'http://example.com#top',
+  #  'http://example.com/#top',
+  #  'http://example.com/path#top',
+  #  'http://example.com/a=b&c=d#top'
+  #])]
+  public function with_fragment($uri) {
+    $this->assertEquals('top', (new URI($uri))->fragment());
+  }
+
+  #[@test, @values([
+  #  'http://example.com',
+  #  'http://example.com:80',
+  #  'http://user@example.com',
+  #  'http://user:pass@example.com',
+  #  'http://u%3Aroot:p%3Asecret@example.com',
+  #  'http://example.com?param=value',
+  #  'http://example.com/#fragment',
+  #  'http://example.com//path',
+  #  'http://example.com/path/with%2Fslashes',
+  #  'http://example.com/path?param=value&ie=utf8#fragment',
+  #  'https://example.com',
+  #  'https://[::1]:443',
+  #  'ftp://example.com',
+  #  'file:///usr/local/etc/php.ini',
+  #  'file:///c:/php/php.ini',
+  #  'file:///c|/php/php.ini',
+  #  'tel:+1-816-555-1212',
+  #  'urn:oasis:names:specification:docbook:dtd:xml:4.1.2',
+  #  'ldap://[2001:db8::7]/c=GB?objectClass?one'
+  #])]
+  public function string_cast_yields_input($input) {
+    $this->assertEquals($input, (string)new URI($input));
+  }
+
+  #[@test]
+  public function string_representation_does_not_include_password() {
+    $this->assertEquals(
+      'util.URI<http://user:********@example.com>',
+      (new URI('http://user:pass@example.com'))->toString()
+    );
+  }
+
+  #[@test]
+  public function can_be_created_via_with() {
+    $this->assertEquals(
+      'https://example.com:443/',
+      (string)URI::with()->scheme('https')->authority(new Authority('example.com', 443))->path('/')->create()
+    );
+  }
+
+  #[@test]
+  public function can_be_modified_via_using() {
+    $this->assertEquals(
+      'http://example.com?a=b',
+      (string)(new URI('http://example.com'))->using()->query('a=b')->create()
+    );
+  }
+
+  #[@test]
+  public function compared_to_itself() {
+    $uri= new URI('https://example.com/');
+    $this->assertEquals(0, $uri->compareTo($uri));
+  }
+
+  #[@test, @values([
+  #  ['https://example.com', 1],
+  #  ['https://example.com/', 0],
+  #  ['https://example.com/path', -1]
+  #])]
+  public function compared_to_another($uri, $expected) {
+    $this->assertEquals($expected, (new URI('https://example.com/'))->compareTo(new URI($uri)));
+  }
+
+  #[@test, @values([
+  #  [null],
+  #  [false], [true],
+  #  [0], [6100], [-1],
+  #  [0.0], [1.5],
+  #  [''], ['Hello'], ['https://example.com/'],
+  #  [[]], [[1, 2, 3]],
+  #  [['key' => 'value']],
+  #  [Primitive::$STRING]
+  #])]
+  public function compared_to($value) {
+    $this->assertEquals(1, (new URI('https://example.com/'))->compareTo($value));
+  }
+
+  #[@test]
+  public function canonicalize() {
+    $this->assertEquals(new URI('http://localhost/'), (new URI('http://localhost:80'))->canonicalize());
+  }
+
+  #[@test, @expect(FormatException::class)]
+  public function empty_input() {
+    new URI('');
+  }
+
+  #[@test, @expect(FormatException::class)]
+  public function missing_scheme() {
+    new URI('example.com');
+  }
+
+  #[@test, @expect(class= FormatException::class, withMessage= '/Authority malformed/'), @values([
+  #  'http://user:',
+  #  'http://user@',
+  #  'http://user:password@',
+  #  'http://user@:8080',
+  #  'http://:8080',
+  #  'http://:foo',
+  #  'http://:123foo',
+  #  'http://:foo123',
+  #  'http://example.com:foo',
+  #  'http://example.com:123foo',
+  #  'http://example.com:foo123',
+  #  'http://example$'
+  #])]
+  public function malformed_authority($arg) {
+    new URI($arg);
+  }
+
+  #[@test]
+  public function semantic_attack() {
+
+    // See https://tools.ietf.org/html/rfc3986#section-7.6
+    $this->assertEquals(
+      'cnn.example.com&story=breaking_news',
+      (new URI('ftp://cnn.example.com&story=breaking_news@10.0.0.1/top_story.htm'))->authority()->user()
+    );
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/util/URITest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/URITest.class.php
@@ -34,13 +34,23 @@ class URITest extends \unittest\TestCase {
   }
 
   #[@test, @values([
+  #  'http://example.com',
+  #  'http://example.com:8080',
+  #  'http://user:pass@example.com',
+  #  'ldap://example.com/c=GB?objectClass?one'
+  #])]
+  public function domain_as_host($uri) {
+    $this->assertEquals('example.com', (new URI($uri))->host());
+  }
+
+  #[@test, @values([
   #  'http://127.0.0.1',
   #  'http://127.0.0.1:8080',
   #  'http://user:pass@127.0.0.1',
   #  'ldap://127.0.0.1/c=GB?objectClass?one'
   #])]
   public function ipv4_address_as_host($uri) {
-    $this->assertEquals('127.0.0.1', (new URI($uri))->authority()->host());
+    $this->assertEquals('127.0.0.1', (new URI($uri))->host());
   }
 
   #[@test, @values([
@@ -50,17 +60,17 @@ class URITest extends \unittest\TestCase {
   #  'ldap://[::1]/c=GB?objectClass?one'
   #])]
   public function ipv6_address_as_host($uri) {
-    $this->assertEquals('[::1]', (new URI($uri))->authority()->host());
+    $this->assertEquals('[::1]', (new URI($uri))->host());
   }
 
   #[@test]
   public function without_port() {
-    $this->assertEquals(null, (new URI('http://example.com'))->authority()->port());
+    $this->assertEquals(null, (new URI('http://example.com'))->port());
   }
 
   #[@test]
   public function with_port() {
-    $this->assertEquals(8080, (new URI('http://example.com:8080'))->authority()->port());
+    $this->assertEquals(8080, (new URI('http://example.com:8080'))->port());
   }
 
   #[@test]
@@ -89,17 +99,17 @@ class URITest extends \unittest\TestCase {
   #  'http://api:secret@example.com:8080',
   #])]
   public function with_user($uri) {
-    $this->assertEquals('api', (new URI($uri))->authority()->user());
+    $this->assertEquals('api', (new URI($uri))->user());
   }
 
   #[@test]
   public function without_user() {
-    $this->assertEquals(null, (new URI('http://example.com'))->authority()->user());
+    $this->assertEquals(null, (new URI('http://example.com'))->user());
   }
 
   #[@test]
   public function urlencoded_user() {
-    $this->assertEquals('u:root', (new URI('http://u%3Aroot@example.com'))->authority()->user());
+    $this->assertEquals('u:root', (new URI('http://u%3Aroot@example.com'))->user());
   }
 
   #[@test, @values([
@@ -107,17 +117,17 @@ class URITest extends \unittest\TestCase {
   #  'http://api:secret@example.com:8080'
   #])]
   public function with_password($uri) {
-    $this->assertEquals('secret', (new URI($uri))->authority()->password()->reveal());
+    $this->assertEquals('secret', (new URI($uri))->password()->reveal());
   }
 
   #[@test]
   public function without_password() {
-    $this->assertEquals(null, (new URI('http://example.com'))->authority()->password());
+    $this->assertEquals(null, (new URI('http://example.com'))->password());
   }
 
   #[@test]
   public function urlencoded_password() {
-    $this->assertEquals('p:secret', (new URI('http://u%3Aroot:p%3Asecret@example.com'))->authority()->password()->reveal());
+    $this->assertEquals('p:secret', (new URI('http://u%3Aroot:p%3Asecret@example.com'))->password()->reveal());
   }
 
   #[@test]


### PR DESCRIPTION
This pull request implements https://github.com/xp-framework/rfc/issues/321

*Work in progress*

* [X] Write RFC; documenting new API
* [x] Add utility methods to access authority.host, authority.port, authority.user, authority.password directly
* [ ] Encoding / decoding of escape sequences in path, query and fragment
* [ ] Parameter handling
* [ ] Compare with Java / C# implementations
* [ ] Add some real life before / after comparisons with `peer.URL`.
* [ ] Release in 8.2.0
* [ ] Think about also backporting this to PHP 5.6 /  XP7 (-> 7.9.0) to make this usable from libraries early on

## In a nutshell

A Uniform Resource Identifier (URI) is a compact sequence of characters that identifies an abstract or physical resource.

```
  foo://example.com:8042/over/there?name=ferret#nose
  \_/   \______________/\_________/ \_________/ \__/
   |           |            |            |        |
scheme     authority       path        query   fragment
   |   _____________________|__
  / \ /                        \
  urn:example:animal:ferret:nose
```

See https://tools.ietf.org/html/rfc3986

## Example

Parsing from a string:
```php
use util\URI;

$uri= new URI('https://user:password@localhost:8443/index?sort=name#top');
$uri->isOpaque();   // false - it's a hierarchical URI
$uri->scheme();     // "https"
$uri->authority();  // util.Authority("localhost", 8443, "user", util.Secret("password"))
$uri->host();       // "localhost"
$uri->port();       // 8443
$uri->user();       // "user"
$uri->password();   // util.Secret("password")
$uri->path();       // "index"
$uri->query();      // "sort=name"
$uri->fragment();   // "top"
```

Creating or modifying using the fluent interface:
```php
use util\URI;

$uri= URI::with()->scheme('mailto')->path('timm@example.com')->query('Subject=Hello')->create();
$uri->isOpaque();   // true - it's an opaque URI
$uri->scheme();     // "mailto"
$uri->authority();  // null
(string)$uri;       // mailto:timm@example.com?Subject=Hello

$copy= $uri->using()->path('cc@example.com')->create();
(string)$copy;      // mailto:cc@example.com?Subject=Hello
```

Resolving URIs:
```php
use util\URI;

$uri= new URI('http://localhost/home/');
$uri->resolve('/index.html');       // http://localhost/index.html
$uri->resolve('index.html');        // http://localhost/home/index.html
$uri->resolve('?sort=name');        // http://localhost/home/?sort=name
$uri->resolve('#top');              // http://localhost/home/#top
$uri->resolve('//example.com');     // http://example.com
$uri->resolve('https://localhost'); // https://localhost
```