### PR TITLE
Remove deprecated XP registry

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -21,7 +21,6 @@ final class xp {
   public static $classpath= null;
   public static $errors= [];
   public static $meta= [];
-  public static $registry= [];
   
   // {{{ proto lang.IClassLoader findClass(string class)
   //     Finds the class loader for a class by its fully qualified name

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -662,22 +662,13 @@ class XPClass extends Type {
   public static function detailsForClass($class) {
     static $parser= null;
 
-    if (!$class) {                                              // Border case
-      return null;
-    } else if (isset(\xp::$meta[$class])) {                     // Cached
-      return \xp::$meta[$class];
-    } else if (isset(\xp::$registry[$l= 'details.'.$class])) {  // BC: Cached in registry
-      return \xp::$registry[$l];
-    }
+    if (isset(\xp::$meta[$class])) return \xp::$meta[$class];
 
     // Retrieve class' sourcecode
     $cl= self::_classLoaderFor($class);
     if (!$cl || !($bytes= $cl->loadClassBytes($class))) return null;
 
-    // Return details for specified class
-    if (!$parser) {
-      $parser= new \lang\reflect\ClassParser();
-    }
+    $parser ?? $parser= new \lang\reflect\ClassParser();
     return \xp::$meta[$class]= $parser->parseDetails($bytes, $class);
   }
 

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -255,15 +255,6 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function canBeCachedViaXpRegistry() {
-    with (\xp::$registry['details.'.($fixture= 'DummyDetails')]= $details= $this->dummyDetails()); {
-      $actual= \lang\XPClass::detailsForClass($fixture);
-      unset(\xp::$registry['details.'.$fixture]);
-    }
-    $this->assertEquals($details, $actual);
-  }
-
-  #[@test]
   public function use_statements_evaluated() {
     $actual= (new ClassParser())->parseDetails('<?php namespace test;
       use net\xp_framework\unittest\Name;


### PR DESCRIPTION
This removes `xp::$registry` which has since been replaced by dedicated functionality.