### PR TITLE
PHP 7.4 forward compatiblity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
   - hhvm
   - hhvm-nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - 7.3
   - nightly
   - hhvm
   - hhvm-nightly

--- a/src/main/php/lang/Enum.class.php
+++ b/src/main/php/lang/Enum.class.php
@@ -12,11 +12,11 @@ abstract class Enum implements Value {
   protected $ordinal= 0;
 
   static function __static() {
-    if (self::class === ($class= get_called_class())) return;
+    if (self::class === static::class) return;
 
     // Automatically initialize this enum's public static members
     $i= 0;
-    $c= new \ReflectionClass($class);
+    $c= new \ReflectionClass(static::class);
     foreach ($c->getProperties(\ReflectionProperty::IS_STATIC) as $prop) {
       if ($prop->isPublic()) {
         $value= $prop->getValue(null);
@@ -99,7 +99,7 @@ abstract class Enum implements Value {
    */
   public static function values() {
     $r= [];
-    $c= new \ReflectionClass(get_called_class());
+    $c= new \ReflectionClass(static::class);
     foreach ($c->getStaticProperties() as $prop) {
       if ($prop instanceof self && $c->isInstance($prop)) {
         $r[]= $prop;

--- a/src/main/php/util/Observable.class.php
+++ b/src/main/php/util/Observable.class.php
@@ -10,7 +10,7 @@
  * class TextObserver implements \util\Observer {
  *
  *   public function update($obs, $arg= NULL) {
- *     Console::writeLine(__CLASS__, ' was notified of update in value, is now ', $obs->getValue());
+ *     Console::writeLine(self::class, ' was notified of update in value, is now ', $obs->getValue());
  *   }
  * }
  * ```

--- a/src/main/php/util/Random.class.php
+++ b/src/main/php/util/Random.class.php
@@ -34,7 +34,7 @@ class Random {
       self::$sources[self::SYSTEM]= ['bytes' => 'random_bytes', 'ints' => 'random_int'];
     }
     if (strncasecmp(PHP_OS, 'Win', 3) !== 0 && is_readable('/dev/urandom')) {
-      self::$sources[self::URANDOM]= ['bytes' => [__CLASS__, self::URANDOM], 'ints' => null];
+      self::$sources[self::URANDOM]= ['bytes' => [self::class, self::URANDOM], 'ints' => null];
     }
 
     // All of these above are secure pseudo-random sources
@@ -43,14 +43,14 @@ class Random {
     }
 
     if (function_exists('openssl_random_pseudo_bytes')) {
-      self::$sources[self::OPENSSL]= ['bytes' => [__CLASS__, self::OPENSSL], 'ints' => null];
+      self::$sources[self::OPENSSL]= ['bytes' => [self::class, self::OPENSSL], 'ints' => null];
       if (!isset(self::$sources[self::SECURE])) {
         self::$sources[self::SECURE]= &self::$sources[self::OPENSSL];
       }
     }
 
     // The Mersenne Twister algorithm is always available
-    self::$sources[self::MTRAND]= ['bytes' => [__CLASS__, self::MTRAND], 'ints' => 'mt_rand'];
+    self::$sources[self::MTRAND]= ['bytes' => [self::class, self::MTRAND], 'ints' => 'mt_rand'];
 
     self::$sources[self::BEST]= &self::$sources[key(self::$sources)];
     self::$sources[self::FAST]= &self::$sources[self::MTRAND];

--- a/src/test/php/net/xp_framework/unittest/core/CommandLineTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CommandLineTest.class.php
@@ -156,32 +156,32 @@ class CommandLineTest extends \unittest\TestCase {
   #[@test]
   public function quotedArgumentPartWindows() {
     $this->assertEquals(
-      ['C:/usr/bin/php', '-q', '-dinclude_path=.:/usr/share', '-dmagic_quotes_gpc=Off'],
-      CommandLine::$WINDOWS->parse('C:/usr/bin/php -q -dinclude_path=".:/usr/share" -dmagic_quotes_gpc=Off')
+      ['C:/usr/bin/php', '-q', '-dinclude_path=.:/usr/share', '-dauto_globals_jit=0'],
+      CommandLine::$WINDOWS->parse('C:/usr/bin/php -q -dinclude_path=".:/usr/share" -dauto_globals_jit=0')
     );        
   }
 
   #[@test]
   public function quotedArgumentPartUnix() {
     $this->assertEquals(
-      ['/usr/bin/php', '-q', '-dinclude_path=".:/usr/share"', '-dmagic_quotes_gpc=Off'],
-      CommandLine::$UNIX->parse('/usr/bin/php -q -dinclude_path=".:/usr/share" -dmagic_quotes_gpc=Off')
+      ['/usr/bin/php', '-q', '-dinclude_path=".:/usr/share"', '-dauto_globals_jit=0'],
+      CommandLine::$UNIX->parse('/usr/bin/php -q -dinclude_path=".:/usr/share" -dauto_globals_jit=0')
     );        
   }
 
   #[@test]
   public function quotedCommandAndArgumentPartWindows() {
     $this->assertEquals(
-      ['C:/usr/bin/php', '-q', '-dinclude_path=.:/usr/share', '-dmagic_quotes_gpc=Off'],
-      CommandLine::$WINDOWS->parse('"C:/usr/bin/php" -q -dinclude_path=".:/usr/share" -dmagic_quotes_gpc=Off')
+      ['C:/usr/bin/php', '-q', '-dinclude_path=.:/usr/share', '-dauto_globals_jit=0'],
+      CommandLine::$WINDOWS->parse('"C:/usr/bin/php" -q -dinclude_path=".:/usr/share" -dauto_globals_jit=0')
     );
   }
 
   #[@test]
   public function quotedCommandAndArgumentPartUnix() {
     $this->assertEquals(
-      ['/usr/bin/php', '-q', '-dinclude_path=".:/usr/share"', '-dmagic_quotes_gpc=Off'],
-      CommandLine::$UNIX->parse('"/usr/bin/php" -q -dinclude_path=".:/usr/share" -dmagic_quotes_gpc=Off')
+      ['/usr/bin/php', '-q', '-dinclude_path=".:/usr/share"', '-dauto_globals_jit=0'],
+      CommandLine::$UNIX->parse('"/usr/bin/php" -q -dinclude_path=".:/usr/share" -dauto_globals_jit=0')
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ExceptionsTest.class.php
@@ -55,7 +55,7 @@ class ExceptionsTest extends \unittest\TestCase {
     $first= (new Throwable('Test'))->getStackTrace()[0];
     
     $this->assertEquals(
-      ['class' => __CLASS__, 'method' => __FUNCTION__],
+      ['class' => self::class, 'method' => __FUNCTION__],
       ['class' => $first->class, 'method' => $first->method]
     );
   }

--- a/src/test/php/net/xp_framework/unittest/core/RuntimeOptionsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/RuntimeOptionsTest.class.php
@@ -162,11 +162,11 @@ class RuntimeOptionsTest extends \unittest\TestCase {
     $options= (new RuntimeOptions())
       ->withSwitch('q')
       ->withSwitch('n')
-      ->withSetting('enable_dl', 1)
+      ->withSetting('auto_globals_jit', 1)
       ->withSetting('extension', ['php_xsl.dll', 'php_sybase_ct.dll'])
     ;
     $this->assertArguments(
-      ['-q', '-n', '-d', 'enable_dl=1', '-d', 'extension=php_xsl.dll', '-d', 'extension=php_sybase_ct.dll'],
+      ['-q', '-n', '-d', 'auto_globals_jit=1', '-d', 'extension=php_xsl.dll', '-d', 'extension=php_sybase_ct.dll'],
       $options
     );
   }

--- a/src/test/php/net/xp_framework/unittest/core/RuntimeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/RuntimeTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace net\xp_framework\unittest\core;
 
+use lang\FormatException;
+use lang\Process;
 use lang\Runtime;
 use lang\RuntimeOptions;
-use lang\Process;
 use lang\XPClass;
-use lang\FormatException;
 
 class RuntimeTest extends \unittest\TestCase {
 
@@ -77,8 +77,8 @@ class RuntimeTest extends \unittest\TestCase {
 
   #[@test]
   public function parseSettingToleratesWhitespace() {
-    $startup= Runtime::parseArguments(['-d magic_quotes_gpc=0']);
-    $this->assertEquals(['0'], $startup['options']->getSetting('magic_quotes_gpc'));
+    $startup= Runtime::parseArguments(['-d auto_globals_jit=0']);
+    $this->assertEquals(['0'], $startup['options']->getSetting('auto_globals_jit'));
   }
 
   #[@test]


### PR DESCRIPTION
See https://wiki.php.net/rfc/deprecations_php_7_4

* [x] Replaces `__CLASS__` with `self::class`
* [x] Replaces `get_called_class()` with `static::class`
* [x] Refrains from using magic quotes / enable_dl INI settings
