### PR TITLE
Make object type consistent with PHP type system

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,9 @@ XP Framework Core ChangeLog
 
 ### Heads up!
 
+* Changed `object` type handling in `is()` and `Type::$OBJECT` to be
+  consistent with PHP type system, including closures and generators.
+  (@thekid)
 * Merged PR #216: Remove third & optional "nullsafe" argument to cast()
   (@thekid)
 * Merged PR #215: Remove deprecated System class - @thekid

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -185,7 +185,7 @@ function is($type, $object) {
   } else if ('array' === $type) {
     return is_array($object);
   } else if ('object' === $type) {
-    return is_object($object) && !($object instanceof \Closure);
+    return is_object($object);
   } else if ('callable' === $type) {
     return is_callable($object);
   } else if ('iterable' === $type) {

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -36,13 +36,13 @@ class Type implements Value {
 
     self::$OBJECT= eval('namespace lang; class NativeObjectType extends Type {
       static function __static() { }
-      public function isInstance($value): bool { return is_object($value) && !$value instanceof \Closure; }
+      public function isInstance($value): bool { return is_object($value); }
       public function newInstance(... $args) {
-        if ($args && is_object($args[0]) && !$args[0] instanceof \Closure) return clone $args[0];
+        if ($args && is_object($args[0])) return clone $args[0];
         throw new IllegalAccessException("Cannot instantiate an object from ".($args ? typeof($args[0])->getName() : "null"));
       }
       public function cast($value) {
-        if (null === $value || is_object($value) && !$value instanceof \Closure) return $value;
+        if (null === $value || is_object($value)) return $value;
         throw new ClassCastException("Cannot cast ".typeof($value)->getName()." to the object type");
       }
       public function isAssignableFrom($type): bool {

--- a/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\{Runnable, ClassLoader};
-use net\xp_framework\unittest\core\generics\ListOf;
 use net\xp_framework\unittest\Name;
+use net\xp_framework\unittest\core\generics\ListOf;
 
 /** Tests the is() core functionality */
 class IsTest extends \unittest\TestCase {
@@ -311,7 +311,7 @@ class IsTest extends \unittest\TestCase {
   #  [function() { }],
   #  [function() { yield 'Test'; }]
   #])]
-  public function closures_are_not_objects($val) {
-    $this->assertFalse(is('object', $val));
+  public function closures_are_objects($val) {
+    $this->assertTrue(is('object', $val));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeTest.class.php
@@ -1,7 +1,5 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use util\collections\{Vector, HashTable};
-use net\xp_framework\unittest\Name;
 use lang\{
   ArrayType,
   ClassCastException,
@@ -13,6 +11,8 @@ use lang\{
   Type,
   XPClass
 };
+use net\xp_framework\unittest\Name;
+use util\collections\{Vector, HashTable};
 
 class TypeTest extends \unittest\TestCase {
 
@@ -475,8 +475,8 @@ class TypeTest extends \unittest\TestCase {
   #  [function() { }],
   #  [function() { yield 'Test'; }]
   #])]
-  public function closures_are_not_instances_of_the_object_type_union($value) {
-    $this->assertFalse(Type::$OBJECT->isInstance($value));
+  public function closures_are_instances_of_the_object_type_union($value) {
+    $this->assertTrue(Type::$OBJECT->isInstance($value));
   }
 
   #[@test, @values([


### PR DESCRIPTION
This pull request changes `is()` and `lang.Type::$OBJECT` to behave exactly like the PHP type hint *object*. Previously, it was inconsistent regarding closures and generators:

```php
function test(object $f) { return true; }

$f= function() { };

$result= test($f);          // true
$verify= is('object', $f);  // false ⚡️ 
```

See also xp-framework/compiler#68