### PR TITLE
Clean up inheritance and implementation oddities in io.streams

### DIFF
--- a/src/main/php/io/streams/ConsoleInputStream.class.php
+++ b/src/main/php/io/streams/ConsoleInputStream.class.php
@@ -14,7 +14,8 @@ class ConsoleInputStream implements InputStream {
   /**
    * Constructor
    *
-   * @param   resource descriptor STDIN
+   * @param  var $descriptor STDIN
+   * @param  bool $close
    */
   public function __construct($descriptor, $close= false) {
     $this->descriptor= $descriptor;

--- a/src/main/php/io/streams/ConsoleInputStream.class.php
+++ b/src/main/php/io/streams/ConsoleInputStream.class.php
@@ -9,15 +9,16 @@
  * ```
  */
 class ConsoleInputStream implements InputStream {
-  protected $descriptor= null;
+  private $descriptor, $close;
   
   /**
    * Constructor
    *
    * @param   resource descriptor STDIN
    */
-  public function __construct($descriptor) {
+  public function __construct($descriptor, $close= false) {
     $this->descriptor= $descriptor;
+    $this->close= $close;
   }
 
   /**
@@ -54,6 +55,8 @@ class ConsoleInputStream implements InputStream {
    *
    */
   public function close() {
-    fclose($this->descriptor);
+    if ($this->close) {
+      fclose($this->descriptor);
+    }
   }
 }

--- a/src/main/php/io/streams/ConsoleOutputStream.class.php
+++ b/src/main/php/io/streams/ConsoleOutputStream.class.php
@@ -10,15 +10,17 @@
  * ```
  */
 class ConsoleOutputStream implements OutputStream {
-  protected $descriptor= null;
+  private $descriptor, $close;
   
   /**
    * Constructor
    *
-   * @param   resource descriptor one of STDOUT, STDERR
+   * @param  var $descriptor one of STDOUT, STDERR
+   * @param  bool $close
    */
-  public function __construct($descriptor) {
+  public function __construct($descriptor, $close= false) {
     $this->descriptor= $descriptor;
+    $this->close= $close;
   }
 
   /**
@@ -52,6 +54,8 @@ class ConsoleOutputStream implements OutputStream {
    *
    */
   public function close() {
-    fclose($this->descriptor);
+    if ($this->close) {
+      fclose($this->descriptor);
+    }
   }
 }

--- a/src/main/php/io/streams/InputStreamReader.class.php
+++ b/src/main/php/io/streams/InputStreamReader.class.php
@@ -6,13 +6,6 @@
 interface InputStreamReader {
 
   /**
-   * Constructor
-   *
-   * @param   io.streams.InputStream in
-   */
-  public function __construct($in);
-
-  /**
    * Read a number of bytes
    *
    * @param   int size default 8192

--- a/src/main/php/io/streams/LinesIn.class.php
+++ b/src/main/php/io/streams/LinesIn.class.php
@@ -6,7 +6,7 @@ use lang\IllegalArgumentException;
  * Represents the lines inside an input stream of bytes, delimited
  * by either Unix, Mac or Windows line endings.
  *
- * @see   xp://io.streams.TextReader#lines
+ * @see   xp://io.streams.Reader#lines
  * @test  xp://net.xp_framework.unittest.io.streams.LinesInTest
  */
 class LinesIn implements \IteratorAggregate {
@@ -15,13 +15,13 @@ class LinesIn implements \IteratorAggregate {
   /**
    * Creates a new lines instance
    *
-   * @param  io.streams.TextReader|io.streams.InputStrean|io.Channel|string $arg Input
-   * @param  string $charset Not taken into account when created by a TextReader
+   * @param  io.streams.Reader|io.streams.InputStrean|io.Channel|string $arg Input
+   * @param  string $charset Not taken into account when created by a Reader
    * @param  bool $reset Whether to start from the beginning (default: true)
    * @throws lang.IllegalArgumentException
    */
   public function __construct($arg, $charset= \xp::ENCODING, $reset= true) {
-    if ($arg instanceof TextReader) {
+    if ($arg instanceof Reader) {
       $this->reader= $arg;
     } else {
       $this->reader= new TextReader($arg, $charset);

--- a/src/main/php/io/streams/OutputStream.class.php
+++ b/src/main/php/io/streams/OutputStream.class.php
@@ -8,13 +8,15 @@ interface OutputStream extends \lang\Closeable {
   /**
    * Write a string
    *
-   * @param   var arg
+   * @param  var $arg
+   * @return void
    */
   public function write($arg);
 
   /**
    * Flush this buffer
    *
+   * @return void
    */
   public function flush();
 }

--- a/src/main/php/io/streams/OutputStreamWriter.class.php
+++ b/src/main/php/io/streams/OutputStreamWriter.class.php
@@ -6,34 +6,28 @@
 interface OutputStreamWriter {
 
   /**
-   * Constructor
-   *
-   * @param   io.streams.OutputStream out
-   */
-  public function __construct($out);
-
-  /**
    * Flush output buffer
    *
+   * @return void
    */
   public function flush();
 
   /**
-   * Print arguments
+   * Write arguments
    *
    * @param   var... args
    */
   public function write(... $args);
   
   /**
-   * Print arguments and append a newline
+   * Write arguments and append a newline
    *
    * @param   var... args
    */
   public function writeLine(... $args);
   
   /**
-   * Print a formatted string
+   * Write a formatted string
    *
    * @param   string format
    * @param   var... args
@@ -42,7 +36,7 @@ interface OutputStreamWriter {
   public function writef($format, ... $args);
 
   /**
-   * Print a formatted string and append a newline
+   * Write a formatted string and append a newline
    *
    * @param   string format
    * @param   var... args

--- a/src/main/php/io/streams/Reader.class.php
+++ b/src/main/php/io/streams/Reader.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\streams;
 
-use io\IOException;
-use lang\{Closeable, Value};
+use io\{IOException, Channel};
+use lang\{Closeable, Value, IllegalArgumentException};
 use util\Objects;
 
 /**
@@ -17,12 +17,22 @@ abstract class Reader implements InputStreamReader, Closeable, Value {
   protected $start= 0;
 
   /**
-   * Creates a new Reader from an InputStream.
+   * Constructor. Creates a new TextReader on an underlying input
+   * stream with a given charset.
    *
-   * @param io.streams.InputStream $stream
+   * @param   io.streams.InputStream|io.Channel|string $arg The input source
+   * @throws  lang.IllegalArgumentException
    */
-  public function __construct(InputStream $stream) {
-    $this->stream= $stream;
+  public function __construct($arg, $charset= null) {
+    if ($arg instanceof InputStream) {
+      $this->stream= $arg;
+    } else if ($arg instanceof Channel) {
+      $this->stream= $arg->in();
+    } else if (is_string($arg)) {
+      $this->stream= new MemoryInputStream($arg);
+    } else {
+      throw new IllegalArgumentException('Given argument is neither an input stream, a channel nor a string: '.typeof($arg)->getName());
+    }
   }
 
   /**

--- a/src/main/php/io/streams/Reader.class.php
+++ b/src/main/php/io/streams/Reader.class.php
@@ -1,7 +1,8 @@
 <?php namespace io\streams;
 
-use lang\Closeable;
 use io\IOException;
+use lang\{Closeable, Value};
+use util\Objects;
 
 /**
  * Serves as an abstract base class for all other readers. A reader
@@ -9,38 +10,101 @@ use io\IOException;
  * implementation (which works with bytes - for single-byte character
  * sets, there is no difference, obviously).
  */
-abstract class Reader implements Closeable {
+abstract class Reader implements InputStreamReader, Closeable, Value {
   protected $stream= null;
-  
+  protected $buf= '';
+  protected $beginning= true;
+  protected $start= 0;
+
   /**
    * Creates a new Reader from an InputStream.
    *
-   * @param   io.streams.InputStream stream
+   * @param io.streams.InputStream $stream
    */
   public function __construct(InputStream $stream) {
     $this->stream= $stream;
   }
 
   /**
+   * Returns whether we're at the beginning of the stream
+   *
+   * @return  bool
+   */
+  public function atBeginning() { return $this->beginning; }
+
+  /**
+   * Returns the underlying stream
+   *
+   * @deprecated Use stream() instead
+   * @return  io.streams.InputStream stream
+   */
+  public function getStream() { return $this->stream; }
+
+  /**
    * Returns the underlying stream
    *
    * @return  io.streams.InputStream stream
    */
-  public function getStream() {
-    return $this->stream;
+  public function stream() { return $this->stream; }
+
+  /**
+   * Return underlying output stream
+   *
+   * @param  io.streams.InputStream stream
+   * @return void
+   */
+  public function redirect(InputStream $stream) {
+    $this->stream= $stream;
+    $this->beginning= true;
+    $this->buf= '';
   }
 
   /**
-   * Reset to start. 
+   * Reset to start.
    *
    * @throws  io.IOException in case the underlying stream does not support seeking
    */
   public function reset() {
-    if (!($this->stream instanceof Seekable)) {
+    if ($this->stream instanceof Seekable) {
+      $this->stream->seek($this->start, SEEK_SET);
+      $this->beginning= true;
+      $this->buf= '';
+    } else {
       throw new IOException('Underlying stream does not support seeking');
     }
-    $this->stream->seek(0, SEEK_SET);
   }
+
+  /**
+   * Reads a given number of bytes
+   *
+   * @param  int $size
+   * @return string
+   */
+  protected function read0($size) {
+    $len= $size - strlen($this->buf);
+    if ($len > 0) {
+      $bytes= $this->buf.$this->stream->read($len);
+      $this->buf= '';
+    } else {
+      $bytes= substr($this->buf, 0, $size);
+      $this->buf= substr($this->buf, $size);
+    }
+    return $bytes;
+  }
+
+  /**
+   * Reads all lines in this reader
+   *
+   * @return io.streams.LinesIn
+   */
+  public function lines() { return new LinesIn($this, null, true); }
+
+  /**
+   * Reads the lines starting at the current position
+   *
+   * @return io.streams.LinesIn
+   */
+  public function readLines() { return new LinesIn($this, null, false); }
 
   /**
    * Closes this reader (and the underlying stream)
@@ -51,10 +115,28 @@ abstract class Reader implements Closeable {
     $this->stream->close();
   }
 
-  /**
-   * Destructor. Ensures output stream is closed.
-   */
+  /** @return void */
   public function __destruct() {
     $this->close();
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this)."@{\n  ".$this->stream->toString()."\n}";
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf((array)$this);
+  }
+
+  /**
+   * Compares this reader to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->stream, $value->stream) : 1;
   }
 }

--- a/src/main/php/io/streams/Reader.class.php
+++ b/src/main/php/io/streams/Reader.class.php
@@ -72,7 +72,8 @@ abstract class Reader implements InputStreamReader, Closeable, Value {
   /**
    * Reset to start.
    *
-   * @throws  io.IOException in case the underlying stream does not support seeking
+   * @return void
+   * @throws io.IOException in case the underlying stream does not support seeking
    */
   public function reset() {
     if ($this->stream instanceof Seekable) {

--- a/src/main/php/io/streams/StringReader.class.php
+++ b/src/main/php/io/streams/StringReader.class.php
@@ -1,70 +1,22 @@
 <?php namespace io\streams;
 
 /**
- * A InputStreamReader implementation that reads string values of
- * the given arguments from the underlying input stream.
+ * Reads strings from an underlying input stream. In contrast to the
+ * TextReader, no character set conversio is performed.
  *
  * @test  xp://net.xp_framework.unittest.io.streams.StringReaderTest
  */
-class StringReader implements InputStreamReader {
-  protected
-    $in  = null,
-    $buf = '';
-  
-  /**
-   * Constructor
-   *
-   * @param   io.streams.InputStream in
-   */
-  public function __construct($in) {
-    $this->in= $in;
-  }
-  
-  /**
-   * Return underlying input stream
-   *
-   * @return  io.streams.InputStream
-   */
-  public function getStream() {
-    return $this->in;
-  }
+class StringReader extends Reader {
 
   /**
    * Set underlying input stream
    *
-   * @param   io.streams.InputStream stream
+   * @deprecated Use redirect() instead
+   * @param  io.streams.InputStream $stream
+   * @return void
    */
   public function setStream(InputStream $stream) {
-    $this->in= $stream;
-    $this->buf= '';
-  }
-
-  /**
-   * Creates a string representation of this writer
-   *
-   * @return  string
-   */
-  public function toString() {
-    return nameof($this)."@{\n  ".$this->in->toString()."\n}";
-  }
-  
-  /**
-   * Read
-   *
-   * @param   int size
-   * @return  string
-   */
-  protected function read0($size) {
-    while (strlen($this->buf) < $size && $this->in->available() > 0) {
-      if (null === ($read= $this->in->read($size))) break;
-      $this->buf.= $read;
-    }
-
-    if (0 === strlen($this->buf)) return null;
-
-    $chunk= substr($this->buf, 0, $size);
-    $this->buf= substr($this->buf, $size);
-    return $chunk;
+    $this->redirect($stream);
   }
 
   /**
@@ -74,27 +26,48 @@ class StringReader implements InputStreamReader {
    * @return  string
    */
   public function read($size= 8192) {
-    return $this->read0($size);
+    if (0 === $size) return '';
+
+    $this->beginning= false;
+    $bytes= $this->read0($size);
+    if ('' === $bytes) {
+      $this->buf= null;
+      return null;
+    } else {
+      return $bytes;
+    }
   }
   
   /**
-   * Read an entire line. Returns NULL if no more lines are available.
+   * Read an entire line
    *
-   * @return  string
+   * @return  string NULL when end of data is reached
    */
   public function readLine() {
-    if (null === ($c= $this->read0(1))) return null;
-    $line= '';
+    if (null === $this->buf) return null;
+
+    $this->beginning= false;
     do {
-      if ("\r" === $c) {
-        $n= $this->read0(1);
-        if ("\n" !== $n) $this->buf= $n.$this->buf;
-        return $line;
-      } else if ("\n" === $c) {
-        return $line;
+      $p= strcspn($this->buf, "\r\n");
+      $l= strlen($this->buf);
+      if ($p >= $l - 1) {
+        $chunk= $this->stream->read();
+        if ('' === $chunk) {
+          if ('' === $this->buf) return null;
+          $bytes= $p === $l ? $this->buf : substr($this->buf, 0, $p);
+          $this->buf= null;
+          break;
+        }
+        $this->buf.= $chunk;
+        continue;
       }
-      $line.= $c;
-    } while (null !== ($c= $this->read0(1)));
-    return $line;
+
+      $o= ("\r" === $this->buf{$p} && "\n" === $this->buf{$p + 1}) ? 2 : 1;
+      $bytes= substr($this->buf, 0, $p);
+      $this->buf= substr($this->buf, $p + $o);
+      break;
+    } while (true);
+
+    return $bytes;
   }
 }

--- a/src/main/php/io/streams/StringWriter.class.php
+++ b/src/main/php/io/streams/StringWriter.class.php
@@ -8,102 +8,26 @@ use util\Objects;
  *
  * @test  xp://net.xp_framework.unittest.io.streams.StringWriterTest
  */
-class StringWriter implements OutputStreamWriter {
-  protected $out= null;
-  
-  /**
-   * Constructor
-   *
-   * @param   io.streams.OutputStream out
-   */
-  public function __construct($out) {
-    $this->out= $out;
-  }
-  
-  /**
-   * Return underlying output stream
-   *
-   * @return  io.streams.OutputStream
-   */
-  public function getStream() {
-    return $this->out;
-  }
+class StringWriter extends Writer {
 
   /**
    * Return underlying output stream
    *
-   * @param   io.streams.OutputStream stream
+   * @deprecated Use redirect() instead
+   * @param  io.streams.OutputStream stream
+   * @return void
    */
   public function setStream(OutputStream $stream) {
-    $this->out= $stream;
+    $this->redirect($stream);
   }
 
   /**
-   * Creates a string representation of this writer
+   * Writes text
    *
-   * @return  string
+   * @param  string $text
+   * @return int
    */
-  public function toString() {
-    return nameof($this)."@{\n  ".$this->out->toString()."\n}";
-  }
-
-  /**
-   * Flush output buffer
-   *
-   */
-  public function flush() {
-    $this->out->flush();
-  }
-
-  /**
-   * Print arguments
-   *
-   * @param   var... args
-   */
-  public function write(... $args) {
-    foreach ($args as $arg) {
-      if (is_string($arg)) {
-        $this->out->write($arg);
-      } else {
-        $this->out->write(Objects::stringOf($arg));
-      }
-    }
-  }
-  
-  /**
-   * Print arguments and append a newline
-   *
-   * @param   var... args
-   */
-  public function writeLine(... $args) {
-    foreach ($args as $arg) {
-      if (is_string($arg)) {
-        $this->out->write($arg);
-      } else {
-        $this->out->write(Objects::stringOf($arg));
-      }
-    }
-    $this->out->write("\n");
-  }
-  
-  /**
-   * Print a formatted string
-   *
-   * @param   string format
-   * @param   var... args
-   * @see     php://writef
-   */
-  public function writef($format, ... $args) {
-    $this->out->write(vsprintf($format, $args));
-  }
-
-  /**
-   * Print a formatted string and append a newline
-   *
-   * @param   string format
-   * @param   var... args
-   */
-  public function writeLinef($format, ... $args) {
-    $this->out->write(vsprintf($format, $args)."\n");
+  protected function write0($text) {
+    $this->stream->write($text);
   }
 }

--- a/src/main/php/io/streams/TextReader.class.php
+++ b/src/main/php/io/streams/TextReader.class.php
@@ -1,9 +1,6 @@
 <?php namespace io\streams;
 
-use io\IOException;
-use io\Channel;
 use lang\FormatException;
-use lang\IllegalArgumentException;
 
 /**
  * Reads text from an underlying input stream, converting it from the
@@ -25,16 +22,7 @@ class TextReader extends Reader {
    * @throws  lang.IllegalArgumentException
    */
   public function __construct($arg, $charset= null) {
-    if ($arg instanceof InputStream) {
-      parent::__construct($arg);
-    } else if ($arg instanceof Channel) {
-      parent::__construct($arg->in());
-    } else if (is_string($arg)) {
-      parent::__construct(new MemoryInputStream($arg));
-    } else {
-      throw new IllegalArgumentException('Given argument is neither an input stream, a channel nor a string: '.typeof($arg)->getName());
-    }
-
+    parent::__construct($arg);
     switch ($this->charset= strtolower($charset ?: $this->detectCharset())) {
       case 'utf-16le': $this->cl= 2; $this->of= 0; break;
       case 'utf-16be': $this->cl= 2; $this->of= 1; break;

--- a/src/main/php/io/streams/TextWriter.class.php
+++ b/src/main/php/io/streams/TextWriter.class.php
@@ -4,42 +4,49 @@ use lang\IllegalArgumentException;
 use io\Channel;
 
 /**
- * Writes text from to underlying output stream. When writing lines,
- * uses the newLine property's bytes as newline separator, defaulting
- * to "\n".
+ * Writes text from to underlying output stream, encoding to the
+ * given character set.
  *
- * @test    xp://net.xp_framework.unittest.io.streams.TextWriterTest
- * @ext     iconv
+ * @test  xp://net.xp_framework.unittest.io.streams.TextWriterTest
+ * @ext   iconv
  */
 class TextWriter extends Writer {
-  private $charset= '';
-  private $newLine= "\n";
+  private $charset;
 
   /**
    * Constructor. Creates a new TextWriter on an underlying output
    * stream with a given charset.
    *
    * @param   io.streams.OutputStream|io.Channel $arg The target
-   * @param   string $charset the charset the stream is encoded in.
+   * @param   string $charset the character set to encode to.
    * @throws  lang.IllegalArgumentException
    */
   public function __construct($arg, $charset= \xp::ENCODING) {
     if ($arg instanceof OutputStream) {
-      parent::__construct($arg);
+      $target= $arg;
     } else if ($arg instanceof Channel) {
-      parent::__construct($arg->out());
+      $target= $arg->out();
     } else {
       throw new IllegalArgumentException('Given argument is neither an input stream, a channel nor a string: '.typeof($arg)->getName());
     }
+
     $this->charset= $charset;
+    parent::__construct($target);
   }
+
+  /**
+   * Returns the character set used
+   *
+   * @return string
+   */
+  public function charset() { return $this->charset; }
 
   /**
    * Writes a BOM
    *
-   * @see     http://de.wikipedia.org/wiki/Byte_Order_Mark
-   * @see     http://unicode.org/faq/utf_bom.html
-   * @return  io.streams.TextWriter this
+   * @see    http://de.wikipedia.org/wiki/Byte_Order_Mark
+   * @see    http://unicode.org/faq/utf_bom.html
+   * @return self
    */
   public function withBom() {
     switch (strtolower($this->charset)) {
@@ -53,6 +60,7 @@ class TextWriter extends Writer {
   /**
    * Sets newLine property's bytes
    *
+   * @deprecated Use withNewLine() instead
    * @param   string newLine
    */
   public function setNewLine($newLine) {
@@ -60,19 +68,9 @@ class TextWriter extends Writer {
   }
   
   /**
-   * Sets newLine property's bytes and returns this writer
-   *
-   * @param   string newLine
-   * @return  io.streams.TextWriter this
-   */
-  public function withNewLine($newLine) {
-    $this->newLine= $newLine;
-    return $this;
-  }
-
-  /**
    * Gets newLine property's bytes
    *
+   * @deprecated Use newLine() instead
    * @return  string newLine
    */
   public function getNewLine() {
@@ -80,20 +78,12 @@ class TextWriter extends Writer {
   }
 
   /**
-   * Write characters
+   * Writes text
    *
-   * @param   string text
+   * @param  string $text
+   * @return int
    */
-  public function write($text) {
-    $this->stream->write(iconv(\xp::ENCODING, $this->charset, $text));
-  }
-  
-  /**
-   * Write an entire line
-   *
-   * @param   string text
-   */
-  public function writeLine($text= '') {
-    $this->stream->write(iconv(\xp::ENCODING, $this->charset, $text).$this->newLine);
+  protected function write0($text) {
+    return $this->stream->write(iconv(\xp::ENCODING, $this->charset, $text));
   }
 }

--- a/src/main/php/io/streams/TextWriter.class.php
+++ b/src/main/php/io/streams/TextWriter.class.php
@@ -1,8 +1,5 @@
 <?php namespace io\streams;
 
-use lang\IllegalArgumentException;
-use io\Channel;
-
 /**
  * Writes text from to underlying output stream, encoding to the
  * given character set.
@@ -22,16 +19,8 @@ class TextWriter extends Writer {
    * @throws  lang.IllegalArgumentException
    */
   public function __construct($arg, $charset= \xp::ENCODING) {
-    if ($arg instanceof OutputStream) {
-      $target= $arg;
-    } else if ($arg instanceof Channel) {
-      $target= $arg->out();
-    } else {
-      throw new IllegalArgumentException('Given argument is neither an input stream, a channel nor a string: '.typeof($arg)->getName());
-    }
-
-    $this->charset= $charset;
-    parent::__construct($target);
+    parent::__construct($arg);
+    $this->charset= $charset;    
   }
 
   /**

--- a/src/main/php/io/streams/Writer.class.php
+++ b/src/main/php/io/streams/Writer.class.php
@@ -1,6 +1,7 @@
 <?php namespace io\streams;
 
-use lang\{Closeable, Value};
+use io\Channel;
+use lang\{Closeable, Value, IllegalArgumentException};
 use util\Objects;
 
 /**
@@ -14,12 +15,23 @@ abstract class Writer implements OutputStreamWriter, Closeable, Value {
   protected $newLine= "\n";
   
   /**
-   * Constructor. Creates a new Writer from an OutputStream.
+   * Constructor. Creates a new TextWriter on an underlying output
+   * stream with a given charset.
    *
-   * @param   io.streams.OutputStream stream
+   * @param  io.streams.OutputStream|io.Channel|string $arg The target
+   * @param  string $charset the character set to encode to.
+   * @throws lang.IllegalArgumentException
    */
-  public function __construct(OutputStream $stream) {
-    $this->stream= $stream;
+  public function __construct($arg, $charset= \xp::ENCODING) {
+    if ($arg instanceof OutputStream) {
+      $this->stream= $arg;
+    } else if ($arg instanceof Channel) {
+      $this->stream= $arg->out();
+    } else if (is_string($arg)) {
+      $this->stream= new MemoryOutputStream($arg);
+    } else {
+      throw new IllegalArgumentException('Given argument is neither an output stream, a channel nor a string: '.typeof($arg)->getName());
+    }
   }
 
   /**

--- a/src/main/php/io/streams/Writer.class.php
+++ b/src/main/php/io/streams/Writer.class.php
@@ -1,6 +1,7 @@
 <?php namespace io\streams;
 
-use lang\Closeable;
+use lang\{Closeable, Value};
+use util\Objects;
 
 /**
  * Serves as an abstract base class for all other writers. A writer
@@ -8,8 +9,9 @@ use lang\Closeable;
  * (which works with bytes - for single-byte character sets, there is 
  * no difference, obviously).
  */
-abstract class Writer implements Closeable {
+abstract class Writer implements OutputStreamWriter, Closeable, Value {
   protected $stream= null;
+  protected $newLine= "\n";
   
   /**
    * Constructor. Creates a new Writer from an OutputStream.
@@ -19,21 +21,150 @@ abstract class Writer implements Closeable {
   public function __construct(OutputStream $stream) {
     $this->stream= $stream;
   }
-  
+
+  /**
+   * Returns the underlying stream
+   *
+   * @deprecated Use stream() instead
+   * @return  io.streams.OutputStream stream
+   */
+  public function getStream() { return $this->stream; }
+
   /**
    * Returns the underlying stream
    *
    * @return  io.streams.OutputStream stream
    */
-  public function getStream() {
-    return $this->stream;
+  public function stream() { return $this->stream; }
+
+  /**
+   * Return underlying output stream
+   *
+   * @param  io.streams.OutputStream stream
+   * @return void
+   */
+  public function redirect(OutputStream $stream) {
+    $this->stream= $stream;
+  }
+
+  /**
+   * Gets newLine property's bytes
+   *
+   * @return  string newLine
+   */
+  public function newLine() { return $this->newLine; }
+
+  /**
+   * Sets newLine property's bytes and returns this writer
+   *
+   * @param  string $newLine
+   * @return self
+   */
+  public function withNewLine($newLine) {
+    $this->newLine= $newLine;
+    return $this;
+  }
+
+  /**
+   * Flush output buffer
+   *
+   * @return void
+   */
+  public function flush() {
+    $this->stream->flush();
+  }
+
+  /**
+   * Writes text. Implemented in subclasses.
+   *
+   * @param  string $text
+   * @return int
+   */
+  protected abstract function write0($text);
+
+  /**
+   * Print arguments
+   *
+   * @param   var... args
+   */
+  public function write(... $args) {
+    foreach ($args as $arg) {
+      if (is_string($arg)) {
+        $this->write0($arg);
+      } else {
+        $this->write0(Objects::stringOf($arg));
+      }
+    }
   }
   
   /**
-   * Closes this reader (and the underlying stream)
+   * Print arguments and append a newline
    *
+   * @param   var... args
+   */
+  public function writeLine(... $args) {
+    foreach ($args as $arg) {
+      if (is_string($arg)) {
+        $this->write0($arg);
+      } else {
+        $this->write0(Objects::stringOf($arg));
+      }
+    }
+    $this->write0($this->newLine);
+  }
+  
+  /**
+   * Print a formatted string
+   *
+   * @param   string format
+   * @param   var... args
+   * @see     php://writef
+   */
+  public function writef($format, ... $args) {
+    $this->write0(vsprintf($format, $args));
+  }
+
+  /**
+   * Print a formatted string and append a newline
+   *
+   * @param   string format
+   * @param   var... args
+   */
+  public function writeLinef($format, ... $args) {
+    $this->write0(vsprintf($format, $args).$this->newLine);
+  }
+
+  /**
+   * Closes this writer (and the underlying stream)
+   *
+   * @return void
    */
   public function close() {
     $this->stream->close();
+  }
+
+  /** @return void */
+  public function __destruct() {
+    $this->close();
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this)."@{\n  ".$this->stream->toString()."\n}";
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf((array)$this);
+  }
+
+  /**
+   * Compares this reader to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->stream, $value->stream) : 1;
   }
 }

--- a/src/main/php/io/streams/Writer.class.php
+++ b/src/main/php/io/streams/Writer.class.php
@@ -97,7 +97,8 @@ abstract class Writer implements OutputStreamWriter, Closeable, Value {
   /**
    * Print arguments
    *
-   * @param   var... args
+   * @param  var... $args
+   * @return void
    */
   public function write(... $args) {
     foreach ($args as $arg) {
@@ -112,7 +113,8 @@ abstract class Writer implements OutputStreamWriter, Closeable, Value {
   /**
    * Print arguments and append a newline
    *
-   * @param   var... args
+   * @param  var... $args
+   * @return void
    */
   public function writeLine(... $args) {
     foreach ($args as $arg) {
@@ -128,9 +130,9 @@ abstract class Writer implements OutputStreamWriter, Closeable, Value {
   /**
    * Print a formatted string
    *
-   * @param   string format
-   * @param   var... args
-   * @see     php://writef
+   * @param  string $format
+   * @param  var... $args
+   * @return void
    */
   public function writef($format, ... $args) {
     $this->write0(vsprintf($format, $args));
@@ -139,8 +141,9 @@ abstract class Writer implements OutputStreamWriter, Closeable, Value {
   /**
    * Print a formatted string and append a newline
    *
-   * @param   string format
-   * @param   var... args
+   * @param  string $format
+   * @param  var... $args
+   * @return void
    */
   public function writeLinef($format, ... $args) {
     $this->write0(vsprintf($format, $args).$this->newLine);

--- a/src/main/php/io/streams/Writer.class.php
+++ b/src/main/php/io/streams/Writer.class.php
@@ -19,10 +19,9 @@ abstract class Writer implements OutputStreamWriter, Closeable, Value {
    * stream with a given charset.
    *
    * @param  io.streams.OutputStream|io.Channel|string $arg The target
-   * @param  string $charset the character set to encode to.
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($arg, $charset= \xp::ENCODING) {
+  public function __construct($arg) {
     if ($arg instanceof OutputStream) {
       $this->stream= $arg;
     } else if ($arg instanceof Channel) {

--- a/src/main/php/util/cmd/Console.class.php
+++ b/src/main/php/util/cmd/Console.class.php
@@ -1,14 +1,6 @@
 <?php namespace util\cmd;
 
-use lang\IllegalStateException;
-use io\streams\{
-  InputStreamReader,
-  OutputStreamWriter,
-  StringWriter,
-  StringReader,
-  ConsoleOutputStream,
-  ConsoleInputStream
-};
+use io\streams\{StringWriter, StringReader, ConsoleOutputStream, ConsoleInputStream};
 
 /**
  * Represents system console
@@ -53,30 +45,16 @@ abstract class Console {
       self::$out= new StringWriter(new ConsoleOutputStream(STDOUT));
       self::$err= new StringWriter(new ConsoleOutputStream(STDERR));
     } else {
-      self::$in= new class(null) implements InputStreamReader {
-        public function __construct($in) { }
-        public function getStream() { return null; }
-        public function raise() { throw new IllegalStateException('There is no console present'); }
-        public function read($count= 8192) { $this->raise(); }
-        public function readLine() { $this->raise(); }
-      };
-      self::$out= self::$err= new class(null) implements OutputStreamWriter {
-        public function __construct($out) { }
-        public function getStream() { return null; }
-        public function flush() { $this->raise(); }
-        public function raise() { throw new IllegalStateException('There is no console present'); }
-        public function write(... $args) { $this->raise(); }
-        public function writeLine(... $args) { $this->raise(); }
-        public function writef($format, ... $args) { $this->raise(); }
-        public function writeLinef($format, ... $args) { $this->raise(); }
-      };
+      self::$in= new NoInput();
+      self::$out= new NoOutput();
+      self::$err= new NoOutput();
     }
   }
 
   /**
    * Flush output buffer
    *
-   * @return  void
+   * @return void
    */
   public static function flush() {
     self::$out->flush();
@@ -85,7 +63,8 @@ abstract class Console {
   /**
    * Write a string to standard output
    *
-   * @param   var... args
+   * @param  var... $args
+   * @return void
    */
   public static function write(... $args) {
     self::$out->write(...$args);
@@ -94,7 +73,8 @@ abstract class Console {
   /**
    * Write a string to standard output and append a newline
    *
-   * @param   var... args
+   * @param  var... $args
+   * @return void
    */
   public static function writeLine(... $args) {
     self::$out->writeLine(...$args);
@@ -103,9 +83,9 @@ abstract class Console {
   /**
    * Write a formatted string to standard output
    *
-   * @param   string format
-   * @param   var... args
-   * @see     php://printf
+   * @param  string $format
+   * @param  var... $args
+   * @return void
    */
   public static function writef($format, ... $args) {
     self::$out->writef($format, ...$args);
@@ -114,8 +94,9 @@ abstract class Console {
   /**
    * Write a formatted string to standard output and append a newline
    *
-   * @param   string format
-   * @param   var* args
+   * @param  string $format
+   * @param  var... $args
+   * @return void
    */
   public static function writeLinef($format, ... $args) {
     self::$out->writeLinef($format, ...$args);
@@ -124,8 +105,11 @@ abstract class Console {
   /**
    * Read a line from standard input. The line ending (\r and/or \n)
    * is trimmed off the end.
+   *
+   * @param  string $prompt Optional prompt
+   * @return string
    */    
-  public static function readLine(string $prompt= null): string {
+  public static function readLine(string $prompt= null) {
     $prompt && self::$out->write($prompt.' ');
     return self::$in->readLine();
   }
@@ -133,10 +117,10 @@ abstract class Console {
   /**
    * Read a single character from standard input.
    *
-   * @param   string prompt = NULL
-   * @return  string
+   * @param  string $prompt Optional prompt
+   * @return string
    */    
-  public static function read(string $prompt= null): string {
+  public static function read(string $prompt= null) {
     $prompt && self::$out->write($prompt.' ');
     return self::$in->read(1);
   }

--- a/src/main/php/util/cmd/NoConsole.class.php
+++ b/src/main/php/util/cmd/NoConsole.class.php
@@ -1,0 +1,22 @@
+<?php namespace util\cmd;
+
+use lang\IllegalStateException;
+
+/** Used by NoInput and NoOutput */
+trait NoConsole {
+
+  /** No-arg constructor */
+  public function __construct() {
+    // Intentionally empty!
+  }
+
+  /** @return void */
+  public function close() {
+    // Intentionally empty!
+  }
+
+  /** @return void */
+  protected function raise() {
+    throw new IllegalStateException('There is no console present');
+  }
+}

--- a/src/main/php/util/cmd/NoInput.class.php
+++ b/src/main/php/util/cmd/NoInput.class.php
@@ -1,0 +1,21 @@
+<?php namespace util\cmd;
+
+class NoInput extends \io\streams\StringReader {
+  use NoConsole;
+
+  /**
+   * Read a string
+   *
+   * @param  int $limit default 8192
+   * @return string
+   */
+  public function read($limit= 8192) { $this->raise(); }
+
+  /**
+   * Read a string
+   *
+   * @param  int $limit default 8192
+   * @return string
+   */
+  public function readLine() { $this->raise(); }
+}

--- a/src/main/php/util/cmd/NoOutput.class.php
+++ b/src/main/php/util/cmd/NoOutput.class.php
@@ -1,0 +1,13 @@
+<?php namespace util\cmd;
+
+class NoOutput extends \io\streams\StringWriter {
+  use NoConsole;
+
+  /**
+   * Writes text
+   *
+   * @param  string $text
+   * @return int
+   */
+  protected function write0($text) { $this->raise(); }
+}

--- a/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/cmd/ConsoleTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace net\xp_framework\unittest\util\cmd;
 
-use util\cmd\Console;
+use util\cmd\{Console, NoInput, NoOutput};
 use lang\{Value, IllegalStateException};
 use io\streams\{MemoryInputStream, MemoryOutputStream, ConsoleOutputStream, ConsoleInputStream};
 
@@ -15,24 +15,24 @@ class ConsoleTest extends \unittest\TestCase {
    * to memory streams
    */
   public function setUp() {
-    $this->original= [Console::$in->getStream(), Console::$out->getStream(), Console::$err->getStream()];
+    $this->original= [Console::$in->stream(), Console::$out->stream(), Console::$err->stream()];
     $this->streams= [null, new MemoryOutputStream(), new MemoryOutputStream()];
-    Console::$out->setStream($this->streams[1]);
-    Console::$err->setStream($this->streams[2]);
+    Console::$out->redirect($this->streams[1]);
+    Console::$err->redirect($this->streams[2]);
   }
   
   /**
    * Tear down testcase. Restores original standard output/error streams
    */
   public function tearDown() {
-    Console::$in->setStream($this->original[0]);
-    Console::$out->setStream($this->original[1]);
-    Console::$err->setStream($this->original[2]);
+    Console::$in->redirect($this->original[0]);
+    Console::$out->redirect($this->original[1]);
+    Console::$err->redirect($this->original[2]);
   }
 
   #[@test]
   public function read() {
-    Console::$in->setStream(new MemoryInputStream('.'));
+    Console::$in->redirect(new MemoryInputStream('.'));
     $this->assertEquals('.', Console::read());
   }
 
@@ -42,20 +42,20 @@ class ConsoleTest extends \unittest\TestCase {
   #  "Hello\r\nHallo",
   #])]
   public function readLine($variation) {
-    Console::$in->setStream(new MemoryInputStream($variation));
+    Console::$in->redirect(new MemoryInputStream($variation));
     $this->assertEquals('Hello', Console::readLine());
     $this->assertEquals('Hallo', Console::readLine());
   }
 
   #[@test]
   public function read_from_standard_input() {
-    Console::$in->setStream(new MemoryInputStream('.'));
+    Console::$in->redirect(new MemoryInputStream('.'));
     $this->assertEquals('.', Console::$in->read(1));
   }
  
   #[@test]
   public function readLine_from_standard_input() {
-    Console::$in->setStream(new MemoryInputStream("Hello\nHallo\nOla"));
+    Console::$in->redirect(new MemoryInputStream("Hello\nHallo\nOla"));
     $this->assertEquals('Hello', Console::$in->readLine());
     $this->assertEquals('Hallo', Console::$in->readLine());
     $this->assertEquals('Ola', Console::$in->readLine());
@@ -208,8 +208,8 @@ class ConsoleTest extends \unittest\TestCase {
   /**
    * Test initialization
    *
-   * @param  bool console
-   * @param  var assertions
+   * @param  bool $console
+   * @param  function(): void $assertions
    */
   protected function initialize($console, $assertions) {
     $in= Console::$in;
@@ -228,18 +228,18 @@ class ConsoleTest extends \unittest\TestCase {
   #[@test]
   public function initialize_on_console() {
     $this->initialize(true, function() {
-      $this->assertInstanceOf(ConsoleInputStream::class, Console::$in->getStream());
-      $this->assertInstanceOf(ConsoleOutputStream::class, Console::$out->getStream());
-      $this->assertInstanceOf(ConsoleOutputStream::class, Console::$err->getStream());
+      $this->assertInstanceOf(ConsoleInputStream::class, Console::$in->stream());
+      $this->assertInstanceOf(ConsoleOutputStream::class, Console::$out->stream());
+      $this->assertInstanceOf(ConsoleOutputStream::class, Console::$err->stream());
     });
   }
 
   #[@test]
   public function initialize_without_console() {
     $this->initialize(false, function() {
-      $this->assertEquals(null, Console::$in->getStream());
-      $this->assertEquals(null, Console::$out->getStream());
-      $this->assertEquals(null, Console::$err->getStream());
+      $this->assertNull(Console::$in->stream());
+      $this->assertNull(Console::$out->stream());
+      $this->assertNull(Console::$err->stream());
     });
   }
 }


### PR DESCRIPTION
## In a nutshell

This pull request:

* Changes `io.streams.StringReader` and `io.streams.TextReader` to both inherit from `io.streams.Reader`. The first reads without encoding, the latter does.
* Does the same for `io.streams.StringWriter` and `io.streams.TextWriter`
* Deprecates `getStream()` in favor of `stream()` and `setStream()` in favor of `redirect()`.

## Motivation

In addition to cleaning up the odd API, util.cmd.Console becomes useable in place where previously only TextReaders were accepted, see for example xp-forge/markdown#11

## API
Old readers:
```php
package io.streams;

public class StringReader extends Reader {
  public __construct(InputStream $in)

  public InputStream getStream()
  public var setStream(InputStream $stream)
  public string toString()
  public string read(int $size)
  public string readLine()
}

public class TextReader extends Reader {
  public __construct(InputStream|io.Channel|string $arg, string $charset)

  public string charset()
  public bool atBeginning()
  public var reset()
  public string read(int $size)
  public string readLine()
  public LinesIn lines()
  public LinesIn readLines()
  public InputStream getStream()
  public void close()
}
```

New readers:
```php
package io.streams;

public class StringReader extends Reader {
  public __construct(InputStream|io.Channel|string $arg)
}

public class TextReader extends Reader {
  public __construct(InputStream|io.Channel|string $arg, string $charset)

  public string charset()
}

public abstract class Reader implements InputStreamReader, lang.Closeable, lang.Value {
  public bool atBeginning()
  public InputStream stream()
  public void redirect(InputStream $stream)
  public void reset()
  public string read(int $size)
  public string readLine()
  public LinesIn lines()
  public LinesIn readLines()
  public void close()
  public string toString()
  public string hashCode()
  public int compareTo(var $value)
}
```

Old writers:

```php
package io.streams;

public class StringWriter implements OutputStreamWriter {
  public __construct(OutputStream $out)

  public OutputStream getStream()
  public var setStream(OutputStream $stream)
  public string toString()
  public var flush()
  public var write(var... $args)
  public var writeLine(var... $args)
  public var writef(string $format, var... $args)
  public var writeLinef(string $format, var... $args)
}

public class TextWriter extends Writer {
  public __construct(OutputStream|io.Channel $arg, string $charset)

  public TextWriter withBom()
  public var setNewLine(string $newLine)
  public TextWriter withNewLine(string $newLine)
  public string getNewLine()
  public var write(string $text)
  public var writeLine(string $text)
  public OutputStream getStream()
  public var close()
}
```

New writers:

```php
package io.streams;

public class StringWriter extends Writer {
  public __construct(OutputStream|io.Channel|string $arg)
}

public class TextWriter extends Writer {
  public __construct(OutputStream|io.Channel $arg, string $charset)

  public string charset()
  public self withBom()
}

public abstract class Writer implements OutputStreamWriter, lang.Closeable, lang.Value {
  public __construct(OutputStream|io.Channel|string $arg, string $charset)

  public OutputStream stream()
  public void redirect(OutputStream $stream)
  public string newLine()
  public self withNewLine(string $newLine)
  public void flush()
  public void write(var... $args)
  public void writeLine(var... $args)
  public void writef(string $format, var... $args)
  public void writeLinef(string $format, var... $args)
  public void close()
  public string toString()
  public string hashCode()
  public int compareTo(var $value)
}
```
