### PR TITLE
Reinstate XAR command

### DIFF
--- a/src/main/resources/xp/runtime/ar.md
+++ b/src/main/resources/xp/runtime/ar.md
@@ -3,26 +3,26 @@
 * Creates an archive from the directories "src" and "lib" as well as
   the file "etc/config.ini".
   ```sh
-  $ xp ar cf app.xar src/ lib/ etc/config.ini
+  $ xar cf app.xar src/ lib/ etc/config.ini
   ```
 * Extract all files inside the **app.xar** into the current directory.
   Directories and files are created if necessary, existing files are 
   overwritten.
   ```sh
-  $ xp ar xf app.xar
+  $ xar xf app.xar
   ```
 * List an archive's contents
   ```sh
-  $ xp ar tf app.xar
+  $ xar tf app.xar
   ```
 * Show a single file inside an archive. Always use forward-slashes!
   ```sh
-  $ xp ar sf tests.xar unittest/TestSuite.class.php
+  $ xar sf tests.xar unittest/TestSuite.class.php
   ```
 * Merge archives
   ```sh
-  $ xp ar mf uber.xar app.xar dependencies.xar
+  $ xar mf uber.xar app.xar dependencies.xar
   ```
 
-Add *v* to any of the operations, e.g. `xp ar cvf`, to get a more verbose
+Add *v* to any of the operations, e.g. `xar cvf`, to get a more verbose
 output of what is happening.


### PR DESCRIPTION
Implements xp-runners/reference#67 by:

* Changing usage to use `xar` instead of `xp ar`
* Changing `xar` invoked w/o arguments to effectively run `xp help ar`.