### PR TITLE
Ensure filenames and lines match up to parsed code

### DIFF
--- a/src/main/php/xp/runtime/Code.class.php
+++ b/src/main/php/xp/runtime/Code.class.php
@@ -140,7 +140,7 @@ class Code {
   public function run($argv= []) {
     $this->modules->require();
 
-    Script::$code[$this->name]= '<?php '.$this->head().str_repeat("\n", $this->line).$this->fragment;
+    Script::$code[$this->name]= '<?php '.$this->head().str_repeat("\n", $this->line).$this->fragment."\nreturn null;";
     try {
       $argc= sizeof($argv);
       return include('script://'.$this->name);

--- a/src/main/php/xp/runtime/Code.class.php
+++ b/src/main/php/xp/runtime/Code.class.php
@@ -63,7 +63,7 @@ class Code {
     }
 
     $this->fragment= rtrim(substr($input, $pos), "\r\n\t ;").';';
-    $this->line= substr_count($input, "\n", 0, $pos > $length ? $length : $pos);
+    $this->line= 0 === $pos ? 0 : substr_count($input, "\n", 0, $pos > $length ? $length : $pos);
   }
 
   /** @return string */

--- a/src/main/php/xp/runtime/Code.class.php
+++ b/src/main/php/xp/runtime/Code.class.php
@@ -93,7 +93,7 @@ class Code {
    *
    * @return self
    */
-  public function asExpression() {
+  public function withReturn() {
     $self= clone $this;
     if (!strstr($self->fragment, 'return ') && !strstr($self->fragment, 'return;')) {
       $self->fragment= 'return '.$self->fragment;

--- a/src/main/php/xp/runtime/Code.class.php
+++ b/src/main/php/xp/runtime/Code.class.php
@@ -9,57 +9,65 @@ use lang\Throwable;
  * @test  xp://net.xp_framework.unittest.runtime.CodeTest
  */
 class Code {
-  private $fragment;
-  private $imports= [];
-  private $modules= [];
-  private $namespace= null;
+  private $name, $fragment, $modules, $line, $imports, $namespace;
+
+  static function __static() {
+    stream_wrapper_register('script', Script::class);
+  }
 
   /**
    * Creates a new code instance
    *
    * @param  string $input
+   * @param  string $name
    */
-  public function __construct($input) {
+  public function __construct($input, $name= '(unnamed)') {
+    $this->name= $name;
+    $this->namespace= null;
+    $this->modules= new Modules();
+    $this->imports= [];
+
+    $pos= 0;
+    $length= strlen($input);
 
     // Shebang
-    if (0 === strncmp($input, '#!', 2)) {
-      $input= substr($input, strcspn($input, "\n") + 1);
+    if ($pos < $length && 0 === substr_compare($input, '#!', $pos, 2)) {
+      $pos+= strcspn($input, "\n", $pos) + 1;
     }
 
     // PHP open tags
-    if (0 === strncmp($input, '<?', 2)) {
-      $input= substr($input, strcspn($input, "\r\n\t =") + 1);
+    if ($pos < $length && 0 === substr_compare($input, '<?', $pos, 2)) {
+      $pos+= strcspn($input, "\r\n\t =", $pos) + 1;
     }
 
-    $this->fragment= trim($input, "\r\n\t ;").';';
+    // Trim whitespace on the left
+    $pos+= strspn($input, "\r\n\t ", $pos);
 
-    if (0 === strncmp($this->fragment, 'namespace', 9)) {
-      $length= strcspn($this->fragment, ';', 10);
-      $this->namespace= substr($this->fragment, 10, $length);
-      $this->fragment= ltrim(substr($this->fragment, 11 + $length), "\r\n\t ");
+    // Parse namespace declaration
+    if ($pos < $length && 0 === substr_compare($input, 'namespace', $pos, 9)) {
+      $l= strcspn($input, ';', $pos);
+      $this->namespace= substr($input, $pos + 10, $l - 10);
+      $pos+= $l + 1;
+      $pos+= strspn($input, "\r\n\t ", $pos);
     }
 
-    $this->modules= new Modules();
-    while (0 === strncmp($this->fragment, 'use ', 4)) {
-      $delim= strpos($this->fragment, ';');
-      foreach ($this->importsIn(substr($this->fragment, 4, $delim - 4)) as $import => $module) {
+    // Parse imports
+    while ($pos < $length && 0 === substr_compare($input, 'use ', $pos, 4)) {
+      $l= strcspn($input, ';', $pos);
+      foreach ($this->importsIn(substr($input, $pos + 4, $l - 4)) as $import => $module) {
         $this->imports[]= $import;
         $module && $this->modules->add($module);
       }
-      $this->fragment= ltrim(substr($this->fragment, $delim + 1), "\r\n\t ");
+      $pos+= $l + 1;
+      $pos+= strspn($input, "\r\n\t ", $pos);
     }
+
+    $this->fragment= rtrim(substr($input, $pos), "\r\n\t ;").';';
+    $this->line= substr_count($input, "\n", 0, $pos > $length ? $length : $pos);
   }
 
   /** @return string */
   public function fragment() { return $this->fragment; }
-
-  /** @return string */
-  public function expression() {
-    return strstr($this->fragment, 'return ') || strstr($this->fragment, 'return;')
-      ? $this->fragment
-      : 'return '.$this->fragment
-    ;
-  }
 
   /** @return string[] */
   public function imports() { return $this->imports; }
@@ -77,6 +85,20 @@ class Code {
       ($this->namespace ? 'namespace '.$this->namespace.';' : '').
       (empty($this->imports) ? '' : 'use '.implode(', ', $this->imports).';')
     ;
+  }
+
+  /**
+   * Returns a new instance of this code instance, with a `return` statement
+   * inserted if necessary.
+   *
+   * @return self
+   */
+  public function asExpression() {
+    $self= clone $this;
+    if (!strstr($self->fragment, 'return ') && !strstr($self->fragment, 'return;')) {
+      $self->fragment= 'return '.$self->fragment;
+    }
+    return $self;
   }
 
   /**
@@ -111,19 +133,21 @@ class Code {
   /**
    * Runs an expression of code in the context of this code
    *
-   * @param  string $expression
    * @param  string[] $argv
    * @return int
    * @throws lang.Throwable
    */
-  public function run($expression, $argv= []) {
+  public function run($argv= []) {
     $this->modules->require();
 
-    $argc= sizeof($argv);
+    Script::$code[$this->name]= '<?php '.$this->head().str_repeat("\n", $this->line).$this->fragment;
     try {
-      return eval($this->head().$expression);
+      $argc= sizeof($argv);
+      return include('script://'.$this->name);
     } catch (\Throwable $t) {
       throw Throwable::wrap($t);
+    } finally {
+      unset(Script::$code[$this->name]);
     }
   }
 }

--- a/src/main/php/xp/runtime/Dump.class.php
+++ b/src/main/php/xp/runtime/Dump.class.php
@@ -1,7 +1,7 @@
 <?php namespace xp\runtime;
 
-use util\cmd\Console;
 use lang\XPClass;
+use util\cmd\Console;
 
 /**
  * Evaluates code and dumps its output.
@@ -11,22 +11,23 @@ class Dump {
   /**
    * Main
    *
-   * @param   string[] args
+   * @param  string[] $args
+   * @return int
    */
   public static function main(array $args) {
     $way= array_shift($args);
 
     // Read sourcecode from STDIN if no further argument is given
     if (empty($args)) {
-      $code= new Code(file_get_contents('php://stdin'));
+      $code= new Code(file_get_contents('php://stdin'), '(standard input)');
     } else if ('--' === $args[0]) {
-      $code= new Code(file_get_contents('php://stdin'));
+      $code= new Code(file_get_contents('php://stdin'), '(standard input)');
     } else {
-      $code= new Code($args[0]);
+      $code= new Code($args[0], '(command line argument)');
     }
 
     // Perform
-    $return= $code->run($code->expression(), [XPClass::nameOf(self::class)] + $args);
+    $return= $code->asExpression()->run([XPClass::nameOf(self::class)] + $args);
     switch ($way) {
       case '-w': Console::writeLine($return); break;
       case '-d': var_dump($return); break;

--- a/src/main/php/xp/runtime/Dump.class.php
+++ b/src/main/php/xp/runtime/Dump.class.php
@@ -27,7 +27,7 @@ class Dump {
     }
 
     // Perform
-    $return= $code->asExpression()->run([XPClass::nameOf(self::class)] + $args);
+    $return= $code->withReturn()->run([XPClass::nameOf(self::class)] + $args);
     switch ($way) {
       case '-w': Console::writeLine($return); break;
       case '-d': var_dump($return); break;

--- a/src/main/php/xp/runtime/Evaluate.class.php
+++ b/src/main/php/xp/runtime/Evaluate.class.php
@@ -17,15 +17,15 @@ class Evaluate {
 
     // Read sourcecode from STDIN if no further argument is given
     if (empty($args)) {
-      $code= new Code(file_get_contents('php://stdin'));
+      $code= new Code(file_get_contents('php://stdin'), '(standard input)');
     } else if ('--' === $args[0]) {
-      $code= new Code(file_get_contents('php://stdin'));
+      $code= new Code(file_get_contents('php://stdin'), '(standard input)');
     } else if (is_file($args[0])) {
-      $code= new Code(file_get_contents($args[0]));
+      $code= new Code(file_get_contents($args[0]), $args[0]);
     } else {
-      $code= new Code($args[0]);
+      $code= new Code($args[0], '(command line argument)');
     }
 
-    return $code->run($code->fragment(), [XPClass::nameOf(self::class)] + $args);
+    return $code->run([XPClass::nameOf(self::class)] + $args);
   }
 }

--- a/src/main/php/xp/runtime/Script.class.php
+++ b/src/main/php/xp/runtime/Script.class.php
@@ -1,0 +1,52 @@
+<?php namespace xp\runtime;
+
+class Script {
+  public static $code= [];
+  private $stream, $offset;
+
+  /**
+   * Opens path
+   *
+   * @param  string $path
+   * @param  string $mode
+   * @param  int $options
+   * @param  string $opened
+   */
+  public function stream_open($path, $mode, $options, &$opened) {
+    sscanf($path, "%[^:]://%[^\r]", $scheme, $opened);
+    if (isset(self::$code[$opened])) {
+      $this->stream= self::$code[$opened];
+      $this->offset= 0;
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Reads bytes
+   *
+   * @param  int $count
+   * @return string
+   */
+  public function stream_read($count) {
+    $chunk= substr($this->stream, $this->offset, $count);
+    $this->offset+= $count;
+    return $chunk;
+  }
+
+  /** @return [:var] */
+  public function stream_stat() {
+    return ['size' => strlen($this->stream)];
+  }
+
+  /** @return bool */
+  public function stream_eof() {
+    return $this->offset >= strlen($this->stream);
+  }
+
+  /** @return void */
+  public function stream_close() {
+    // NOOP
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/runtime/CodeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/runtime/CodeTest.class.php
@@ -160,8 +160,8 @@ class CodeTest extends \unittest\TestCase {
 
   #[@test]
   public function run_without_return() {
-    $code= new Code('// NOOP');
-    $this->assertEquals(1, $code->run());
+    $code= new Code('');
+    $this->assertEquals(null, $code->run());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/runtime/CodeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/runtime/CodeTest.class.php
@@ -36,17 +36,17 @@ class CodeTest extends \unittest\TestCase {
 
   #[@test]
   public function expression() {
-    $this->assertEquals('return "Test";', (new Code('"Test"'))->expression());
+    $this->assertEquals('return "Test";', (new Code('"Test"'))->asExpression()->fragment());
   }
 
   #[@test]
   public function expression_with_semicolon() {
-    $this->assertEquals('return "Test";', (new Code('"Test";'))->expression());
+    $this->assertEquals('return "Test";', (new Code('"Test";'))->asExpression()->fragment());
   }
 
   #[@test]
   public function expression_with_existing_return() {
-    $this->assertEquals('return "Test";', (new Code('return "Test";'))->expression());
+    $this->assertEquals('return "Test";', (new Code('return "Test";'))->asExpression()->fragment());
   }
 
   #[@test, @values([
@@ -61,20 +61,6 @@ class CodeTest extends \unittest\TestCase {
   #])]
   public function use_is_stripped_from_fragment($input) {
     $this->assertEquals('test();', (new Code($input))->fragment());
-  }
-
-  #[@test, @values([
-  #  'use util\Date; test()',
-  #  'use util\Date, util\TimeZone; test()',
-  #  'use util\Date; use util\TimeZone; test()',
-  #  'use util\{Date, TimeZone}; test()',
-  #  ' use util\Date; test()',
-  #  '<?php use util\Date; test()',
-  #  '<?php  use util\Date; test()',
-  #  "<?php\nuse util\Date; test()"
-  #])]
-  public function use_is_stripped_from_expression($input) {
-    $this->assertEquals('return test();', (new Code($input))->expression());
   }
 
   #[@test]
@@ -159,5 +145,52 @@ class CodeTest extends \unittest\TestCase {
   #[@test]
   public function modules_for_code_with_import_from_module() {
     $this->assertEquals(['xp-forge/sequence'], (new Code('use util\data\Sequence from "xp-forge/sequence";'))->modules()->all());
+  }
+
+  #[@test, @values([
+  #  'return "Test";',
+  #  '<?php return "Test";',
+  #  "<?php\nreturn 'Test';",
+  #  "<?php namespace test;\nreturn 'Test';",
+  #])]
+  public function run($input) {
+    $code= new Code($input);
+    $this->assertEquals('Test', $code->run());
+  }
+
+  #[@test]
+  public function run_without_return() {
+    $code= new Code('// NOOP');
+    $this->assertEquals(1, $code->run());
+  }
+
+  #[@test]
+  public function code_has_access_to_argv() {
+    $code= new Code('return $argv;');
+    $this->assertEquals([1, 2, 3], $code->run([1, 2, 3]));
+  }
+
+  #[@test]
+  public function code_has_access_to_argc() {
+    $code= new Code('return $argc;');
+    $this->assertEquals(3, $code->run([1, 2, 3]));
+  }
+
+  #[@test, @values([
+  #  ['', 1],
+  #  ["<?php\n", 2],
+  #  ["<?php namespace test;\n", 2],
+  #  ["<?php namespace test;\n\nuse util\cmd\Console;\n\n", 5],
+  #])]
+  public function errors_reported_with_script_name($head, $line) {
+    $code= new Code($head.'trigger_error("Test");', 'test.script.php');
+    $code->run();
+
+    $e= ['Test' => ['class' => null, 'method' => 'trigger_error', 'cnt' => 1]];
+    try {
+      $this->assertEquals(['test.script.php' => [$line => $e]], \xp::$errors);
+    } finally {
+      \xp::gc();
+    }
   }
 }

--- a/src/test/php/net/xp_framework/unittest/runtime/CodeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/runtime/CodeTest.class.php
@@ -36,17 +36,17 @@ class CodeTest extends \unittest\TestCase {
 
   #[@test]
   public function expression() {
-    $this->assertEquals('return "Test";', (new Code('"Test"'))->asExpression()->fragment());
+    $this->assertEquals('return "Test";', (new Code('"Test"'))->withReturn()->fragment());
   }
 
   #[@test]
   public function expression_with_semicolon() {
-    $this->assertEquals('return "Test";', (new Code('"Test";'))->asExpression()->fragment());
+    $this->assertEquals('return "Test";', (new Code('"Test";'))->withReturn()->fragment());
   }
 
   #[@test]
   public function expression_with_existing_return() {
-    $this->assertEquals('return "Test";', (new Code('return "Test";'))->asExpression()->fragment());
+    $this->assertEquals('return "Test";', (new Code('return "Test";'))->withReturn()->fragment());
   }
 
   #[@test, @values([


### PR DESCRIPTION
This pull request ensures filenames and lines match up to parsed code for `xp eval/dump/write` and XP scripts. 

```php
<?php namespace test;

use util\cmd\Console;

Console::writeLine('Hello ', $argv[1]); 
```

### Before

```sh
$ xp test.script.php
Uncaught exception: Exception lang.IndexOutOfBoundsException (Undefined offset: 1)
  at <main>::__error(8, ...) [line 1 of Code.class.php(124) : eval()'d code]
  at <main>::eval() [line 124 of Code.class.php]
  at xp.runtime.Code::run(...) [line 29 of Evaluate.class.php]
  at xp.runtime.Evaluate::main(array[1]) [line 374 of class-main.php]

$ echo 'throw new \Exception("Test")' | xp -e
Uncaught exception: Exception lang.XPException (Test)
  at <native>::Exception(0, (0x4)'Test') [line 1 of Code.class.php(124) : eval()'d code]
  at <main>::eval() [line 124 of Code.class.php]
  at xp.runtime.Code::run(...) [line 29 of Evaluate.class.php]
  at xp.runtime.Evaluate::main(array[0]) [line 374 of class-main.php]
```

### After

```sh
$ xp test.script.php
Uncaught exception: Exception lang.IndexOutOfBoundsException (Undefined offset: 1)
  at <main>::__error(8, ...) [line 5 of test.script.php]
  at <main>::include((0xf)'test.script.php') [line 146 of Code.class.php]
  at xp.runtime.Code::run(array[1]) [line 29 of Evaluate.class.php]
  at xp.runtime.Evaluate::main(array[1]) [line 374 of class-main.php]

$ echo 'throw new \Exception("Test")' | xp -e
Uncaught exception: Exception lang.XPException (Test)
  at <native>::Exception(0, (0x4)'Test') [line 1 of (standard input)]
  at <main>::include() [line 146 of Code.class.php]
  at xp.runtime.Code::run(array[1]) [line 29 of Evaluate.class.php]
  at xp.runtime.Evaluate::main(array[0]) [line 374 of class-main.php]
```

See xp-framework/rfc#332