### PR TITLE
Support getting annotations from anonymous classes

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -384,7 +384,13 @@ function typeof($arg) {
     }
     return new \lang\FunctionType($signature, $return);
   } else if (is_object($arg)) {
-    return new \lang\XPClass($arg);
+    $class= get_class($arg);
+    if (0 === strncmp($class, 'class@anonymous', 15)) {
+      $r= new \ReflectionObject($arg);
+      \xp::$cl[strtr($class, '\\', '.')]= 'lang.AnonymousClassLoader://'.$r->getStartLine().':'.$r->getEndLine().'@'.$r->getFileName();
+      return new \lang\XPClass($r);
+    }
+    return new \lang\XPClass($class);
   } else if (is_array($arg)) {
     return 0 === key($arg) ? \lang\ArrayType::forName('var[]') : \lang\MapType::forName('[:var]');
   } else {

--- a/src/main/php/lang/AnonymousClassLoader.class.php
+++ b/src/main/php/lang/AnonymousClassLoader.class.php
@@ -1,8 +1,6 @@
 <?php namespace lang;
 
 class AnonymousClassLoader extends AbstractClassLoader {
-  const DEVICE = 3262979129;   // crc32('lang.AnonymousClassLoader')
-
   private $file, $start, $end;
 
   public function __construct($file, $start, $end) {

--- a/src/main/php/lang/AnonymousClassLoader.class.php
+++ b/src/main/php/lang/AnonymousClassLoader.class.php
@@ -1,0 +1,128 @@
+<?php namespace lang;
+
+class AnonymousClassLoader extends AbstractClassLoader {
+  const DEVICE = 3262979129;   // crc32('lang.AnonymousClassLoader')
+
+  private $file, $start, $end;
+
+  public function __construct($file, $start, $end) {
+    $this->file= $file;
+    $this->start= $start;
+    $this->end= $end;
+  }
+
+  /**
+   * Checks whether this loader can provide the requested class
+   *
+   * @param   string class
+   * @return  bool
+   */
+  public function providesClass($class) {
+    return false;
+  }
+
+  /**
+   * Checks whether this loader can provide the requested resource
+   *
+   * @param   string filename
+   * @return  bool
+   */
+  public function providesResource($filename) {
+    return false;
+  }
+
+  /**
+   * Checks whether this loader can provide the requested package
+   *
+   * @param   string package
+   * @return  bool
+   */
+  public function providesPackage($package) {
+    return false;
+  }
+
+  /**
+   * Load class bytes
+   *
+   * @param   string name fully qualified class name
+   * @return  string
+   */
+  public function loadClassBytes($name) {
+    $fd= fopen($this->file, 'rb');
+    $i= 0;
+    $bytes= '';
+    while ($line= fgets($fd, 8192)) {
+      $i++;
+      if ($i > $this->end) {
+        break;
+      } else if ($i >= $this->start) {
+        $bytes.= $line;
+      }
+    }
+    fclose($fd);
+    return '<?php '.substr($bytes, strpos($bytes, 'new class'));
+  }
+  
+  /**
+   * Returns URI suitable for include() given a class name
+   *
+   * @param   string class
+   * @return  string
+   */
+  protected function classUri($class) {
+    return null;
+  }
+
+  /**
+   * Return a class at the given URI
+   *
+   * @param   string uri
+   * @return  string fully qualified class name, or NULL
+   */
+  protected function classAtUri($uri) {
+    return null;
+  }
+
+  /**
+   * Fetch instance of classloader by path
+   *
+   * @param   string path the identifier
+   * @return  lang.IClassLoader
+   */
+  public static function instanceFor($path) {
+    sscanf($path, "%d:%d@%[^\r]", $start, $end, $file);
+    return new self($file, $start, $end);
+  }
+
+  /**
+   * Get package contents
+   *
+   * @param   string package
+   * @return  string[] filenames
+   */
+  public function packageContents($package) {
+    return [];
+  }
+
+  /**
+   * Loads a resource.
+   *
+   * @param   string filename name of resource
+   * @return  string
+   * @throws  lang.ElementNotFoundException in case the resource cannot be found
+   */
+  public function getResource($filename) {
+    throw new ElementNotFoundException('Could not load resource '.$filename);
+  }
+  
+  /**
+   * Retrieve a stream to the resource
+   *
+   * @param   string filename name of resource
+   * @return  io.File
+   * @throws  lang.ElementNotFoundException in case the resource cannot be found
+   */
+  public function getResourceAsStream($filename) {
+    throw new ElementNotFoundException('Could not load resource '.$filename);
+  }
+}

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -80,6 +80,7 @@ class XPClass extends Type {
   public function __construct($ref) {
     if ($ref instanceof \ReflectionClass) {
       $this->_class= $ref->getName();
+      $this->_reflect= $ref;
     } else if ($ref instanceof \__PHP_Incomplete_Class) {
       throw new ClassCastException('Cannot use incomplete classes in reflection');
     } else if (is_object($ref)) {

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -427,6 +427,27 @@ class ClassParser {
           }
           break;
 
+        case T_NEW:                             // Anonymous class
+          $details['class']= [
+            DETAIL_COMMENT      => null,
+            DETAIL_ANNOTATIONS  => [],
+            DETAIL_ARGUMENTS    => null
+          ];
+          $annotations= [0 => [], 1 => []];
+          $comment= '';
+
+          $b= 0;
+          while (++$i < $s) {
+            if ('(' === $tokens[$i][0]) {
+              $b++;
+            } else if (')' === $tokens[$i][0]) {
+              if (0 === --$b) break;
+            } else if (0 === $b && ';' === $tokens[$i][0]) {
+              break;    // Abstract or interface method
+            }
+          }
+          break;
+
         case T_CLASS:
           if (isset($details['class'])) break;  // Inside class, e.g. $lookup= ['self' => self::class]
 

--- a/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use lang\XPClass;
 use lang\ElementNotFoundException;
+use lang\XPClass;
 
 /**
  * Tests the XP Framework's annotations
@@ -104,5 +104,16 @@ class AnnotationTest extends \unittest\TestCase {
       ['time' => 0.1, 'memory' => 100],
       $this->class->getMethod('testMethod')->getAnnotation('limit')
     );
+  }
+
+  #[@test]
+  public function on_anonymous_class() {
+    $c= new class() {
+
+      #[@test]
+      public function fixture() { }
+    };
+
+    $this->assertEquals(['test' => null], typeof($c)->getMethod('fixture')->getAnnotations());
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -440,4 +440,48 @@ class ClassDetailsTest extends \unittest\TestCase {
     ');
     $this->assertEquals(['test' => $value], $details[1]['fixture'][DETAIL_ANNOTATIONS]);
   }
+
+  #[@test]
+  public function anonymous_class() {
+    $details= (new ClassParser())->parseDetails('<?php
+      new class() { }
+    ');
+    $this->assertEquals(
+      [DETAIL_COMMENT => null, DETAIL_ANNOTATIONS => [], DETAIL_ARGUMENTS => null],
+      $details['class']
+    );
+  }
+
+  #[@test]
+  public function anonymous_class_with_arguments() {
+    $details= (new ClassParser())->parseDetails('<?php
+      new class(1, 2, 3) { }
+    ');
+    $this->assertEquals(
+      [DETAIL_COMMENT => null, DETAIL_ANNOTATIONS => [], DETAIL_ARGUMENTS => null],
+      $details['class']
+    );
+  }
+
+  #[@test]
+  public function anonymous_class_member() {
+    $details= (new ClassParser())->parseDetails('<?php
+      new class() {
+        #[@test]
+        public $fixture;
+      }
+    ');
+    $this->assertEquals(['test' => null], $details[0]['fixture'][DETAIL_ANNOTATIONS]);
+  }
+
+  #[@test]
+  public function anonymous_class_method() {
+    $details= (new ClassParser())->parseDetails('<?php
+      new class() {
+        #[@test]
+        public function fixture() { }
+      }
+    ');
+    $this->assertEquals(['test' => null], $details[1]['fixture'][DETAIL_ANNOTATIONS]);
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/ModuleLoadingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ModuleLoadingTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use lang\ClassLoader;
-use lang\reflect\Module;
 use lang\ElementNotFoundException;
+use lang\reflect\Module;
 
 /**
  * TestCase for modules
@@ -120,7 +120,11 @@ class ModuleLoadingTest extends \unittest\TestCase {
     $this->register(new LoaderProviding([
       'module.xp' => '<?php module xp-framework/impl implements net\xp_framework\unittest\reflection\IModule { }'
     ]));
-    $this->assertTrue(in_array($cl, typeof(Module::forName('xp-framework/impl'))->getInterfaces()));
+    $interfaces= typeof(Module::forName('xp-framework/impl'))->getInterfaces();
+    foreach ($interfaces as $interface) {
+      if ($cl->equals($interface)) return;
+    }
+    $this->fail($cl->getName().' not included', $interfaces, [$cl]);
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/ProxyTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ProxyTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use lang\{XPClass, Type, ClassLoader, IllegalArgumentException, Error};
 use lang\reflect\{Proxy, InvocationHandler};
-use util\{XPIterator, Observer};
+use lang\{XPClass, Type, ClassLoader, IllegalArgumentException, Error};
 use unittest\actions\RuntimeVersion;
+use util\{XPIterator, Observer};
 
 /**
  * Tests the Proxy class
@@ -104,18 +104,13 @@ class ProxyTest extends \unittest\TestCase {
   #[@test]
   public function iteratorInterfaceIsImplemented() {
     $class= $this->proxyClassFor([$this->iteratorClass]);
-    $interfaces= $class->getInterfaces();
-    $this->assertEquals(1, sizeof($interfaces));
-    $this->assertTrue(in_array($this->iteratorClass, $interfaces)); 
+    $this->assertEquals([$this->iteratorClass], $class->getInterfaces());
   }
 
   #[@test]
   public function allInterfacesAreImplemented() {
     $class= $this->proxyClassFor([$this->iteratorClass, $this->observerClass]);
-    $interfaces= $class->getInterfaces();
-    $this->assertEquals(2, sizeof($interfaces));
-    $this->assertTrue(in_array($this->iteratorClass, $interfaces));
-    $this->assertTrue(in_array($this->observerClass, $interfaces));
+    $this->assertEquals([$this->iteratorClass, $this->observerClass], $class->getInterfaces());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/XPClassTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
+use lang\reflect\{Package, Constructor, TargetInvocationException};
 use lang\{
   ClassLoader,
   ClassNotFoundException,
@@ -9,7 +10,6 @@ use lang\{
   Primitive,
   XPClass
 };
-use lang\reflect\{Package, Constructor, TargetInvocationException};
 
 /**
  * Test the XPClass class, the entry point to the XP Framework's class reflection API.
@@ -168,11 +168,11 @@ class XPClassTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function getInterfaces_contains_declared_interface() {
-    $this->assertTrue(in_array(
-      XPClass::forName('lang.Runnable'),
+  public function getInterfaces_consist_of_declared_interface() {
+    $this->assertEquals(
+      [XPClass::forName('lang.Runnable')],
       $this->fixture->getInterfaces()
-    ));
+    );
   }
 
   #[@test]


### PR DESCRIPTION
Example:

```php
$instance= new class() {

  #[@test]
  public function fixture() { }
};

$annotations= typeof($instance)->getMethod('fixture')->getAnnotations();
// ['test' => null]
```