### PR TITLE
Add support for PHP 7.4 arrow functions in annotations

### DIFF
--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -148,7 +148,7 @@ class ClassParser {
         $type.= '.'.$tokens[$i++][1];
       }
       return $this->memberOf(XPClass::forName(substr($type, 1)), $tokens[$i], $context);
-    } else if (T_FN === $token || 'fn' === $tokens[$i][1]) {
+    } else if (T_FN === $token || T_STRING === $token && 'fn' === $tokens[$i][1]) {
       $s= sizeof($tokens);
       $b= 0;
       $code= 'function';

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -441,6 +441,47 @@ class ClassDetailsTest extends \unittest\TestCase {
     $this->assertEquals(['test' => $value], $details[1]['fixture'][DETAIL_ANNOTATIONS]);
   }
 
+  #[@test, @values([
+  #  'function() { return "Test"; }',
+  #  'fn() => "Test"',
+  #])]
+  public function closures_inside_annotations($declaration) {
+    $details= (new ClassParser())->parseDetails('<?php
+      abstract class Test {
+        #[@call('.$declaration.')]
+        public abstract function fixture();
+      }
+    ');
+    $this->assertEquals('Test', $details[1]['fixture'][DETAIL_ANNOTATIONS]['call']());
+  }
+
+  #[@test]
+  public function fn_braced_expression() {
+    $details= (new ClassParser())->parseDetails('<?php
+      abstract class Test {
+        #[@call(fn() => ord(chr(42)))]
+        public abstract function fixture();
+      }
+    ');
+    $this->assertEquals(42, $details[1]['fixture'][DETAIL_ANNOTATIONS]['call']());
+  }
+
+  #[@test, @values([
+  #  '[fn() => [1, 2, 3]]',
+  #  '[fn() => [1, 2, 3], ]',
+  #  '[fn() => [1, 2, 3], 1]',
+  #  '[fn() => [[1, [2][0], 3]][0]]',
+  #])]
+  public function fn_with_arrays($declaration) {
+    $details= (new ClassParser())->parseDetails('<?php
+      abstract class Test {
+        #[@call('.$declaration.')]
+        public abstract function fixture();
+      }
+    ');
+    $this->assertEquals([1, 2, 3], $details[1]['fixture'][DETAIL_ANNOTATIONS]['call'][0]());
+  }
+
   #[@test]
   public function anonymous_class() {
     $details= (new ClassParser())->parseDetails('<?php


### PR DESCRIPTION
Allows using `fn` inside annotations in addition to being able to use `function`.

## Example

```php
class RandomTest {
  #[@test, @action(new VerifyThat(function() { return is_readable('/dev/urandom'); }))]
  public function urandom_bytes() {
    // ...
  }
}
```

Now it's also possible to use the shorter and more concise form, even on PHP < 7.4!

```php
class RandomTest {
  #[@test, @action(new VerifyThat(fn() => is_readable('/dev/urandom')))]
  public function urandom_bytes() {
    // ...
  }
}
```
