### PR TITLE
Increase TextReader::readLine() performance 50-fold (!)

### DIFF
--- a/src/main/php/io/streams/TextReader.class.php
+++ b/src/main/php/io/streams/TextReader.class.php
@@ -18,6 +18,8 @@ class TextReader extends Reader {
   private $charset;
   private $beginning;
 
+  private $cl= 1, $of= 0;
+
   /**
    * Constructor. Creates a new TextReader on an underlying input
    * stream with a given charset.
@@ -36,8 +38,14 @@ class TextReader extends Reader {
     } else {
       throw new IllegalArgumentException('Given argument is neither an input stream, a channel nor a string: '.\xp::typeOf($arg));
     }
-    $this->charset= $charset ?: $this->detectCharset();
+
     $this->beginning= true;
+    switch ($this->charset= strtolower($charset ?: $this->detectCharset())) {
+      case 'utf-16le': $this->cl= 2; $this->of= 0; break;
+      case 'utf-16be': $this->cl= 2; $this->of= 1; break;
+      case 'utf-32le': $this->cl= 4; $this->of= 0; break;
+      case 'utf-32be': $this->cl= 4; $this->of= 3; break;
+    }
   }
 
   /**
@@ -104,7 +112,7 @@ class TextReader extends Reader {
   }
 
   /**
-   * Reads a given number of bytes
+   * Reads a given nuofer of bytes
    *
    * @param  int $size
    * @return string
@@ -122,7 +130,7 @@ class TextReader extends Reader {
   }
 
   /**
-   * Read a number of characters
+   * Read a nuofer of characters
    *
    * @param   int size default 8192
    * @return  string NULL when end of data is reached
@@ -147,30 +155,51 @@ class TextReader extends Reader {
       \xp::gc(__FILE__);
       throw new FormatException($message);
     } else if ('' === $bytes) {
+      $this->buf= null;
       return null;
     } else {
       return iconv($this->charset, \xp::ENCODING, $bytes);
     }
   }
-  
+
   /**
    * Read an entire line
    *
    * @return  string NULL when end of data is reached
    */
   public function readLine() {
-    if (null === ($c= $this->read(1))) return null;
-    $line= '';
+    if (null === $this->buf) return null;
+
+    $this->beginning= false;
     do {
-      if ("\r" === $c) {
-        $n= $this->read(1);
-        if ("\n" !== $n) $this->buf= $n.$this->buf;
-        return $line;
-      } else if ("\n" === $c) {
-        return $line;
+      $p= strcspn($this->buf, "\r\n");
+      $l= strlen($this->buf);
+      if ($p >= $l - $this->cl) {
+        $chunk= $this->stream->read();
+        if ('' === $chunk) {
+          if ('' === $this->buf) return null;
+          $bytes= $p === $l ? $this->buf : substr($this->buf, 0, $p - $this->of);
+          $this->buf= null;
+          break;
+        }
+        $this->buf.= $chunk;
+        continue;
       }
-      $line.= $c;
-    } while (null !== ($c= $this->read(1)));
+
+      $o= ("\r" === $this->buf{$p} && "\n" === $this->buf{$p + $this->cl}) ? $this->cl * 2 : $this->cl;
+      $bytes= substr($this->buf, 0, $p - $this->of);
+      $this->buf= substr($this->buf, $p + $o);
+      break;
+    } while (true);
+
+    // echo "<<< '", addcslashes($bytes, "\0..\17!\177..\377"), "'\n";
+
+    $line= iconv($this->charset, \xp::ENCODING, $bytes);
+    if (false === $line) {
+      $message= key(@\xp::$errors[__FILE__][__LINE__ - 2]);
+      \xp::gc(__FILE__);
+      throw new FormatException($message);
+    }
     return $line;
   }
 

--- a/src/main/php/io/streams/TextReader.class.php
+++ b/src/main/php/io/streams/TextReader.class.php
@@ -112,7 +112,7 @@ class TextReader extends Reader {
   }
 
   /**
-   * Reads a given nuofer of bytes
+   * Reads a given number of bytes
    *
    * @param  int $size
    * @return string
@@ -130,7 +130,7 @@ class TextReader extends Reader {
   }
 
   /**
-   * Read a nuofer of characters
+   * Read a number of characters
    *
    * @param   int size default 8192
    * @return  string NULL when end of data is reached
@@ -187,7 +187,8 @@ class TextReader extends Reader {
       }
 
       $o= ("\r" === $this->buf{$p} && "\n" === $this->buf{$p + $this->cl}) ? $this->cl * 2 : $this->cl;
-      $bytes= substr($this->buf, 0, $p - $this->of);
+      $p-= $this->of;
+      $bytes= substr($this->buf, 0, $p);
       $this->buf= substr($this->buf, $p + $o);
       break;
     } while (true);

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -264,6 +264,26 @@ class TextReaderTest extends \unittest\TestCase {
     $this->assertEquals('utf-16le', $r->charset());
   }
 
+  #[@test, @values([
+  #  "L\000\000\0001\000\000\000\n\000\000\000L\000\000\0002\000\000\000",
+  #  "L\000\000\0001\000\000\000\r\000\000\000L\000\000\0002\000\000\000",
+  #  "L\000\000\0001\000\000\000\r\000\000\000\n\000\000\000L\000\000\0002\000\000\000"
+  #])]
+  public function readLinesUtf32Le($value) {
+    $r= $this->newReader($value, 'utf-32le');
+    $this->assertEquals(['L1', 'L2'], [$r->readLine(), $r->readLine()]);
+  }
+
+  #[@test, @values([
+  #  "\000\000\000L\000\000\0001\000\000\000\n\000\000\000L\000\000\0002",
+  #  "\000\000\000L\000\000\0001\000\000\000\r\000\000\000L\000\000\0002",
+  #  "\000\000\000L\000\000\0001\000\000\000\r\000\000\000\n\000\000\000L\000\000\0002"
+  #])]
+  public function readLinesUtf32Be($value) {
+    $r= $this->newReader($value, 'utf-32be');
+    $this->assertEquals(['L1', 'L2'], [$r->readLine(), $r->readLine()]);
+  }
+
   #[@test]
   public function defaultCharsetIsIso88591() {
     $r= $this->newReader('Übercoder', null);

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -230,9 +230,14 @@ class TextReaderTest extends \unittest\TestCase {
     $this->assertEquals('utf-8', $r->charset());
   }
 
-  #[@test]
-  public function readLinesAutodetectUtf16BE() {
-    $r= $this->newReader("\376\377\000\334\000b\000e\000r\000c\000o\000d\000e\000r", null);
+  #[@test, @values([
+  #  "\376\377\000\334\000b\000e\000r\000c\000o\000d\000e\000r",
+  #  "\376\377\000\334\000b\000e\000r\000c\000o\000d\000e\000r\000\015",
+  #  "\376\377\000\334\000b\000e\000r\000c\000o\000d\000e\000r\000\015\000\012",
+  #  "\376\377\000\334\000b\000e\000r\000c\000o\000d\000e\000r\000\012"
+  #])]
+  public function readLinesAutodetectUtf16BE($value) {
+    $r= $this->newReader($value, null);
     $this->assertEquals('Übercoder', $r->readLine());
   }
 
@@ -242,9 +247,14 @@ class TextReaderTest extends \unittest\TestCase {
     $this->assertEquals('utf-16be', $r->charset());
   }
   
-  #[@test]
-  public function readLinesAutodetectUtf16Le() {
-    $r= $this->newReader("\377\376\334\000b\000e\000r\000c\000o\000d\000e\000r\000", null);
+  #[@test, @values([
+  #  "\377\376\334\000b\000e\000r\000c\000o\000d\000e\000r\000",
+  #  "\377\376\334\000b\000e\000r\000c\000o\000d\000e\000r\000\015\000",
+  #  "\377\376\334\000b\000e\000r\000c\000o\000d\000e\000r\000\012\000",
+  #  "\377\376\334\000b\000e\000r\000c\000o\000d\000e\000r\000\015\000\012\000"
+  #])]
+  public function readLinesAutodetectUtf16Le($value) {
+    $r= $this->newReader($value, null);
     $this->assertEquals('Übercoder', $r->readLine());
   }
 

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -481,4 +481,15 @@ class TextReaderTest extends \unittest\TestCase {
       $reader->readLine()
     ]);
   }
+
+  #[@test]
+  public function readLine_and_read() {
+    $reader= $this->newReader("L1\nABL2");
+    $this->assertEquals(['L1', 'A', 'B', 'L2'], [
+      $reader->readLine(),
+      $reader->read(1),
+      $reader->read(1),
+      $reader->readLine()
+    ]);
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -470,4 +470,15 @@ class TextReaderTest extends \unittest\TestCase {
       // OK
     }
   }
+
+  #[@test]
+  public function read_and_readLine() {
+    $reader= $this->newReader("AL1\nBBL2");
+    $this->assertEquals(['A', 'L1', 'BB', 'L2'], [
+      $reader->read(1),
+      $reader->readLine(),
+      $reader->read(2),
+      $reader->readLine()
+    ]);
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -42,7 +42,7 @@ class TextReaderTest extends \unittest\TestCase {
    * @param   string $charset
    * @return  io.streams.TextReader
    */
-  protected function newReader($str, $charset= \xp::ENCODING) {
+  private function newReader($str, $charset= \xp::ENCODING) {
     return new TextReader(new MemoryInputStream($str), $charset);
   }
 
@@ -51,18 +51,21 @@ class TextReaderTest extends \unittest\TestCase {
    *
    * @return  io.streams.InputStream
    */
-  protected function unseekableStream() {
+  private function unseekableStream() {
     return new class() implements InputStream {
       public $bytes = "A\nB\n";
       public $offset = 0;
+
       public function read($length= 8192) {
         $chunk= substr($this->bytes, $this->offset, $length);
         $this->offset+= strlen($chunk);
         return $chunk;
       }
+
       public function available() {
         return strlen($this->bytes) - $this->offset;
       }
+
       public function close() { }
     };
   }


### PR DESCRIPTION
```php
<?php

use io\streams\TextReader;
use io\streams\FileInputStream;
use io\File;

class LineReading extends \util\profiling\Measurable {
  const FIXTURE = 'certs.lst';

  #[@measure]
  public function readLine_old() {
    $r= new TextReader(new FileInputStream(self::FIXTURE));
    $lines= 0;
    $longest= 0;
    while (null !== ($line= $r->readLine_old())) {
      $lines++;
      $longest= max($longest, strlen($line));
    }
    return [$lines, $longest];
  }

  #[@measure]
  public function readLine() {
    $r= new TextReader(new FileInputStream(self::FIXTURE));
    $lines= 0;
    $longest= 0;
    while (null !== ($line= $r->readLine())) {
      $lines++;
      $longest= max($longest, strlen($line));
    }
    return [$lines, $longest];
  }
}
```

```bash
$ xp -m devel\xp\measure\ util.profiling.Measure LineReading  -n 10
readLine_old: 10 iteration(s), 3.195 seconds, result= [2680, 76]
readLine: 10 iteration(s), 0.064 seconds, result= [2680, 76]
```