### PR TITLE
Allow passing string types to Enum::valueOf() / Enum::valuesOf()

### DIFF
--- a/src/main/php/lang/Enum.class.php
+++ b/src/main/php/lang/Enum.class.php
@@ -40,12 +40,13 @@ abstract class Enum implements Value {
   /**
    * Returns the enumeration member uniquely identified by its name
    *
-   * @param  lang.XPClass class class object
-   * @param  string name enumeration member
+   * @param  lang.XPClass|string $type
+   * @param  string $name enumeration member
    * @return self
    * @throws lang.IllegalArgumentException in case the enum member does not exist or when the given class is not an enum
    */
-  public static function valueOf(XPClass $class, string $name): self {
+  public static function valueOf($type, string $name): self {
+    $class= $type instanceof XPClass ? $type : XPClass::forName($type);
     if (!$class->isEnum()) {
       throw new IllegalArgumentException('Argument class must be lang.XPClass<? extends lang.Enum>');
     }
@@ -69,11 +70,12 @@ abstract class Enum implements Value {
   /**
    * Returns the enumeration members for a given class
    *
-   * @param  lang.XPClass class class object
+   * @param  lang.XPClass|string $type
    * @return self[]
    * @throws lang.IllegalArgumentException in case the given class is not an enum
    */
-  public static function valuesOf(XPClass $class) {
+  public static function valuesOf($type) {
+    $class= $type instanceof XPClass ? $type : XPClass::forName($type);
     if (!$class->isEnum()) {
       throw new IllegalArgumentException('Argument class must be lang.XPClass<? extends lang.Enum>');
     }

--- a/src/test/php/net/xp_framework/unittest/core/EnumTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnumTest.class.php
@@ -149,14 +149,22 @@ class EnumTest extends \unittest\TestCase {
     );
   }
 
+  #[@test]
+  public function valueOf_string() {
+    $this->assertEquals(
+      Coin::$penny, 
+      Enum::valueOf(Coin::class, 'penny')
+    );
+  }
+
   #[@test, @expect(IllegalArgumentException::class)]
   public function valueOfNonExistant() {
     Enum::valueOf(XPClass::forName(Coin::class), '@@DOES_NOT_EXIST@@');
   }
 
-  #[@test, @expect(Error::class)]
-  public function valueOfNonEnum7() {
-    Enum::valueOf($this, 'irrelevant');
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function valueOfNonEnum() {
+    Enum::valueOf(self::class, 'irrelevant');
   }
 
   #[@test]
@@ -176,6 +184,14 @@ class EnumTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function valuesOf_string() {
+    $this->assertEquals(
+      [Coin::$penny, Coin::$nickel, Coin::$dime, Coin::$quarter],
+      Enum::valuesOf(Coin::class)
+    );
+  }
+
+  #[@test]
   public function valuesOfAbstractEnum() {
     $this->assertEquals(
       [Operation::$plus, Operation::$minus, Operation::$times, Operation::$divided_by],
@@ -183,9 +199,9 @@ class EnumTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect(Error::class)]
-  public function valuesOfNonEnum7() {
-    Enum::valuesOf($this);
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function valuesOfNonEnum() {
+    Enum::valuesOf(self::class);
   }
 
   #[@test]


### PR DESCRIPTION
Following the *be liberal in what you accept* principle:

```php
use my\enum\Name;

// Current functionality
$values= Enum::valuesOf(XPClass::forName(Name::class));

// Now also possible
$values= Enum::valuesOf(Name::class);
```