### PR TITLE
Use goto instead of `do ... while(true)` loop

### DIFF
--- a/src/main/php/io/streams/TextReader.class.php
+++ b/src/main/php/io/streams/TextReader.class.php
@@ -194,8 +194,6 @@ class TextReader extends Reader {
       $this->buf= substr($this->buf, $p + $o);
     }
 
-    // echo "<<< '", addcslashes($bytes, "\0..\17!\177..\377"), "'\n";
-
     $line= iconv($this->charset, \xp::ENCODING, $bytes);
     if (false === $line) {
       $message= key(@\xp::$errors[__FILE__][__LINE__ - 2]);


### PR DESCRIPTION
I never would've believed I'd say this one day, but IMO the code actually looks more readable with `goto` /cc @mikey179 @kiesel 

## In a nutshell
Before:
```php
do {
  $p= strcspn($buffer, "\r\n");
  if ($p === strlen($buffer)) {
    $buffer.= $stream->read();
    continue;
  }

  $line= substr(...);
  break;
} while (true);
```

After:
```php
search:
$p= strcspn($buffer, "\r\n");
if ($p === strlen($buffer)) {
  $buffer.= $stream->read();
  goto search;
}

$line= substr(...);
```