### PR TITLE
Add DateUtil::add() and DateUtil::subtract()

### DIFF
--- a/src/main/php/util/DateUtil.class.php
+++ b/src/main/php/util/DateUtil.class.php
@@ -52,7 +52,11 @@ abstract class DateUtil {
    * @return  util.Date
    */
   public static function getBeginningOfWeek(Date $date) {
-    return DateUtil::addDays(DateUtil::getMidnight($date), -$date->getDayOfWeek());
+    $hdl= $date->getHandle();
+    $dow= date_format($hdl, 'w');
+    date_date_set($hdl, $date->getYear(), $date->getMonth(), $date->getDay() - $dow);
+    date_time_set($hdl, 0, 0, 0);
+    return new Date($hdl);
   }
 
   /**
@@ -63,11 +67,10 @@ abstract class DateUtil {
    */
   public static function getEndOfWeek(Date $date) {
     $hdl= $date->getHandle();
-    date_date_set($hdl, $date->getYear(), $date->getMonth(), $date->getDay());
+    $dow= date_format($hdl, 'w');
+    date_date_set($hdl, $date->getYear(), $date->getMonth(), $date->getDay() + 6 - $dow);
     date_time_set($hdl, 23, 59, 59);
-
-    $date= new Date($hdl);
-    return DateUtil::addDays($date, 6- $date->getDayOfWeek());
+    return new Date($hdl);
   }
 
   /**
@@ -113,7 +116,9 @@ abstract class DateUtil {
    * @return  util.Date
    */
   public static function addWeeks(Date $date, $count= 1) {
-    return DateUtil::addDays($date, $count * 7);
+    $hdl= $date->getHandle();
+    date_date_set($hdl, $date->getYear(), $date->getMonth(), $date->getDay() + $count * 7);
+    return new Date($hdl);
   }
   
   /**
@@ -137,9 +142,7 @@ abstract class DateUtil {
    * @return  util.Date
    */
   public static function addHours(Date $date, $count= 1) {
-    $hdl= $date->getHandle();
-    date_time_set($hdl, $date->getHours() + $count, $date->getMinutes(), $date->getSeconds());
-    return new Date($hdl);
+    return new Date($date->getTime() + $count * 3600);
   }
   
   /**
@@ -150,9 +153,7 @@ abstract class DateUtil {
    * @return  util.Date
    */
   public static function addMinutes(Date $date, $count= 1) {
-    $hdl= $date->getHandle();
-    date_time_set($hdl, $date->getHours(), $date->getMinutes() + $count, $date->getSeconds());
-    return new Date($hdl);
+    return new Date($date->getTime() + $count * 60);
   }
 
   /**
@@ -163,9 +164,7 @@ abstract class DateUtil {
    * @return  util.Date
    */
   public static function addSeconds(Date $date, $count= 1) {
-    $hdl= $date->getHandle();
-    date_time_set($hdl, $date->getHours(), $date->getMinutes(), $date->getSeconds() + $count);
-    return new Date($hdl);
+    return new Date($date->getTime() + $count);
   }
   
   /**

--- a/src/main/php/util/DateUtil.class.php
+++ b/src/main/php/util/DateUtil.class.php
@@ -71,6 +71,20 @@ abstract class DateUtil {
   }
 
   /**
+   * Adds a time span to a date
+   *
+   * @param   util.Date $date
+   * @param   util.TimeSpan $span
+   * @return  util.Date
+   */
+  public static function add(Date $date, TimeSpan $span) {
+    $hdl= $date->getHandle();
+    date_time_set($hdl, $date->getHours(), $date->getMinutes(), $date->getSeconds() + $span->getSeconds());
+    return new Date($hdl);
+  }
+
+
+  /**
    * Adds a positive or negative amount of months
    *
    * @param   util.Date date

--- a/src/main/php/util/DateUtil.class.php
+++ b/src/main/php/util/DateUtil.class.php
@@ -78,11 +78,19 @@ abstract class DateUtil {
    * @return  util.Date
    */
   public static function add(Date $date, TimeSpan $span) {
-    $hdl= $date->getHandle();
-    date_time_set($hdl, $date->getHours(), $date->getMinutes(), $date->getSeconds() + $span->getSeconds());
-    return new Date($hdl);
+    return new Date($date->getTime() + $span->getSeconds());
   }
 
+  /**
+   * Subtracts a time span from a date
+   *
+   * @param   util.Date $date
+   * @param   util.TimeSpan $span
+   * @return  util.Date
+   */
+  public static function subtract(Date $date, TimeSpan $span) {
+    return new Date($date->getTime() - $span->getSeconds());
+  }
 
   /**
    * Adds a positive or negative amount of months

--- a/src/test/php/net/xp_framework/unittest/util/DateUtilTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DateUtilTest.class.php
@@ -29,6 +29,14 @@ class DateUtilTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function subtract() {
+    $this->assertEquals(
+      Date::create(2000, 1, 1, 11, 15, 11, new TimeZone('Europe/Berlin')),
+      DateUtil::subtract($this->fixture, TimeSpan::hours(1))
+    );
+  }
+
+  #[@test]
   public function addSeconds() {
     $this->assertEquals(
       Date::create(2000, 1, 1, 12, 15, 30, new TimeZone('Europe/Berlin')),

--- a/src/test/php/net/xp_framework/unittest/util/DateUtilTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DateUtilTest.class.php
@@ -2,6 +2,7 @@
  
 use util\Date;
 use util\DateUtil;
+use util\TimeSpan;
 use util\TimeZone;
 
 /**
@@ -17,6 +18,14 @@ class DateUtilTest extends \unittest\TestCase {
    */
   public function setUp() {
     $this->fixture= Date::create(2000, 1, 1, 12, 15, 11, new TimeZone('Europe/Berlin'));
+  }
+
+  #[@test]
+  public function add() {
+    $this->assertEquals(
+      Date::create(2000, 1, 1, 13, 15, 11, new TimeZone('Europe/Berlin')),
+      DateUtil::add($this->fixture, TimeSpan::hours(1))
+    );
   }
 
   #[@test]


### PR DESCRIPTION
These new methods work with `util.TimeSpan` instances:

```php
$date= Date::now();

$tomorrow= DateUtil::add($date, TimeSpan::days(1));
$yesterday= DateUtil::subtract($date, TimeSpan::days(1));
```

/cc @mikey179