### PR TITLE
Add new util.Dates class superseding util.DateUtil

### DIFF
--- a/src/main/php/util/Dates.class.php
+++ b/src/main/php/util/Dates.class.php
@@ -1,0 +1,122 @@
+<?php namespace util;
+
+/**
+ * Dates is a helper class to handle Date objects and 
+ * calculate date- and timestamps.
+ *
+ * @test  xp://net.xp_framework.unittest.util.DatesTest
+ * @see   https://www.php.net/manual/en/datetime.formats.relative.php Relative formats
+ * @see   https://www.php.net/manual/en/dateinterval.construct.php Periods
+ * @see   https://en.wikipedia.org/wiki/ISO_8601#Durations
+ */
+class Dates {
+
+  /**
+   * Adds a time span to a date
+   *
+   * @param  util.Date $date
+   * @param  util.TimeSpan|int|string $span
+   * @return util.Date
+   */
+  public static function add(Date $date, $span) {
+    if ($span instanceof TimeSpan) {
+      return new Date($date->getTime() + $span->getSeconds());
+    } else if (is_numeric($span)) {
+      return new Date($date->getTime() + $span);
+    } else if ('P' === $span{0}) {
+      return new Date($date->getHandle()->add(new \DateInterval($span)));
+    } else {
+      return new Date($date->getHandle()->add(\DateInterval::createFromDateString($span)));
+    }
+  }
+
+  /**
+   * Subtracts a time span from a date
+   *
+   * @param  util.Date $date
+   * @param  util.TimeSpan|int|string $span
+   * @return util.Date
+   */
+  public static function subtract(Date $date, $span) {
+    if ($span instanceof TimeSpan) {
+      return new Date($date->getTime() - $span->getSeconds());
+    } else if (is_numeric($span)) {
+      return new Date($date->getTime() - $span);
+    } else if ('P' === $span{0}) {
+      return new Date($date->getHandle()->sub(new \DateInterval($span)));
+    } else {
+      return new Date($date->getHandle()->sub(\DateInterval::createFromDateString($span)));
+    }
+  }
+
+  /**
+   * Truncates a date, leaving the field specified as the most significant field.
+   *
+   * @param  util.Date $date
+   * @param  util.TimeInterval $interval
+   * @return util.Date
+   */
+  public static function truncate(Date $date, TimeInterval $interval) {
+    $h= $date->getHandle();
+    switch ($interval) {
+      case TimeInterval::$YEAR: $h->setDate($date->getYear(), 1, 1); $h->setTime(0, 0, 0); break;
+      case TimeInterval::$MONTH: $h->setDate($date->getYear(), $date->getMonth(), 1); $h->setTime(0, 0, 0); break;
+      case TimeInterval::$DAY: $h->setTime(0, 0, 0); break;
+      case TimeInterval::$HOURS: $h->setTime($date->getHours(), 0, 0); break;
+      case TimeInterval::$MINUTES: $h->setTime($date->getHours(), $date->getMinutes(), 0); break;
+      case TimeInterval::$SECONDS: $h->setTime($date->getHours(), $date->getMinutes(), (int)$date->getSeconds()); break;
+    }
+    return new Date($h);
+  }
+
+  /**
+   * Gets a date ceiling, leaving the field specified as the most significant field.
+   *
+   * @param  util.Date $date
+   * @param  util.TimeInterval $interval
+   * @return util.Date
+   */
+  public static function ceiling(Date $date, TimeInterval $interval) {
+    $h= $date->getHandle();
+    switch ($interval) {
+      case TimeInterval::$YEAR: $h->setDate($date->getYear() + 1, 1, 1); $h->setTime(0, 0, 0); break;
+      case TimeInterval::$MONTH: $h->setDate($date->getYear(), $date->getMonth() + 1, 1); $h->setTime(0, 0, 0); break;
+      case TimeInterval::$DAY: $h->setDate($date->getYear(), $date->getMonth(), $date->getDay() + 1); $h->setTime(0, 0, 0); break;
+      case TimeInterval::$HOURS: $h->setTime($date->getHours() + 1, 0, 0); break;
+      case TimeInterval::$MINUTES: $h->setTime($date->getHours(), $date->getMinutes() + 1, 0); break;
+      case TimeInterval::$SECONDS: $h->setTime($date->getHours(), $date->getMinutes(), (int)$date->getSeconds() + 1); break;
+    }
+    return new Date($h);
+  }
+
+  /**
+   * Returns a TimeSpan representing the difference 
+   * between the two given Date objects
+   *
+   * @param  util.Date $a
+   * @param  util.Date $b
+   * @return util.TimeSpan
+   */
+  public static function diff(Date $a, Date $b) {
+    return new TimeSpan($a->getTime() - $b->getTime());
+  }
+
+  /**
+   * Comparator method for two Date objects
+   *
+   * Returns a negative number if a < b, a positive number if a > b 
+   * and 0 if both dates are equal
+   *
+   * Example usage with usort():
+   * ```php
+   * usort($datelist, [Dates::class, 'compare'])
+   * ```
+   *
+   * @param  util.Date $a
+   * @param  util.Date $b
+   * @return int
+   */
+  public static function compare(Date $a, Date $b) {
+    return $b->compareTo($a);
+  }
+} 

--- a/src/test/config/unittest/date.ini
+++ b/src/test/config/unittest/date.ini
@@ -18,6 +18,9 @@ class="net.xp_framework.unittest.util.TimeSpanTest"
 [dateutil]
 class="net.xp_framework.unittest.util.DateUtilTest"
 
+[dates]
+class="net.xp_framework.unittest.util.DatesTest"
+
 [calendar]
 class="net.xp_framework.unittest.util.CalendarTest"
 

--- a/src/test/php/net/xp_framework/unittest/util/DatesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DatesTest.class.php
@@ -1,0 +1,174 @@
+<?php namespace net\xp_framework\unittest\util;
+ 
+use unittest\TestCase;
+use util\{Date, Dates, TimeSpan, TimeInterval};
+
+class DatesTest extends TestCase {
+
+  #[@test]
+  public function add_timespan() {
+    $this->assertEquals(
+      Date::create(2019, 6, 13, 12, 0, 10),
+      Dates::add(Date::create(2019, 6, 13, 12, 0, 0), TimeSpan::seconds(10))
+    );
+  }
+
+  #[@test]
+  public function add_period() {
+    $this->assertEquals(
+      Date::create(2020, 6, 13, 12, 0, 0),
+      Dates::add(Date::create(2019, 6, 13, 12, 0, 0), 'P1Y')
+    );
+  }
+
+  #[@test]
+  public function add_int() {
+    $this->assertEquals(
+      Date::create(2019, 6, 14, 12, 0, 0),
+      Dates::add(Date::create(2019, 6, 13, 12, 0, 0), 86400)
+    );
+  }
+
+  #[@test]
+  public function add_string() {
+    $this->assertEquals(
+      Date::create(2019, 7, 13, 12, 0, 0),
+      Dates::add(Date::create(2019, 6, 13, 12, 0, 0), '1 month')
+    );
+  }
+
+  #[@test]
+  public function subtract_timespan() {
+    $this->assertEquals(
+      Date::create(2019, 6, 13, 11, 59, 50),
+      Dates::subtract(Date::create(2019, 6, 13, 12, 0, 0), TimeSpan::seconds(10))
+    );
+  }
+
+  #[@test]
+  public function subtract_period() {
+    $this->assertEquals(
+      Date::create(2018, 6, 13, 12, 0, 0),
+      Dates::subtract(Date::create(2019, 6, 13, 12, 0, 0), 'P1Y')
+    );
+  }
+
+  #[@test]
+  public function subtract_int() {
+    $this->assertEquals(
+      Date::create(2019, 6, 12, 12, 0, 0),
+      Dates::subtract(Date::create(2019, 6, 13, 12, 0, 0), 86400)
+    );
+  }
+
+  #[@test]
+  public function subtract_string() {
+    $this->assertEquals(
+      Date::create(2019, 5, 13, 12, 0, 0),
+      Dates::subtract(Date::create(2019, 6, 13, 12, 0, 0), '1 month')
+    );
+  }
+
+  #[@test]
+  public function truncate_minutes() {
+    $this->assertEquals(
+      Date::create(2019, 6, 13, 12, 39, 0),
+      Dates::truncate(Date::create(2019, 6, 13, 12, 39, 11), TimeInterval::$MINUTES)
+    );
+  }
+
+  #[@test]
+  public function truncate_hours() {
+    $this->assertEquals(
+      Date::create(2019, 6, 13, 12, 0, 0),
+      Dates::truncate(Date::create(2019, 6, 13, 12, 39, 11), TimeInterval::$HOURS)
+    );
+  }
+
+  #[@test]
+  public function truncate_day() {
+    $this->assertEquals(
+      Date::create(2019, 6, 13, 0, 0, 0),
+      Dates::truncate(Date::create(2019, 6, 13, 12, 0, 0), TimeInterval::$DAY)
+    );
+  }
+
+  #[@test]
+  public function truncate_month() {
+    $this->assertEquals(
+      Date::create(2019, 6, 1, 0, 0, 0),
+      Dates::truncate(Date::create(2019, 6, 13, 12, 0, 0), TimeInterval::$MONTH)
+    );
+  }
+
+  #[@test]
+  public function truncate_year() {
+    $this->assertEquals(
+      Date::create(2019, 1, 1, 0, 0, 0),
+      Dates::truncate(Date::create(2019, 6, 13, 12, 0, 0), TimeInterval::$YEAR)
+    );
+  }
+
+  #[@test]
+  public function ceiling_of_minutes() {
+    $this->assertEquals(
+      Date::create(2019, 6, 13, 12, 40, 0),
+      Dates::ceiling(Date::create(2019, 6, 13, 12, 39, 11), TimeInterval::$MINUTES)
+    );
+  }
+
+  #[@test]
+  public function ceiling_of_hours() {
+    $this->assertEquals(
+      Date::create(2019, 6, 13, 13, 0, 0),
+      Dates::ceiling(Date::create(2019, 6, 13, 12, 39, 11), TimeInterval::$HOURS)
+    );
+  }
+
+  #[@test]
+  public function ceiling_of_day() {
+    $this->assertEquals(
+      Date::create(2019, 6, 14, 0, 0, 0),
+      Dates::ceiling(Date::create(2019, 6, 13, 12, 0, 0), TimeInterval::$DAY)
+    );
+  }
+
+  #[@test]
+  public function ceiling_of_month() {
+    $this->assertEquals(
+      Date::create(2019, 7, 1, 0, 0, 0),
+      Dates::ceiling(Date::create(2019, 6, 13, 12, 0, 0), TimeInterval::$MONTH)
+    );
+  }
+
+  #[@test]
+  public function ceiling_of_year() {
+    $this->assertEquals(
+      Date::create(2020, 1, 1, 0, 0, 0),
+      Dates::ceiling(Date::create(2019, 6, 13, 12, 0, 0), TimeInterval::$YEAR)
+    );
+  }
+
+  #[@test]
+  public function diff() {
+    $this->assertEquals(
+      TimeSpan::hours(1),
+      Dates::diff(Date::create(2019, 6, 13, 12, 39, 1), Date::create(2019, 6, 13, 13, 39, 1))
+    );
+  }
+
+  #[@test]
+  public function compare_a_less_than_b() {
+    $this->assertTrue(Dates::compare(new Date('1977-12-14'), new Date('1980-05-28')) < 0, 'a < b');
+  }
+
+  #[@test]
+  public function compare_a_greater_than_b() {
+    $this->assertTrue(Dates::compare(new Date('1980-05-28'), new Date('1977-12-14')) > 0, 'a > b');
+  }
+
+  #[@test]
+  public function compare_a_equal_to_b() {
+    $this->assertEquals(0, Dates::compare(new Date('1980-05-28'), new Date('1980-05-28')));
+  }
+}


### PR DESCRIPTION
## API

```php
public class util.Dates {
  public static util.Date add(util.Date $date, util.TimeSpan|int|string $span)
  public static util.Date subtract(util.Date $date, util.TimeSpan|int|string $span)
  public static util.Date truncate(util.Date $date, util.TimeInterval $interval)
  public static util.Date ceiling(util.Date $date, util.TimeInterval $interval)
  public static util.TimeSpan diff(util.Date $a, util.Date $b)
  public static int compare(util.Date $a, util.Date $b)
}
```

## See also

https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/time/DateUtils.html