### PR TITLE
Remove "double" type in favor of "float"

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -13,7 +13,8 @@ final class xp {
     'xp'     => 'xp',
     'string' => "\xfestring",
     'int'    => "\xfeint",
-    'double' => "\xfedouble",
+    'float'  => "\xfefloat",
+    'double' => "\xfefloat",
     'bool'   => "\xfebool",
     'var'    => "var",
   ];

--- a/src/main/php/lang/Primitive.class.php
+++ b/src/main/php/lang/Primitive.class.php
@@ -5,7 +5,7 @@
  * 
  * - string
  * - int
- * - double
+ * - float
  * - bool
  *
  * @test  xp://net.xp_framework.unittest.reflection.PrimitiveTest 
@@ -15,7 +15,6 @@ class Primitive extends Type {
   public static
     $STRING  = null,
     $INT     = null,
-    $DOUBLE  = null,
     $FLOAT   = null,
     $BOOL    = null;
   
@@ -24,7 +23,6 @@ class Primitive extends Type {
     self::$INT= new self('int', 0);
     self::$FLOAT= new self('float', 0.0);
     self::$BOOL= new self('bool', false);
-    self::$DOUBLE= self::$FLOAT;  // Deprecated, kept as alias
   }
   
   /**

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -182,7 +182,7 @@ class Type implements Value {
    * Gets a type for a given name
    *
    * Checks for:
-   * - Primitive types (string, int, double, boolean, resource)
+   * - Primitive types (string, int, float, bool, resource)
    * - Array and map notations (array, string[], string*, [:string])
    * - Any type (var)
    * - Void type (void)

--- a/src/test/php/net/xp_framework/unittest/core/XpTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/XpTest.class.php
@@ -52,8 +52,13 @@ class XpTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function literal_of_double() {
-    $this->assertEquals('þdouble', literal('double'));
+  public function literal_of_float() {
+    $this->assertEquals('þfloat', literal('float'));
+  }
+
+  #[@test]
+  public function literal_of_float_alias_double() {
+    $this->assertEquals('þfloat', literal('double'));
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
@@ -6,40 +6,40 @@ use net\xp_framework\unittest\Name;
 use unittest\TestCase;
 use unittest\actions\RuntimeVersion;
 
-/**
- * TestCase
- *
- * @see   xp://lang.Primitive
- */
 class PrimitiveTest extends TestCase {
 
   #[@test]
-  public function stringPrimitive() {
+  public function string_primitive() {
     $this->assertEquals(Primitive::$STRING, Primitive::forName('string'));
   }
 
   #[@test]
-  public function intPrimitive() {
+  public function int_primitive() {
     $this->assertEquals(Primitive::$INT, Primitive::forName('int'));
   }
 
   #[@test]
-  public function doublePrimitive() {
-    $this->assertEquals(Primitive::$FLOAT, Primitive::forName('double'));
+  public function float_primitive() {
+    $this->assertEquals(Primitive::$FLOAT, Primitive::forName('float'));
   }
 
   #[@test]
-  public function boolPrimitive() {
+  public function bool_primitive() {
     $this->assertEquals(Primitive::$BOOL, Primitive::forName('bool'));
   }
 
+  #[@test]
+  public function float_primitive_double_alias() {
+    $this->assertEquals(Primitive::$FLOAT, Primitive::forName('double'));
+  }
+
   #[@test, @expect(IllegalArgumentException::class)]
-  public function arrayPrimitive() {
+  public function array_primitive() {
     Primitive::forName('array');
   }
 
   #[@test, @expect(IllegalArgumentException::class)]
-  public function nonPrimitive() {
+  public function non_primitive() {
     Primitive::forName('lang.Value');
   }
 
@@ -66,42 +66,42 @@ class PrimitiveTest extends TestCase {
   }
 
   #[@test, @values(['', 'Hello'])]
-  public function isAnInstanceOfStringPrimitive($value) {
+  public function isAnInstanceOfString_primitive($value) {
     $this->assertTrue(Primitive::$STRING->isInstance($value));
   }
   
   #[@test, @values(source= 'instances', args= [['', 'Hello']])]
-  public function notInstanceOfStringPrimitive($value) {
+  public function notInstanceOfString_primitive($value) {
     $this->assertFalse(Primitive::$STRING->isInstance($value));
   }
 
   #[@test, @values([0, -1])]
-  public function isAnInstanceOfIntegerPrimitive($value) {
+  public function isAnInstanceOfInteger_primitive($value) {
     $this->assertTrue(Primitive::$INT->isInstance($value));
   }
 
   #[@test, @values(source= 'instances', args= [[0, -1]])]
-  public function notInstanceOfIntegerPrimitive($value) {
+  public function notInstanceOfInteger_primitive($value) {
     $this->assertFalse(Primitive::$INT->isInstance($value));
   }
 
   #[@test, @values([0.0, -1.5])]
-  public function isAnInstanceOfDoublePrimitive($value) {
+  public function isAnInstanceOfDouble_primitive($value) {
     $this->assertTrue(Primitive::$FLOAT->isInstance($value));
   }
 
   #[@test, @values(source= 'instances', args= [[0.0, -1.5]])]
-  public function notInstanceOfDoublePrimitive($value) {
+  public function notInstanceOfDouble_primitive($value) {
     $this->assertFalse(Primitive::$FLOAT->isInstance($value));
   }
 
   #[@test, @values([false, true])]
-  public function isAnInstanceOfBooleanPrimitive($value) {
+  public function isAnInstanceOfBoolean_primitive($value) {
     $this->assertTrue(Primitive::$BOOL->isInstance($value));
   }
 
   #[@test, @values(source= 'instances', args= [[false, true]])]
-  public function notInstanceOfBooleanPrimitive($value) {
+  public function notInstanceOfBoolean_primitive($value) {
     $this->assertFalse(Primitive::$BOOL->isInstance($value));
   }
 


### PR DESCRIPTION
We use `int` for integer numbers (and not *long*), so we should be using `float` for floating point numbers (and not *double*). The latter are implementation details, whereas *int* and *float* are generic terms.

See also https://wiki.php.net/rfc/var_type
