### PR TITLE
Deprecate io.sys package

### DIFF
--- a/src/main/php/io/sys/Ftok.class.php
+++ b/src/main/php/io/sys/Ftok.class.php
@@ -19,6 +19,7 @@
  * the same name.
  * </quote>
  * 
+ * @deprecated See https://github.com/xp-framework/rfc/issues/329
  * @ext      sem
  */
 class Ftok {

--- a/src/main/php/io/sys/IPCMessage.class.php
+++ b/src/main/php/io/sys/IPCMessage.class.php
@@ -3,6 +3,7 @@
 /**
  * Represent an IPC message
  *
+ * @deprecated See https://github.com/xp-framework/rfc/issues/329
  * @see   http://de3.php.net/manual/en/ref.sem.php
  */
 class IPCMessage {

--- a/src/main/php/io/sys/IPCQueue.class.php
+++ b/src/main/php/io/sys/IPCQueue.class.php
@@ -79,6 +79,8 @@ define('IPC_MSG_MAXSIZE', 16384);
  * $t[1]->start();
  * var_dump($t[0]->join(), $t[1]->join());
  * ```
+ *
+ * @deprecated See https://github.com/xp-framework/rfc/issues/329
  */
 class IPCQueue {
   public

--- a/src/main/php/io/sys/Semaphore.class.php
+++ b/src/main/php/io/sys/Semaphore.class.php
@@ -11,6 +11,7 @@
  *   $s->remove();
  * </code>
  *
+ * @deprecated See https://github.com/xp-framework/rfc/issues/329
  * @ext   sem
  * @see   http://www.cs.cf.ac.uk/Dave/C/node27.html#SECTION002700000000000000000
  * @see   http://www.cs.cf.ac.uk/Dave/C/node26.html#SECTION002600000000000000000

--- a/src/main/php/io/sys/ShmSegment.class.php
+++ b/src/main/php/io/sys/ShmSegment.class.php
@@ -12,6 +12,7 @@ use io\IOException;
  *
  * Note: This extension is not available on Windows platforms. 
  *
+ * @deprecated See https://github.com/xp-framework/rfc/issues/329
  * @ext   sem
  * @see   http://www.cs.cf.ac.uk/Dave/C/node27.html#SECTION002700000000000000000
  * @see   http://www.cs.cf.ac.uk/Dave/C/node26.html#SECTION002600000000000000000


### PR DESCRIPTION
This RFC implements the first part of https://github.com/xp-framework/rfc/issues/329 and deprecates the `io.sys` package. 