### PR TITLE
Allow casting from arbitrary values to classes

### DIFF
--- a/src/main/php/util/Date.class.php
+++ b/src/main/php/util/Date.class.php
@@ -10,7 +10,7 @@ use lang\IllegalArgumentException;
 class Date implements \lang\Value {
   const DEFAULT_FORMAT= 'Y-m-d H:i:sO';
 
-  /** @type php.DateTime */
+  /** @type DateTime */
   private $handle;
 
   /**
@@ -18,7 +18,7 @@ class Date implements \lang\Value {
    *
    * - integer - interpreted as timestamp
    * - string - parsed into a date
-   * - php.DateTime object - will be used as is
+   * - DateTime object - will be used as is
    * - NULL - creates a date representing the current instance
    *
    * Timezone assignment works through these rules:
@@ -30,7 +30,7 @@ class Date implements \lang\Value {
    * - If no timezone has been given as second parameter, the system's default
    *   timezone is used.
    *
-   * @param  int|string|php.DateTime $in
+   * @param  int|string|DateTime $in
    * @param  string $timezone default NULL string of timezone
    * @throws lang.IllegalArgumentException in case the date is unparseable
    */

--- a/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CastingTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\{Runnable, Value, CommandLine, ClassCastException};
 use unittest\TestCase;
+use util\Date;
 
 /**
  * Tests cast() functionality
@@ -89,5 +90,10 @@ class CastingTest extends TestCase implements Runnable {
   #[@test, @expect(ClassCastException::class)]
   public function cannot_cast_arrays_to_nullable_string() {
     cast([1], '?string');
+  }
+
+  #[@test]
+  public function primitive_to_single_arg_constructor() {
+    $this->assertInstanceOf(Date::class, cast('2019-08-15', Date::class));
   }
 }


### PR DESCRIPTION
Check for a class with a single-arg constructor with matching type. Allows simplifying code following the "be liberal in what you accept" principle:

```php
// Before
public function __construct($auth, $secret) {
  $this->auth= $auth instanceof URI ? $auth : new URI($auth);
  $this->secret= $secret instanceof Secret ? $secret : new Secret($secret);
}

// After
public function __construct($auth, $secret) {
  $this->auth= cast($auth, URI::class);
  $this->secret= cast($secret, Secret::class);
}
```
