### PR TITLE
Fix path normalization

### DIFF
--- a/src/main/php/io/Path.class.php
+++ b/src/main/php/io/Path.class.php
@@ -42,26 +42,22 @@ class Path implements Value {
   /**
    * Creates a new instance with a variable number of arguments
    *
-   * @param  var $base Either a string, a Path, a File, Folder or IOElement
-   * @param  var... $args Further components to be concatenated, Paths or strings.
+   * @param  string|self|io.File|io.Folder|io.collections.IOElement
+   * @param  (string|io.Path)... $args Further components to be concatenated
    */
   public function __construct($base, ... $args) {
-    if (is_array($base)) {
-      $this->path= self::pathFor($base);
-    } else {
-      array_unshift($args, $base);
-      $this->path= self::pathFor($args);
-    }
+    null === $base || array_unshift($args, $base);
+    $this->path= self::pathFor($args);
   }
 
   /**
    * Creates a new instance from an array of objects
    *
-   * @param  var[] $args
+   * @param  (string|io.Path)[] $args
    * @return self
    */
   public static function compose(array $args): self {
-    return new self($args);
+    return new self(null, ...$args);
   }
 
   /**
@@ -294,7 +290,7 @@ class Path implements Value {
    * $r= (new Path('/usr/local'))->resolve('/usr');   // "../.."
    * ```
    *
-   * @param  var $other Either a string or a path
+   * @param  string|self|io.File|io.Folder|io.collections.IOElement $arg
    * @return self
    */
   public function resolve($arg): self {
@@ -310,7 +306,7 @@ class Path implements Value {
   /**
    * Creates relative path
    *
-   * @param  var $other Either a string or a path
+   * @param  string|self|io.File|io.Folder|io.collections.IOElement $arg
    * @return self
    */
   public function relativeTo($arg): self {
@@ -333,7 +329,7 @@ class Path implements Value {
       $pb= explode(DIRECTORY_SEPARATOR, $b);
       $s= sizeof($pb);
       for ($i= 0; $i < min(sizeof($pa), $s) && $pa[$i] === $pb[$i]; $i++) { }
-      return new self(array_merge(array_fill(0, $s - $i, '..'), array_slice($pa, $i)));
+      return new self(null, ...array_merge(array_fill(0, $s - $i, '..'), array_slice($pa, $i)));
     }
   }
 

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -301,11 +301,51 @@ class PathTest extends \unittest\TestCase {
   #  ['./a', 'a'], ['././a', 'a'],
   #  ['a/./b', 'a/b'], ['a/././b', 'a/b'],
   #  ['a/../b', 'b'], ['a/../b/../c', 'c'],
-  #  ['a/..', ''], ['a/b/../..', ''],
-  #  ['..', '..'], ['../..', '../..'], ['../../a', '../../a'],
-  #  ['./..', '..'], ['./../..', '../..'], ['a/../..', '..']
+  #  ['a/..', '.'], ['a/b/../..', '.'],
+  #  ['../../a', '../../a'],
+  #  ['a/../..', '..'],
   #])]
   public function normalize($input, $result) {
+    $this->assertEquals($result, (new Path($input))->normalize()->toString('/'));
+  }
+
+  #[@test, @values([
+  #  ['.', '.'],
+  #  ['./.', '.'],
+  #  ['././.', '.'],
+  #  ['./..', '..'],
+  #  ['..', '..'],
+  #  ['../.', '..'],
+  #  ['../..', '../..'],
+  #  ['./../..', '../..'],
+  #])]
+  public function normalize_dots($input, $result) {
+    $this->assertEquals($result, (new Path($input))->normalize()->toString('/'));
+  }
+
+  #[@test, @values([
+  #  ['/', '/'],
+  #  ['/var/lib/', '/var/lib'],
+  #  ['//', '/'],
+  #  ['/.', '/'],
+  #  ['/var/lib/dpkg/..', '/var/lib'],
+  #  ['/var/lib/.', '/var/lib'],
+  #  ['C:', 'C:/'], ['C:/', 'C:/'], ['c:/', 'C:/'],
+  #  ['C:/tools', 'C:/tools'],
+  #  ['C://', 'C:/'],
+  #  ['C:/.', 'C:/'],
+  #  ['C:/tools/..', 'C:/'],
+  #  ['C:/tools/.', 'C:/tools'],
+  #])]
+  public function normalize_absolute($input, $result) {
+    $this->assertEquals($result, (new Path($input))->normalize()->toString('/'));
+  }
+
+  #[@test, @values([
+  #  ['/..', '/'], ['/../..', '/'],
+  #  ['C:/..', 'C:/'], ['C:/../..', 'C:/'],
+  #])]
+  public function normalize_dotdot_below_root($input, $result) {
     $this->assertEquals($result, (new Path($input))->normalize()->toString('/'));
   }
 
@@ -344,12 +384,18 @@ class PathTest extends \unittest\TestCase {
   #  ['xp/core', 'xp/sequence', '../core'],
   #  ['xp/core', 'stubbles/core', '../../xp/core'],
   #  ['src', 'src/test/php', '../..'], ['src/main', 'src/main/php', '..'],
+  #])]
+  public function relative_to($a, $b, $result) {
+    $this->assertEquals($result, (new Path($a))->relativeTo($b)->toString('/'));
+  }
+
+  #[@test, @values([
   #  ['/var', '/', 'var'],
   #  ['/var', '/var', ''], ['/usr/local', '/usr/bin', '../local'],
   #  ['C:/Windows', 'C:/', 'Windows'], ['C:\Windows', 'C:', 'Windows'],
-  #  ['c:/Windows', 'C:/', 'Windows'], ['C:\Windows', 'c:', 'Windows']
+  #  ['c:/Windows', 'C:/', 'Windows'], ['C:\Windows', 'c:', 'Windows'],
   #])]
-  public function relative_to($a, $b, $result) {
+  public function relative_to_absolute($a, $b, $result) {
     $this->assertEquals($result, (new Path($a))->relativeTo($b)->toString('/'));
   }
 

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -394,6 +394,7 @@ class PathTest extends \unittest\TestCase {
   #  ['/var', '/var', ''], ['/usr/local', '/usr/bin', '../local'],
   #  ['C:/Windows', 'C:/', 'Windows'], ['C:\Windows', 'C:', 'Windows'],
   #  ['c:/Windows', 'C:/', 'Windows'], ['C:\Windows', 'c:', 'Windows'],
+  #  ['/home/seq/src/main/php/Test.php', '/home/compiler', '../seq/src/main/php/Test.php']
   #])]
   public function relative_to_absolute($a, $b, $result) {
     $this->assertEquals($result, (new Path($a))->relativeTo($b)->toString('/'));


### PR DESCRIPTION
Now handles the `.` directory as well as absolute Unix paths correctly.

| Input | Old  | New | Comment |
| ------ | ----- | ----- | ------------------------------------------------------------------------------ |
| "."      | ""     | "." | Kind of OK, since "" basically also means the current directory                    |
| "./."    | ""     | "." | -"- |
| "a/.."  | ""     | "." | -"- |
| "C:"    | "C:"  | "C:\\" | Windows drive root is now always returned with a trailing backslash |
| "C:\\"   | "C:"  | "C:\\" | -"- |
| "/"      | ""     | "/" | This is the real bug! |
| "/var" | "var" | "/var" | Obviously also broken |
