### PR TITLE
Remove all reference to lang.Object

### DIFF
--- a/src/main/php/lang/FunctionType.class.php
+++ b/src/main/php/lang/FunctionType.class.php
@@ -163,7 +163,7 @@ class FunctionType extends Type {
    *
    * - A closure
    * - A string referencing a function, e.g. 'strlen' or 'typeof'
-   * - A string referencing an instance creation expression: 'lang.Object::new'
+   * - A string referencing an instance creation expression: 'util.Date::new'
    * - A string referencing a static method: 'lang.XPClass::forName'
    * - An array of two strings referencing a static method: ['lang.XPClass', 'forName']
    * - An array of an instance and a string referencing an instance method: [$this, 'getName']

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -43,7 +43,6 @@ define('DETAIL_GENERIC',        7);
  * }
  * ``` 
  *
- * @see   xp://lang.Object#getClass
  * @see   xp://lang.XPClass#forName
  * @test  xp://net.xp_framework.unittest.reflection.XPClassTest
  * @test  xp://net.xp_framework.unittest.reflection.ClassDetailsTest
@@ -177,7 +176,7 @@ class XPClass extends Type {
    * </code>
    *
    * @param   var... args
-   * @return  lang.Object 
+   * @return  object 
    * @throws  lang.IllegalAccessException in case this class cannot be instantiated
    */
   public function newInstance($value= null) {
@@ -419,8 +418,8 @@ class XPClass extends Type {
    * Tests whether this class is assignable from a given type
    *
    * <code>
-   *   // util.Date instanceof lang.Object
-   *   XPClass::forName('lang.Object')->isAssignableFrom('util.Date');   // TRUE
+   *   // util.Date instanceof lang.Value
+   *   XPClass::forName('lang.Value')->isAssignableFrom('util.Date');   // TRUE
    * </code>
    *
    * @param   string|lang.Type $type
@@ -445,7 +444,7 @@ class XPClass extends Type {
    * 
    * var_dump($class->isInstance(new TempFile()));  // TRUE
    * var_dump($class->isInstance(new File()));      // TRUE
-   * var_dump($class->isInstance(new Object()));    // FALSE
+   * var_dump($class->isInstance(new Date()));      // FALSE
    * ```
    *
    * @param   var obj

--- a/src/main/php/lang/reflect/Method.class.php
+++ b/src/main/php/lang/reflect/Method.class.php
@@ -18,8 +18,8 @@ class Method extends Routine {
    *
    * Example:
    * ```php
-   * $method= XPClass::forName('lang.Object')->getMethod('toString');
-   * $str= $method->invoke(new Object());
+   * $method= XPClass::forName('lang.Value')->getMethod('toString');
+   * $str= $method->invoke(new Date());
    * ```
    *
    * Example (passing arguments)

--- a/src/test/php/net/xp_framework/unittest/core/ReferencesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ReferencesTest.class.php
@@ -40,8 +40,8 @@ class ReferencesTest extends \unittest\TestCase {
   /**
    * Helper method that asserts to objects are references to each other
    *
-   * @param   &lang.Object $a
-   * @param   &lang.Object $b
+   * @param   var $a
+   * @param   var $b
    * @throws  unittest.AssertionFailedError
    */
   protected function assertReference($a, $b) {

--- a/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/StringOfTest.class.php
@@ -16,7 +16,7 @@ class StringOfTest extends \unittest\TestCase {
    * Returns a class with a toString() method that always returns the 
    * string `TestString(6) { String }`.
    *
-   * @return lang.Object
+   * @return object
    */
   protected function testStringInstance() {
     return new class() implements Value {

--- a/src/test/php/net/xp_framework/unittest/reflection/AbstractTestClass.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/AbstractTestClass.class.php
@@ -7,7 +7,7 @@
  */
 abstract class AbstractTestClass {
   protected
-    #[@type('lang.Object')]
+    #[@type('lang.Value')]
     $inherited= null;
 
   /**

--- a/src/test/php/net/xp_framework/unittest/reflection/TestClass.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TestClass.class.php
@@ -15,7 +15,7 @@ class TestClass extends AbstractTestClass implements \lang\Runnable {
   #[@type('util.Date')]
   public $date   = null;
 
-  /** @var [:lang.Object] */
+  /** @var [:object] */
   public $map    = [];
 
   /** @type int */
@@ -128,7 +128,7 @@ class TestClass extends AbstractTestClass implements \lang\Runnable {
   /**
    * Retrieve map as a PHP hashmap
    *
-   * @return  [:lang.Object]
+   * @return  [:object]
    */
   public function getMap() {
     return $this->map;
@@ -153,7 +153,7 @@ class TestClass extends AbstractTestClass implements \lang\Runnable {
   /**
    * Initialize map to default values
    *
-   * @param   [:lang.Object] map
+   * @param   [:object] map
    */
   final public function setMap($map) {
     $this->map= $map;
@@ -171,7 +171,7 @@ class TestClass extends AbstractTestClass implements \lang\Runnable {
   /**
    * Create a new instance statically
    *
-   * @param   [:lang.Object] map
+   * @param   [:object] map
    * @return  net.xp_framework.unittest.reflection.TestClass
    */
   public static function fromMap(array $map) {
@@ -183,10 +183,10 @@ class TestClass extends AbstractTestClass implements \lang\Runnable {
   /**
    * Retrieve values
    *
-   * @return  util.collections.Vector<lang.Object>
+   * @return  util.collections.Vector<object>
    */
   public function mapValues() {
-    $c= create('new Vector<lang.Object>');
+    $c= create('new Vector<object>');
     $c->addAll(array_values($this->map));
     return $c;
   }
@@ -195,7 +195,7 @@ class TestClass extends AbstractTestClass implements \lang\Runnable {
    * Retrieve values filtered by a given pattern
    *
    * @param   string pattern default NULL
-   * @return  util.collections.Vector<lang.Object>
+   * @return  util.collections.Vector<object>
    */
   public function filterMap($pattern= null) {
     // TBI


### PR DESCRIPTION
Fixes the following:

```bash
$ xp -w 'cast("lang.XPClass::newInstance", "function(var): var")'
Uncaught exception: Exception lang.ClassCastException (Cannot cast)
# ...
Caused by Exception lang.ClassNotFoundException (Class "lang.Object" could not be found)
# ...
```