### PR TITLE
Remove third & optional "nullsafe" argument to cast()

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -153,8 +153,9 @@ function __error($code, $msg, $file, $line) {
 
 // {{{ proto var cast (var arg, var type)
 //     Casts an arg NULL-safe
-function cast($arg, $type, $nullsafe= true) {
-  if (null === $arg && $nullsafe && 0 !== strncmp($type, '?', 1)) {
+function cast($arg, $type) {
+  if (null === $arg) {
+    if (0 === strncmp($type, '?', 1)) return null;
     throw new \lang\ClassCastException('Cannot cast NULL to '.$type);
   } else if ($type instanceof \lang\Type) {
     return $type->cast($arg);

--- a/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use unittest\TestCase;
 use lang\{Runnable, Value, CommandLine, ClassCastException};
+use unittest\TestCase;
 
 /**
  * Tests cast() functionality
@@ -29,12 +29,6 @@ class CastingTest extends TestCase implements Runnable {
   #[@test, @expect(ClassCastException::class)]
   public function is_nullsafe_per_default() {
     cast(null, Runnable::class)->run();
-  }
-
-  /** @deprecated See https://github.com/xp-framework/rfc/issues/326 */
-  #[@test]
-  public function passing_null_allowed_when_nullsafe_set_to_false() {
-    $this->assertNull(cast(null, Value::class, false));
   }
 
   #[@test]


### PR DESCRIPTION
Replaced by nullable types

See https://github.com/xp-framework/rfc/issues/326