### PR TITLE
Verify trait methods can be invoked

### DIFF
--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -140,15 +140,24 @@ class Field implements Value {
    */
   public function get($instance) {
     if (null !== $instance && !($instance instanceof $this->_class)) {
-      if (!$this->_reflect->getDeclaringClass()->isTrait()) {
+      $d= $this->_reflect->getDeclaringClass();
+      if (!$d->isTrait()) {
         throw new IllegalArgumentException(sprintf(
           'Passed argument is not a %s class (%s)',
           XPClass::nameOf($this->_class),
-          typeof($instance)->getName()
+          nameof($instance)
         ));
       }
 
-      $target= (new \ReflectionObject($instance))->getProperty($this->_reflect->getName());
+      $o= new \ReflectionObject($instance);
+      if (!in_array($d->getName(), $o->getTraitNames())) {
+        throw new IllegalArgumentException(sprintf(
+          'Passed argument does not use the trait %s (%s)',
+          XPClass::nameOf($this->_class),
+          nameof($instance)
+        ));
+      }
+      $target= $o->getProperty($this->_reflect->getName());
     } else {
       $target= $this->_reflect;
     }
@@ -201,15 +210,24 @@ class Field implements Value {
    */
   public function set($instance, $value) {
     if (null !== $instance && !($instance instanceof $this->_class)) {
-      if (!$this->_reflect->getDeclaringClass()->isTrait()) {
+      $d= $this->_reflect->getDeclaringClass();
+      if (!$d->isTrait()) {
         throw new IllegalArgumentException(sprintf(
           'Passed argument is not a %s class (%s)',
           XPClass::nameOf($this->_class),
-          typeof($instance)->getName()
+          nameof($instance)
         ));
       }
 
-      $target= (new \ReflectionObject($instance))->getProperty($this->_reflect->getName());
+      $o= new \ReflectionObject($instance);
+      if (!in_array($d->getName(), $o->getTraitNames())) {
+        throw new IllegalArgumentException(sprintf(
+          'Passed argument does not use the trait %s (%s)',
+          XPClass::nameOf($this->_class),
+          nameof($instance)
+        ));
+      }
+      $target= $o->getProperty($this->_reflect->getName());
     } else {
       $target= $this->_reflect;
     }

--- a/src/main/php/lang/reflect/Method.class.php
+++ b/src/main/php/lang/reflect/Method.class.php
@@ -60,7 +60,13 @@ class Method extends Routine {
           nameof($obj)
         ));
       }
-      $target= $o->getMethod($this->_reflect->getName());
+
+      if ($aliases= $o->getTraitAliases()) {
+        $a= array_search($d->getName().'::'.$this->getName(), $aliases);
+      } else {
+        $a= null;
+      }
+      $target= $o->getMethod($a ?: $this->_reflect->getName());
     } else {
       $target= $this->_reflect;
     }

--- a/src/main/php/lang/reflect/Method.class.php
+++ b/src/main/php/lang/reflect/Method.class.php
@@ -43,15 +43,24 @@ class Method extends Routine {
    */
   public function invoke($obj, $args= []) {
     if (null !== $obj && !($obj instanceof $this->_class)) {
-      if (!$this->_reflect->getDeclaringClass()->isTrait()) {
+      $d= $this->_reflect->getDeclaringClass();
+      if (!$d->isTrait()) {
         throw new IllegalArgumentException(sprintf(
           'Passed argument is not a %s class (%s)',
           XPClass::nameOf($this->_class),
-          typeof($obj)->getName()
+          nameof($obj)
         ));
       }
 
-      $target= (new \ReflectionObject($obj))->getMethod($this->_reflect->getName());
+      $o= new \ReflectionObject($obj);
+      if (!in_array($d->getName(), $o->getTraitNames())) {
+        throw new IllegalArgumentException(sprintf(
+          'Passed argument does not use the trait %s (%s)',
+          XPClass::nameOf($this->_class),
+          nameof($obj)
+        ));
+      }
+      $target= $o->getMethod($this->_reflect->getName());
     } else {
       $target= $this->_reflect;
     }

--- a/src/test/php/net/xp_framework/unittest/reflection/Database.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/Database.class.php
@@ -1,8 +1,11 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-/** Used in MethodInvocationTest */
+/** Used in MethodInvocationTest and FieldAccessTest */
 trait Database {
+  private $conn= null;
 
-  public function connect($dsn) { return true; }
-
+  public function connect($dsn) {
+    $this->conn= $dsn;
+    return true;
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/Database.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/Database.class.php
@@ -1,0 +1,8 @@
+<?php namespace net\xp_framework\unittest\reflection;
+
+/** Used in MethodInvocationTest */
+trait Database {
+
+  public function connect($dsn) { return true; }
+
+}

--- a/src/test/php/net/xp_framework/unittest/reflection/FieldAccessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/FieldAccessTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use lang\IllegalAccessException;
-use lang\IllegalArgumentException;
+use lang\{IllegalAccessException, IllegalArgumentException, XPClass};
 
 class FieldAccessTest extends FieldsTest {
 
@@ -95,6 +94,12 @@ class FieldAccessTest extends FieldsTest {
     $this->assertNull($t->getTraits()[1]->getField('conn')->setAccessible(true)->get($t->newInstance()));
   }
 
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function read_member_from_trait_with_incompatible() {
+    $t= XPClass::forName('net.xp_framework.unittest.reflection.Database');
+    $t->getField('conn')->setAccessible(true)->get($this);
+  }
+
   #[@test]
   public function write_member_from_trait() {
     $t= $this->type('{ use Database; }');
@@ -105,5 +110,11 @@ class FieldAccessTest extends FieldsTest {
   public function write_member_from_trait_via_traits() {
     $t= $this->type('{ use Database; }');
     $t->getTraits()[1]->getField('conn')->setAccessible(true)->set($t->newInstance(), 'test://localhost');
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function write_member_from_trait_with_incompatible() {
+    $t= XPClass::forName('net.xp_framework.unittest.reflection.Database');
+    $t->getField('conn')->setAccessible(true)->set($this, 'test://localhost');
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/FieldAccessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/FieldAccessTest.class.php
@@ -82,4 +82,28 @@ class FieldAccessTest extends FieldsTest {
     $fixture= $this->type('{ public $fixture; }');
     $fixture->getField('fixture')->set($this, 'Test');
   }
+
+  #[@test]
+  public function read_member_from_trait() {
+    $t= $this->type('{ use Database; }');
+    $this->assertNull($t->getField('conn')->setAccessible(true)->get($t->newInstance()));
+  }
+
+  #[@test]
+  public function read_member_from_trait_via_traits() {
+    $t= $this->type('{ use Database; }');
+    $this->assertNull($t->getTraits()[1]->getField('conn')->setAccessible(true)->get($t->newInstance()));
+  }
+
+  #[@test]
+  public function write_member_from_trait() {
+    $t= $this->type('{ use Database; }');
+    $t->getField('conn')->setAccessible(true)->set($t->newInstance(), 'test://localhost');
+  }
+
+  #[@test]
+  public function write_member_from_trait_via_traits() {
+    $t= $this->type('{ use Database; }');
+    $t->getTraits()[1]->getField('conn')->setAccessible(true)->set($t->newInstance(), 'test://localhost');
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodInvocationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodInvocationTest.class.php
@@ -91,6 +91,16 @@ class MethodInvocationTest extends MethodsTest {
     $this->assertTrue($t->getTraits()[1]->getMethod('connect')->invoke($t->newInstance(), ['test://localhost']));
   }
 
+  #[@test]
+  public function invoke_method_from_trait_aliased() {
+    $t= $this->type('{
+      use Database { connect as open; }
+
+      public function connect() { return false; }
+    }');
+    $this->assertTrue($t->getTraits()[1]->getMethod('connect')->invoke($t->newInstance(), ['test://localhost']));
+  }
+
   #[@test, @expect(IllegalArgumentException::class)]
   public function invoke_method_from_trait_with_incompatible() {
     $t= XPClass::forName('net.xp_framework.unittest.reflection.Database');

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodInvocationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodInvocationTest.class.php
@@ -1,8 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use lang\IllegalAccessException;
-use lang\IllegalArgumentException;
 use lang\reflect\TargetInvocationException;
+use lang\{IllegalAccessException, IllegalArgumentException, XPClass};
 use unittest\actions\RuntimeVersion;
 
 class MethodInvocationTest extends MethodsTest {
@@ -90,5 +89,11 @@ class MethodInvocationTest extends MethodsTest {
   public function invoke_method_from_trait_via_traits() {
     $t= $this->type('{ use Database; }');
     $this->assertTrue($t->getTraits()[1]->getMethod('connect')->invoke($t->newInstance(), ['test://localhost']));
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function invoke_method_from_trait_with_incompatible() {
+    $t= XPClass::forName('net.xp_framework.unittest.reflection.Database');
+    $t->getMethod('connect')->invoke($this, ['test://localhost']);
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodInvocationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodInvocationTest.class.php
@@ -79,4 +79,16 @@ class MethodInvocationTest extends MethodsTest {
     $fixture= $this->type($declaration);
     $this->assertEquals('Test', $fixture->getMethod('fixture')->setAccessible(true)->invoke($fixture->newInstance(), []));
   }
+
+  #[@test]
+  public function invoke_method_from_trait() {
+    $t= $this->type('{ use Database; }');
+    $this->assertTrue($t->getMethod('connect')->invoke($t->newInstance(), ['test://localhost']));
+  }
+
+  #[@test]
+  public function invoke_method_from_trait_via_traits() {
+    $t= $this->type('{ use Database; }');
+    $this->assertTrue($t->getTraits()[1]->getMethod('connect')->invoke($t->newInstance(), ['test://localhost']));
+  }
 }


### PR DESCRIPTION
The following code now invokes the method correctly instead of raising an exception:

```php
trait Database {
  public function connect() { ... }
}

class Handler {
  use Database;
}

$handler= new Handler();
$class->getTraits()[0]->getMethod('connect')->invoke($handler);
```

See https://github.com/xp-forge/inject/commit/e1ba931827de3b955b434fd8f5fea013ea3ba08f#r35781347
