### PR TITLE
Add support for nullable types to is()

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -190,6 +190,8 @@ function is($type, $object) {
     return is_callable($object);
   } else if ('iterable' === $type) {
     return is_array($object) || $object instanceof \Traversable;
+  } else if ('?' === $type[0]) {
+    return null === $object || is(substr($type, 1), $object);
   } else if (0 === strncmp($type, 'function(', 9)) {
     return \lang\FunctionType::forName($type)->isInstance($object);
   } else if (0 === substr_compare($type, '[]', -2)) {

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -155,7 +155,7 @@ function __error($code, $msg, $file, $line) {
 //     Casts an arg NULL-safe
 function cast($arg, $type) {
   if (null === $arg) {
-    if (0 === strncmp($type, '?', 1)) return null;
+    if ('?' === $type[0]) return null;
     throw new \lang\ClassCastException('Cannot cast NULL to '.$type);
   } else if ($type instanceof \lang\Type) {
     return $type->cast($arg);

--- a/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
@@ -267,6 +267,11 @@ class IsTest extends \unittest\TestCase {
     $this->assertTrue(is('int|string', $val));
   }
 
+  #[@test, @values([1, null])]
+  public function nullable($val) {
+    $this->assertTrue(is('?int', $val));
+  }
+
   #[@test, @values([
   #  [function() { }],
   #  [function() { yield 'Test'; }],


### PR DESCRIPTION
This pull request adds support for nullable types to `is()` and makes is consistent with `cast()`.

```php
is('?int', null) // true
is('?int', 1)    // true
```

Previously, using nullable type notation would result in *lang.IllegalArgumentException (Not a wildcard type: ?int)*, so this is considered a bugfix.