### PR TITLE
Deprecate annotation key/value pair syntax

### DIFF
--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -343,7 +343,7 @@ class ClassParser {
             $key= $tokens[$i][1];
             $value= [];
             $state= 3;
-            trigger_error('Use of deprecated annotation key/value pairs in '.$place, E_USER_DEPRECATED);
+            trigger_error('Use of deprecated annotation key/value pair "'.$key.'" in '.$place, E_USER_DEPRECATED);
           } else {
             $value= $this->valueOf($tokens, $i, $context, $imports);
           }

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -343,6 +343,7 @@ class ClassParser {
             $key= $tokens[$i][1];
             $value= [];
             $state= 3;
+            trigger_error('Use of deprecated annotation key/value pairs in '.$place, E_USER_DEPRECATED);
           } else {
             $value= $this->valueOf($tokens, $i, $context, $imports);
           }

--- a/src/main/php/util/Filter.class.php
+++ b/src/main/php/util/Filter.class.php
@@ -4,7 +4,7 @@
  * A filter instance decides based on the passed elements whether to
  * accept them.
  */
-#[@generic(self= 'T')]
+#[@generic(['self' => 'T'])]
 interface Filter {
 
   /**
@@ -13,6 +13,6 @@ interface Filter {
    * @param  T $e
    * @return bool
    */
-  #[@generic(params= 'T')]
+  #[@generic(['params' => 'T'])]
   public function accept($e);
 }

--- a/src/main/php/util/Filters.class.php
+++ b/src/main/php/util/Filters.class.php
@@ -13,7 +13,7 @@ use lang\{IllegalArgumentException, IllegalStateException};
  * @see  xp://util.Filter
  * @test xp://net.xp_framework.unittest.util.FiltersTest
  */
-#[@generic(self= 'T', implements= ['T'])]
+#[@generic(['self' => 'T', 'implements' => ['T']])]
 class Filters implements Filter {
   protected $list;
   protected $accept;
@@ -50,7 +50,7 @@ class Filters implements Filter {
    * @param   php.Closure $accept
    * @throws  lang.IllegalArgumentException if accept is neither a closure nor NULL
    */
-  #[@generic(params= 'util.Filter<T>[]')]
+  #[@generic(['params' => 'util.Filter<T>[]'])]
   public function __construct(array $list= [], $accept= null) {
     $this->list= $list;
     if (null === $accept) {
@@ -68,7 +68,7 @@ class Filters implements Filter {
    * @param   util.Filter<T> $filter
    * @return  self<T>
    */
-  #[@generic(params= 'util.Filter<T>', return= 'self<T>')]
+  #[@generic(['params' => 'util.Filter<T>', 'return' => 'self<T>'])]
   public function add($filter) {
     $this->list[]= $filter;
     return $this;
@@ -91,7 +91,7 @@ class Filters implements Filter {
    * @param  T $e
    * @return bool
    */
-  #[@generic(params= 'T')]
+  #[@generic(['params' => 'T'])]
   public function accept($e) {
     return $this->accept->__invoke($this->list, $e);
   }

--- a/src/test/php/net/xp_framework/unittest/DemoTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/DemoTest.class.php
@@ -49,7 +49,7 @@ class DemoTest extends \unittest\TestCase {
     throw new IllegalArgumentException('');
   }
 
-  #[@test, @limit(time= 0.1)]
+  #[@test, @limit(['time' => 0.1])]
   public function timeouts() {
     usleep(200000);
   }

--- a/src/test/php/net/xp_framework/unittest/annotations/AnnotationParsingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/AnnotationParsingTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\annotations;
 
-use net\xp_framework\unittest\annotations\fixture\Namespaced;
-use lang\reflect\ClassParser;
 use lang\ClassFormatException;
+use lang\reflect\ClassParser;
+use net\xp_framework\unittest\annotations\fixture\Namespaced;
 
 /**
  * Tests the XP Framework's annotation parsing implementation
@@ -201,12 +201,14 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
     );
   }
 
+  /** @deprecated */
   #[@test]
   public function key_value_pairs_annotation_value() {
     $this->assertEquals(
       [0 => ['config' => ['key' => 'value', 'times' => 5, 'disabled' => false, 'null' => null, 'list' => [1, 2]]], 1 => []],
       $this->parse("#[@config(key = 'value', times= 5, disabled= false, null = null, list= [1, 2])]")
     );
+    \xp::gc();
   }
 
   #[@test]
@@ -225,10 +227,10 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
         'net.xp_framework.unittest.core.SecondInterceptor',
       ]]], 1 => []],
       $this->parse("
-        #[@interceptors(classes= [
+        #[@interceptors(['classes' => [
           'net.xp_framework.unittest.core.FirstInterceptor',
           'net.xp_framework.unittest.core.SecondInterceptor',
-        ])]
+        ]])]
       ")
     );
   }
@@ -237,7 +239,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function simple_XPath_annotation() {
     $this->assertEquals(
       [0 => ['fromXml' => ['xpath' => '/parent/child/@attribute']], 1 => []],
-      $this->parse("#[@fromXml(xpath= '/parent/child/@attribute')]")
+      $this->parse("#[@fromXml(['xpath' => '/parent/child/@attribute'])]")
     );
   }
 
@@ -245,7 +247,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function complex_XPath_annotation() {
     $this->assertEquals(
       [0 => ['fromXml' => ['xpath' => '/parent[@attr="value"]/child[@attr1="val1" and @attr2="val2"]']], 1 => []],
-      $this->parse("#[@fromXml(xpath= '/parent[@attr=\"value\"]/child[@attr1=\"val1\" and @attr2=\"val2\"]')]")
+      $this->parse("#[@fromXml(['xpath' => '/parent[@attr=\"value\"]/child[@attr1=\"val1\" and @attr2=\"val2\"]'])]")
     );
   }
 
@@ -261,7 +263,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function string_assigned_without_whitespace() {
     $this->assertEquals(
       [0 => ['arg' => ['name' => 'verbose', 'short' => 'v']], 1 => []],
-      $this->parse("#[@arg(name= 'verbose', short='v')]")
+      $this->parse("#[@arg(['name' => 'verbose', 'short' => 'v'])]")
     );
   }
 
@@ -269,7 +271,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function multiple_values_with_strings_and_equal_signs() {
     $this->assertEquals(
       [0 => ['permission' => ['names' => ['rn=login, rt=config1', 'rn=login, rt=config2']]], 1 => []],
-      $this->parse("#[@permission(names= ['rn=login, rt=config1', 'rn=login, rt=config2'])]")
+      $this->parse("#[@permission(['names' => ['rn=login, rt=config1', 'rn=login, rt=config2']])]")
     );
   }
 
@@ -277,7 +279,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function unittest_annotation() {
     $this->assertEquals(
       [0 => ['test' => NULL, 'ignore' => NULL, 'limit' => ['time' => 0.1, 'memory' => 100]], 1 => []],
-      $this->parse("#[@test, @ignore, @limit(time = 0.1, memory = 100)]")
+      $this->parse("#[@test, @ignore, @limit(['time' => 0.1, 'memory' => 100])]")
     );
   }
 
@@ -285,7 +287,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function overloaded_annotation() {
     $this->assertEquals(
       [0 => ['overloaded' => ['signatures' => [['string'], ['string', 'string']]]], 1 => []],
-      $this->parse('#[@overloaded(signatures= [["string"], ["string", "string"]])]')
+      $this->parse('#[@overloaded(["signatures" => [["string"], ["string", "string"]]])]')
     );
   }
 
@@ -294,10 +296,10 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
     $this->assertEquals(
       [0 => ['overloaded' => ['signatures' => [['string'], ['string', 'string']]]], 1 => []],
       $this->parse(
-        "#[@overloaded(signatures= [\n".
+        "#[@overloaded(['signatures' => [\n".
         "  ['string'],\n".
         "  ['string', 'string']\n".
-        "])]"
+        "]])]"
       )
     );
   }
@@ -309,7 +311,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
         0 => ['webmethod' => ['verb' => 'GET', 'path' => '/greet/{name}']],
         1 => ['$name' => ['path' => null], '$greeting' => ['param' => null]]
       ],
-      $this->parse('#[@webmethod(verb= "GET", path= "/greet/{name}"), @$name: path, @$greeting: param]')
+      $this->parse('#[@webmethod(["verb" => "GET", "path" => "/greet/{name}"]), @$name: path, @$greeting: param]')
     );
   }
 
@@ -333,7 +335,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function short_array_syntax_as_key() {
     $this->assertEquals(
       [0 => ['permissions' => ['names' => ['rn=login, rt=config', 'rn=admin, rt=config']]], 1 => []],
-      $this->parse("#[@permissions(names = ['rn=login, rt=config', 'rn=admin, rt=config'])]")
+      $this->parse("#[@permissions(['names' => ['rn=login, rt=config', 'rn=admin, rt=config']])]")
     );
   }
 
@@ -349,7 +351,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function nested_short_array_syntax_as_key() {
     $this->assertEquals(
       [0 => ['test' => ['values' => [[1, 1], [2, 2], [3, 3]]]], 1 => []],
-      $this->parse("#[@test(values = [[1, 1], [2, 2], [3, 3]])]")
+      $this->parse("#[@test(['values' => [[1, 1], [2, 2], [3, 3]]])]")
     );
   }
 
@@ -421,7 +423,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function class_constant_via_self_in_map() {
     $this->assertEquals(
       [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => []],
-      $this->parse('#[@map(key = self::CONSTANT, value = "val")]')
+      $this->parse('#[@map(["key" => self::CONSTANT, "value" => "val"])]')
     );
   }
 
@@ -429,7 +431,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function class_constant_via_classname_in_map() {
     $this->assertEquals(
       [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => []],
-      $this->parse('#[@map(key = AnnotationParsingTest::CONSTANT, value = "val")]')
+      $this->parse('#[@map(["key" => AnnotationParsingTest::CONSTANT, "value" => "val"])]')
     );
   }
 
@@ -437,7 +439,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
   public function class_constant_via_ns_classname_in_map() {
     $this->assertEquals(
       [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => []],
-      $this->parse('#[@map(key = \net\xp_framework\unittest\annotations\AnnotationParsingTest::CONSTANT, value = "val")]')
+      $this->parse('#[@map(["key" => \net\xp_framework\unittest\annotations\AnnotationParsingTest::CONSTANT, "value" => "val"])]')
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/annotations/AnnotationParsingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/AnnotationParsingTest.class.php
@@ -483,7 +483,10 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
     );
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Cannot access private static field .+AbstractAnnotationParsingTest::\$parentsInternal/')]
+  #[@test, @expect([
+  #  'class' => ClassFormatException::class,
+  #  'withMessage' => '/Cannot access private static field .+AbstractAnnotationParsingTest::\$parentsInternal/'
+  #])]
   public function parent_private_static_member() {
     $this->parse('#[@value(parent::$parentsInternal)]');
   }

--- a/src/test/php/net/xp_framework/unittest/annotations/BrokenAnnotationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/BrokenAnnotationTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace net\xp_framework\unittest\annotations;
 
+use lang\ClassFormatException;
 use lang\XPClass;
 use lang\reflect\ClassParser;
-use lang\ClassFormatException;
+use unittest\TestCase;
 
 /**
  * Tests the XP Framework's annotations
@@ -11,7 +12,7 @@ use lang\ClassFormatException;
  * @see   https://github.com/xp-framework/xp-framework/pull/328
  * @see   https://github.com/xp-framework/xp-framework/issues/313
  */
-class BrokenAnnotationTest extends \unittest\TestCase {
+class BrokenAnnotationTest extends TestCase {
 
   /**
    * Helper
@@ -23,152 +24,167 @@ class BrokenAnnotationTest extends \unittest\TestCase {
     return (new ClassParser())->parseAnnotations($input, nameof($this));
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Unterminated annotation/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Unterminated annotation/'])]
   public function no_ending_bracket() {
     XPClass::forName('net.xp_framework.unittest.annotations.NoEndingBracket')->getAnnotations();
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error/')]
-  public function missing_ending_bracket_in_key_value_pairs() {
-    $this->parse("#[@attribute(key= 'value']");
-  }
-
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error/'])]
   public function unterminated_single_quoted_string_literal() {
-    $this->parse("#[@attribute(key= 'value)]");
+    $this->parse("#[@attribute('value)]");
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error/'])]
   public function unterminated_double_quoted_string_literal() {
-    $this->parse('#[@attribute(key= "value)]');
+    $this->parse('#[@attribute("value)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Expecting "@"/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Expecting "@"/'])]
   public function missing_annotation_after_comma_and_value() {
     $this->parse('#[@ignore("Test"), ]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Expecting "@"/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Expecting "@"/'])]
   public function missing_annotation_after_comma() {
     $this->parse('#[@ignore, ]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Expecting "@"/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Expecting "@"/'])]
   public function missing_annotation_after_second_comma() {
     $this->parse('#[@ignore, @test, ]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unterminated string/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Unterminated string/'])]
   public function unterminated_dq_string() {
     $this->parse('#[@ignore("Test)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unterminated string/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Unterminated string/'])]
   public function unterminated_sq_string() {
     $this->parse("#[@ignore('Test)]");
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Unterminated array/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Unterminated array/'])]
   public function unterminated_short_array() {
     $this->parse('#[@ignore([1');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Unterminated array/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Unterminated array/'])]
   public function unterminated_short_array_key() {
-    $this->parse('#[@ignore(name = [1');
+    $this->parse('#[@ignore(["name" => [1');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Malformed array/'])]
   public function malformed_short_array() {
     $this->parse('#[@ignore([1 ,, 2])]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
-  public function malformed_short_array_inside_key_value_pairs() {
-    $this->parse('#[@ignore(name= [1 ,, 2])]');
+  /** @deprecated */
+  #[@test]
+  public function missing_ending_bracket_in_key_value_pairs() {
+    try {
+      $this->parse("#[@attribute(key= 'value']");
+      $this->fail('No exception raised', null, ClassFormatException::class);
+    } catch (ClassFormatException $expected) {
+      \xp::gc();
+      $this->assertTrue((bool)preg_match('/Unterminated annotation map key/', $expected->getMessage()), $expected->getMessage());
+    }
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Malformed array/')]
+  /** @deprecated */
+  #[@test]
+  public function malformed_short_array_inside_key_value_pairs() {
+    try {
+      $this->parse('#[@ignore(name= [1 ,, 2])]');
+      \xp::gc();
+      $this->fail('No exception raised', null, ClassFormatException::class);
+    } catch (ClassFormatException $expected) {
+      \xp::gc();
+      $this->assertTrue((bool)preg_match('/Malformed array/', $expected->getMessage()), $expected->getMessage());
+    }
+  }
+
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Malformed array/'])]
   public function malformed_short_array_no_commas() {
     $this->parse('#[@ignore([1 2])]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Expecting either "\(", "," or "\]"/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Expecting either "\(", "," or "\]"/'])]
   public function annotation_not_separated_by_commas() {
     $this->parse("#[@test @throws('rdbms.SQLConnectException')]");
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Expecting either "\(", "," or "\]"/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Expecting either "\(", "," or "\]"/'])]
   public function too_many_closing_braces() {
     $this->parse("#[@throws('rdbms.SQLConnectException'))]");
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Undefined constant "editor"/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Undefined constant "editor"/'])]
   public function undefined_constant() {
     $this->parse('#[@$editorId: param(editor)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/No such constant "EDITOR" in class/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/No such constant "EDITOR" in class/'])]
   public function undefined_class_constant() {
     $this->parse('#[@$editorId: param(self::EDITOR)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Class ".+" could not be found/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Class ".+" could not be found/'])]
   public function undefined_class_in_new() {
     $this->parse('#[@$editorId: param(new NonExistantClass())]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Class ".+" could not be found/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Class ".+" could not be found/'])]
   public function undefined_class_in_constant() {
     $this->parse('#[@$editorId: param(NonExistantClass::CONSTANT)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/No such field "EDITOR" in class/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/No such field "EDITOR" in class/'])]
   public function undefined_class_member() {
     $this->parse('#[@$editorId: param(self::$EDITOR)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Cannot access protected static field .+AnnotationParsingTest::\$hidden/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Cannot access protected static field .+AnnotationParsingTest::\$hidden/'])]
   public function class_protected_static_member() {
     $this->parse('#[@value(AnnotationParsingTest::$hidden)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Cannot access private static field .+AnnotationParsingTest::\$internal/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Cannot access private static field .+AnnotationParsingTest::\$internal/'])]
   public function class_private_static_member() {
     $this->parse('#[@value(AnnotationParsingTest::$internal)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/In `.+`: Syntax error/i')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/In `.+`: Syntax error/i'])]
   public function function_without_braces() {
     $this->parse('#[@value(function)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/In `.+`: Syntax error/i')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/In `.+`: Syntax error/i'])]
   public function function_without_body() {
     $this->parse('#[@value(function())]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/In `.+`: Syntax error/i')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/In `.+`: Syntax error/i'])]
   public function function_without_closing_curly() {
     $this->parse('#[@value(function() {)]');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unexpected ","/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Unexpected ","/'])]
   public function multi_value() {
     $this->parse("#[@xmlmapping('hw_server', 'server')]");
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unexpected ","/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Unexpected ","/'])]
   public function multi_value_without_whitespace() {
     $this->parse("#[@xmlmapping('hw_server','server')]");
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unexpected ","/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Unexpected ","/'])]
   public function multi_value_with_variable_types_backwards_compatibility() {
     $this->parse("#[@xmlmapping('hw_server', TRUE)]");
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Parse error: Unexpected ","/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Unexpected ","/'])]
   public function parsingContinuesAfterMultiValue() {
     $this->parse("#[@xmlmapping('hw_server', 'server'), @restricted]");
   }

--- a/src/test/php/net/xp_framework/unittest/core/AnnotatedClass.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/AnnotatedClass.class.php
@@ -48,7 +48,7 @@ class AnnotatedClass {
    * Unittest method annotated with @test, @ignore and @limit
    *
    */
-  #[@test, @ignore, @limit(time = 0.1, memory = 100)]
+  #[@test, @ignore, @limit(['time' => 0.1, 'memory' => 100])]
   public function testMethod() { }
 
 }

--- a/src/test/php/net/xp_framework/unittest/core/AnnotatedClass.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/AnnotatedClass.class.php
@@ -29,12 +29,20 @@ class AnnotatedClass {
   public function stringValue() { }
 
   /**
+   * Method annotated with an annotation with a one key/value pair
+   *
+   * @deprecated
+   */
+  #[@config(key = 'value')]
+  public function keyValuePair() { }
+
+  /**
    * Method annotated with an annotation with a hash value containing one
    * key/value pair
    *
    */
-  #[@config(key = 'value')]
-  public function keyValuePair() { }
+  #[@config(['key' => 'value'])]
+  public function hashValue() { }
 
   /**
    * Unittest method annotated with @test, @ignore and @limit

--- a/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
@@ -12,11 +12,15 @@ use lang\XPClass;
  * @see   rfc://0016
  */
 class AnnotationTest extends \unittest\TestCase {
-  private $class;
 
-  /** @return void */
-  public function setUp() {
-    $this->class= XPClass::forName('net.xp_framework.unittest.core.AnnotatedClass');
+  /** @return lang.XPClass */
+  public function annotated() {
+    $class= XPClass::forName('net.xp_framework.unittest.core.AnnotatedClass');
+
+    // Trigger annotation parsing, swallowing warnings
+    $class->getAnnotations();
+    \xp::gc();
+    return $class;
   }
 
   #[@test]
@@ -31,12 +35,12 @@ class AnnotationTest extends \unittest\TestCase {
 
   #[@test]
   public function simpleAnnotationExists() {
-    $this->assertTrue($this->class->getMethod('simple')->hasAnnotation('simple'));
+    $this->assertTrue($this->annotated()->getMethod('simple')->hasAnnotation('simple'));
   }
 
   #[@test]
   public function simpleAnnotationValue() {
-    $this->assertEquals(null, $this->class->getMethod('simple')->getAnnotation('simple'));
+    $this->assertEquals(null, $this->annotated()->getMethod('simple')->getAnnotation('simple'));
   }
 
   #[@test, @expect(ElementNotFoundException::class)]
@@ -51,24 +55,24 @@ class AnnotationTest extends \unittest\TestCase {
   
   #[@test, @expect(ElementNotFoundException::class)]
   public function getNonExistantAnnotation() {
-    $this->class->getMethod('simple')->getAnnotation('doesnotexist');
+    $this->annotated()->getMethod('simple')->getAnnotation('doesnotexist');
   }
 
   #[@test]
   public function hasNonExistantAnnotation() {
-    $this->assertFalse($this->class->getMethod('simple')->hasAnnotation('doesnotexist'));
+    $this->assertFalse($this->annotated()->getMethod('simple')->hasAnnotation('doesnotexist'));
   }
 
   #[@test, @values(['one', 'two', 'three'])]
   public function multipleAnnotationsExist($annotation) {
-    $this->assertTrue($this->class->getMethod('multiple')->hasAnnotation($annotation));
+    $this->assertTrue($this->annotated()->getMethod('multiple')->hasAnnotation($annotation));
   }
 
   #[@test]
   public function multipleAnnotationsReturnedAsList() {
     $this->assertEquals(
       ['one' => null, 'two' => null, 'three' => null],
-      $this->class->getMethod('multiple')->getAnnotations()
+      $this->annotated()->getMethod('multiple')->getAnnotations()
     );
   }
 
@@ -76,7 +80,7 @@ class AnnotationTest extends \unittest\TestCase {
   public function stringAnnotationValue() {
     $this->assertEquals(
       'String value',
-      $this->class->getMethod('stringValue')->getAnnotation('strval')
+      $this->annotated()->getMethod('stringValue')->getAnnotation('strval')
     );
   }
 
@@ -84,7 +88,7 @@ class AnnotationTest extends \unittest\TestCase {
   public function hashAnnotationValue() {
     $this->assertEquals(
       ['key' => 'value'],
-      $this->class->getMethod('hashValue')->getAnnotation('config')
+      $this->annotated()->getMethod('hashValue')->getAnnotation('config')
     );
   }
 
@@ -93,25 +97,25 @@ class AnnotationTest extends \unittest\TestCase {
   public function keyValuePairAnnotationValue() {
     $this->assertEquals(
       ['key' => 'value'],
-      $this->class->getMethod('keyValuePair')->getAnnotation('config')
+      $this->annotated()->getMethod('keyValuePair')->getAnnotation('config')
     );
   }
 
   #[@test]
   public function testMethodHasTestAnnotation() {
-    $this->assertTrue($this->class->getMethod('testMethod')->hasAnnotation('test'));
+    $this->assertTrue($this->annotated()->getMethod('testMethod')->hasAnnotation('test'));
   }
 
   #[@test]
   public function testMethodHasIgnoreAnnotation() {
-    $this->assertTrue($this->class->getMethod('testMethod')->hasAnnotation('ignore'));
+    $this->assertTrue($this->annotated()->getMethod('testMethod')->hasAnnotation('ignore'));
   }
 
   #[@test]
   public function testMethodsLimitAnnotation() {
     $this->assertEquals(
       ['time' => 0.1, 'memory' => 100],
-      $this->class->getMethod('testMethod')->getAnnotation('limit')
+      $this->annotated()->getMethod('testMethod')->getAnnotation('limit')
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
@@ -81,6 +81,15 @@ class AnnotationTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function hashAnnotationValue() {
+    $this->assertEquals(
+      ['key' => 'value'],
+      $this->class->getMethod('hashValue')->getAnnotation('config')
+    );
+  }
+
+  /** @deprecated */
+  #[@test]
   public function keyValuePairAnnotationValue() {
     $this->assertEquals(
       ['key' => 'value'],

--- a/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/CreateTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace net\xp_framework\unittest\core;
 
-use lang\XPClass;
-use lang\IllegalArgumentException;
+use lang\{XPClass, IllegalArgumentException};
 
 /**
  * TestCase for create() core functionality, which is used to create

--- a/src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
@@ -146,7 +146,7 @@ class ProcessTest extends TestCase {
     $this->assertEquals(222, $p->close());
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot close not-owned/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/Cannot close not-owned/'])]
   public function closingProcessByProcessId() {
     Process::getProcessById(getmypid())->close();
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/AbstractDictionary.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/AbstractDictionary.class.php
@@ -3,7 +3,7 @@
 /**
  * Lookup map
  */
-#[@generic(self= 'K, V', implements= ['K, V'])]
+#[@generic(['self' => 'K, V', 'implements' => ['K, V']])]
 abstract class AbstractDictionary implements IDictionary {
   
   /**

--- a/src/test/php/net/xp_framework/unittest/core/generics/AbstractTypeDictionary.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/AbstractTypeDictionary.class.php
@@ -3,7 +3,7 @@
 /**
  * Lookup map
  */
-#[@generic(self= 'V', implements= ['lang.Type, V'])]
+#[@generic(['self' => 'V', 'implements' => ['lang.Type, V']])]
 abstract class AbstractTypeDictionary implements IDictionary {
 
 }

--- a/src/test/php/net/xp_framework/unittest/core/generics/ArrayFilter.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/ArrayFilter.class.php
@@ -17,7 +17,7 @@
  * }
  * ```
  */
-#[@generic(self= 'T')]
+#[@generic(['self' => 'T'])]
 abstract class ArrayFilter {
   
   /**
@@ -28,7 +28,7 @@ abstract class ArrayFilter {
    * @param   T element
    * @return  bool
    */
-  #[@generic(params= 'T')]
+  #[@generic(['params' => 'T'])]
   protected abstract function accept($element);
 
   /**
@@ -37,7 +37,7 @@ abstract class ArrayFilter {
    * @param   T[] elements
    * @return  T[] filtered
    */
-  #[@generic(params= 'T[]', return= 'T[]')]
+  #[@generic(['params' => 'T[]', 'return' => 'T[]'])]
   public function filter($elements) {
     $filtered= [];
     foreach ($elements as $element) {

--- a/src/test/php/net/xp_framework/unittest/core/generics/IDictionary.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/IDictionary.class.php
@@ -4,7 +4,7 @@
  * Lookup map
  *
  */
-#[@generic(self= 'K, V')]
+#[@generic(['self' => 'K, V'])]
 interface IDictionary {
  
   /**
@@ -13,7 +13,7 @@ interface IDictionary {
    * @param   K key
    * @param   V value
    */
-  #[@generic(params= 'K, V')]
+  #[@generic(['params' => 'K, V'])]
   public function put($key, $value);
 
   /**
@@ -23,7 +23,7 @@ interface IDictionary {
    * @return  V value
    * @throws  util.NoSuchElementException
    */
-  #[@generic(params= 'K', return= 'V')]
+  #[@generic(['params' => 'K', 'return' => 'V'])]
   public function get($key);
 
   /**
@@ -31,6 +31,6 @@ interface IDictionary {
    *
    * @return  V[] values
    */
-  #[@generic(return= 'V[]')]
+  #[@generic(['return' => 'V[]'])]
   public function values();
 }

--- a/src/test/php/net/xp_framework/unittest/core/generics/ListOf.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/ListOf.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
 /** List of elements */
-#[@generic(self= 'T')]
+#[@generic(['self' => 'T'])]
 class ListOf {
   public $elements= [];
 
@@ -10,7 +10,7 @@ class ListOf {
    *
    * @param   T... initial
    */
-  #[@generic(params= 'T...')]
+  #[@generic(['params' => 'T...'])]
   public function __construct(... $args) {
     $this->elements= $args;
   }
@@ -21,7 +21,7 @@ class ListOf {
    * @param   T... elements
    * @return  net.xp_framework.unittest.core.generics.List self
    */
-  #[@generic(params= 'T...')]
+  #[@generic(['params' => 'T...'])]
   public function withAll(... $args) {
     $this->elements= array_merge($this->elements, $args);
     return $this;
@@ -32,7 +32,7 @@ class ListOf {
    *
    * @return  T[] elements
    */
-  #[@generic(return= 'T[]')]
+  #[@generic(['return' => 'T[]'])]
   public function elements() {
     return $this->elements;
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/Lookup.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/Lookup.class.php
@@ -5,11 +5,11 @@ use util\Objects;
 /**
  * Lookup map
  */
-#[@generic(self= 'K, V', parent= 'K, V')]
+#[@generic(['self' => 'K, V', 'parent' => 'K, V'])]
 class Lookup extends AbstractDictionary {
   protected $size;
 
-  #[@generic(var= '[:V]')]
+  #[@generic(['var' => '[:V]'])]
   protected $elements= [];
   
   /**
@@ -18,7 +18,7 @@ class Lookup extends AbstractDictionary {
    * @param   K key
    * @param   V value
    */
-  #[@generic(params= 'K, V')]
+  #[@generic(['params' => 'K, V'])]
   public function put($key, $value) {
     $this->elements[Objects::hashOf($key)]= $value;
     $this->size= sizeof($this->elements);
@@ -31,7 +31,7 @@ class Lookup extends AbstractDictionary {
    * @return  V value
    * @throws  util.NoSuchElementException
    */
-  #[@generic(params= 'K', return= 'V')]
+  #[@generic(['params' => 'K', 'return' => 'V'])]
   public function get($key) {
     $offset= Objects::hashOf($key);
     if (!isset($this->elements[$offset])) {
@@ -45,7 +45,7 @@ class Lookup extends AbstractDictionary {
    *
    * @return  V[] values
    */
-  #[@generic(return= 'V[]')]
+  #[@generic(['return' => 'V[]'])]
   public function values() {
     return array_values($this->elements);
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/Nullable.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/Nullable.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
 /** Nullable value */
-#[@generic(self= 'T')]
+#[@generic(['self' => 'T'])]
 class Nullable {
   protected $value;
 
@@ -10,7 +10,7 @@ class Nullable {
    *
    * @param   T value
    */
-  #[@generic(params= 'T')]
+  #[@generic(['params' => 'T'])]
   public function __construct($value= null) {
     $this->value= $value;
   }
@@ -30,7 +30,7 @@ class Nullable {
    * @param   T value
    * @return  self this instance
    */
-  #[@generic(params= 'T')]
+  #[@generic(['params' => 'T'])]
   public function set($value= null) {
     $this->value= $value;
     return $this;
@@ -41,7 +41,7 @@ class Nullable {
    *
    * @return  T value
    */
-  #[@generic(return= 'T')]
+  #[@generic(['return' => 'T'])]
   public function get() {
     return $this->value;
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/TypeDictionary.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/TypeDictionary.class.php
@@ -6,7 +6,7 @@ use util\NoSuchElementException;
  * Lookup map
  *
  */
-#[@generic(self= 'V', parent= 'V')]
+#[@generic(['self' => 'V', 'parent' => 'V'])]
 class TypeDictionary extends AbstractTypeDictionary {
   protected $elements= [];
   
@@ -16,7 +16,7 @@ class TypeDictionary extends AbstractTypeDictionary {
    * @param   lang.Type key
    * @param   V value
    */
-  #[@generic(params= 'lang.Type, V')]
+  #[@generic(['params' => 'lang.Type, V'])]
   public function put($key, $value) {
     $offset= $key->literal();
     $this->elements[$offset]= $value;
@@ -29,7 +29,7 @@ class TypeDictionary extends AbstractTypeDictionary {
    * @return  V value
    * @throws  util.NoSuchElementException
    */
-  #[@generic(params= 'lang.Type', return= 'V')]
+  #[@generic(['params' => 'lang.Type', 'return' => 'V'])]
   public function get($key) {
     $offset= $key->literal();
     if (!isset($this->elements[$offset])) {
@@ -43,7 +43,7 @@ class TypeDictionary extends AbstractTypeDictionary {
    *
    * @return  V[] values
    */
-  #[@generic(return= 'V[]')]
+  #[@generic(['return' => 'V[]'])]
   public function values() {
     return array_values($this->elements);
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/TypeLookup.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/TypeLookup.class.php
@@ -4,7 +4,7 @@
  * Lookup map
  *
  */
-#[@generic(self= 'V', parent= 'lang.Type, V')]
+#[@generic(['self' => 'V', 'parent' => 'lang.Type, V'])]
 class TypeLookup extends Lookup {
 
 }

--- a/src/test/php/net/xp_framework/unittest/core/generics/Unserializer.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/Unserializer.class.php
@@ -3,7 +3,7 @@
 /**
  * Unserializer
  */
-#[@generic(self= 'T')]
+#[@generic(['self' => 'T'])]
 class Unserializer {
 
   /**
@@ -12,7 +12,7 @@ class Unserializer {
    * @param   var $arg
    * @return  T element
    */
-  #[@generic(return= 'T')]
+  #[@generic(['return' => 'T'])]
   public function newInstance($arg= null) {
     return null === $arg ? $T->default : $T->newInstance($arg);
   }

--- a/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/PathTest.class.php
@@ -209,7 +209,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals($file, (new Path($file))->asFile());
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/.+ is not a file/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/.+ is not a file/'])]
   public function as_file_throws_exception_when_invoked_on_a_folder() {
     (new Path($this->existingFolder()))->asFile();
   }
@@ -219,7 +219,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals(new File('test.txt'), (new Path('test.txt'))->asFile());
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/.+ does not exist/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/.+ does not exist/'])]
   public function as_file_throws_exception_when_existing_flag_defined_an_nonexistant_path_given() {
     (new Path('test.txt'))->asFile(Path::EXISTING);
   }
@@ -230,7 +230,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals($folder, (new Path($folder))->asFolder());
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/.+ is not a folder/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/.+ is not a folder/'])]
   public function as_folder_throws_exception_when_invoked_on_a_folder() {
     (new Path($this->existingFile()))->asFolder();
   }
@@ -240,7 +240,7 @@ class PathTest extends \unittest\TestCase {
     $this->assertEquals(new Folder('test'), (new Path('test'))->asFolder());
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/.+ does not exist/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/.+ does not exist/'])]
   public function as_folder_throws_exception_when_existing_flag_defined_an_nonexistant_path_given() {
     (new Path('test'))->asFolder(Path::EXISTING);
   }

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextReaderTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\io\streams;
 
-use io\{Channel, IOException};
 use io\streams\{LinesIn, TextReader, InputStream, MemoryInputStream, MemoryOutputStream};
+use io\{Channel, IOException};
 use lang\{IllegalArgumentException, FormatException};
 
 /**
@@ -373,7 +373,7 @@ class TextReaderTest extends \unittest\TestCase {
     $this->assertEquals('ABC', $r->read(3));
   }
 
-  #[@test, @expect(class= IOException::class, withMessage= 'Underlying stream does not support seeking')]
+  #[@test, @expect(['class' => IOException::class, 'withMessage' => 'Underlying stream does not support seeking'])]
   public function resetUnseekable() {
     $r= new TextReader($this->unseekableStream());
     $r->reset();

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -397,7 +397,7 @@ class ClassDetailsTest extends \unittest\TestCase {
     $this->assertEquals(['test' => null], $details[0]['fixture'][DETAIL_ANNOTATIONS]);
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/Class does not have a parent/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/Class does not have a parent/'])]
   public function annotation_with_parent_reference_in_parentless_class() {
     (new ClassParser())->parseDetails('<?php
       class Test {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassLoaderTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
+use lang\archive\{Archive, ArchiveClassLoader};
+use lang\reflect\Package;
 use lang\{
   ClassCastException,
   ClassDependencyException,
@@ -9,8 +11,6 @@ use lang\{
   IllegalStateException,
   XPClass
 };
-use lang\reflect\Package;
-use lang\archive\{Archive, ArchiveClassLoader};
 
 /**
  * TestCase for classloading
@@ -144,12 +144,12 @@ class ClassLoaderTest extends \unittest\TestCase {
     ClassLoader::getDefault()->loadClass('@@NON-EXISTANT@@');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/No types declared in .+/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/No types declared in .+/'])]
   public function loadClassFileWithoutDeclaration() {
     XPClass::forName('net.xp_framework.unittest.reflection.classes.broken.NoClass');
   }
 
-  #[@test, @expect(class= ClassFormatException::class, withMessage= '/File does not declare type `.+FalseClass`, but `.+TrueClass`/')]
+  #[@test, @expect(['class' => ClassFormatException::class, 'withMessage' => '/File does not declare type `.+FalseClass`, but `.+TrueClass`/'])]
   public function loadClassFileWithIncorrectDeclaration() {
     XPClass::forName('net.xp_framework.unittest.reflection.classes.broken.FalseClass');
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -191,7 +191,7 @@ class MethodParametersTest extends MethodsTest {
     $this->assertEquals([], $this->method('public function fixture($param) { }')->getParameter(0)->getAnnotations());
   }
 
-  #[@test, @expect(class= ElementNotFoundException::class, withMessage= 'Annotation "test" does not exist')]
+  #[@test, @expect(['class' => ElementNotFoundException::class, 'withMessage' => 'Annotation "test" does not exist'])]
   public function cannot_get_test_annotation_for_un_annotated_parameter() {
     $this->method('public function fixture($param) { }')->getParameter(0)->getAnnotation('test');
   }
@@ -206,7 +206,7 @@ class MethodParametersTest extends MethodsTest {
     $this->assertTrue($this->method('public function fixture($param= true) { }')->getParameter(0)->isOptional());
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= 'Parameter "param" has no default value')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => 'Parameter "param" has no default value'])]
   public function required_parameter_does_not_have_default_value() {
     $this->method('public function fixture($param) { }')->getParameter(0)->getDefaultValue();
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ModuleLoadingTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ModuleLoadingTest.class.php
@@ -58,12 +58,12 @@ class ModuleLoadingTest extends \unittest\TestCase {
     }']));
   }
 
-  #[@test, @expect(class= ElementNotFoundException::class, withMessage= '/Missing or malformed module-info/')]
+  #[@test, @expect(['class' => ElementNotFoundException::class, 'withMessage' => '/Missing or malformed module-info/'])]
   public function empty_module_file() {
     $this->register(new LoaderProviding(['module.xp' => '']));
   }
 
-  #[@test, @expect(class= ElementNotFoundException::class, withMessage= '/Missing or malformed module-info/')]
+  #[@test, @expect(['class' => ElementNotFoundException::class, 'withMessage' => '/Missing or malformed module-info/'])]
   public function module_without_name() {
     $this->register(new LoaderProviding(['module.xp' => 'module { }']));
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ModuleTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ModuleTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use lang\reflect\Module;
 use lang\ClassLoader;
 use lang\ElementNotFoundException;
+use lang\reflect\Module;
 
 /**
  * TestCase for modules
@@ -86,10 +86,10 @@ class ModuleTest extends \unittest\TestCase {
     $this->assertEquals($module, Module::forName($module->name()));
   }
 
-  #[@test, @expect(
-  #  class= ElementNotFoundException::class,
-  #  withMessage= 'No module "@@non-existant@@" declared'
-  #)]
+  #[@test, @expect([
+  #  'class' => ElementNotFoundException::class,
+  #  'withMessage' => 'No module "@@non-existant@@" declared'
+  #])]
   public function forName_throws_exception_when_no_module_registered() {
     Module::forName('@@non-existant@@');
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/OverloadedInterface.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/OverloadedInterface.class.php
@@ -11,9 +11,9 @@ interface OverloadedInterface {
    * Overloaded method.
    *
    */
-  #[@overloaded(signatures= [
+  #[@overloaded(['signatures' => [
   #  ['string'],
   #  ['string', 'string']
-  #])]
+  #]])]
   public function overloaded();
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/PrimitiveTest.class.php
@@ -70,7 +70,7 @@ class PrimitiveTest extends TestCase {
     $this->assertTrue(Primitive::$STRING->isInstance($value));
   }
   
-  #[@test, @values(source= 'instances', args= [['', 'Hello']])]
+  #[@test, @values(['source' => 'instances', 'args' => [['', 'Hello']]])]
   public function notInstanceOfString_primitive($value) {
     $this->assertFalse(Primitive::$STRING->isInstance($value));
   }
@@ -80,7 +80,7 @@ class PrimitiveTest extends TestCase {
     $this->assertTrue(Primitive::$INT->isInstance($value));
   }
 
-  #[@test, @values(source= 'instances', args= [[0, -1]])]
+  #[@test, @values(['source' => 'instances', 'args' => [[0, -1]]])]
   public function notInstanceOfInteger_primitive($value) {
     $this->assertFalse(Primitive::$INT->isInstance($value));
   }
@@ -90,7 +90,7 @@ class PrimitiveTest extends TestCase {
     $this->assertTrue(Primitive::$FLOAT->isInstance($value));
   }
 
-  #[@test, @values(source= 'instances', args= [[0.0, -1.5]])]
+  #[@test, @values(['source' => 'instances', 'args' => [[0.0, -1.5]]])]
   public function notInstanceOfDouble_primitive($value) {
     $this->assertFalse(Primitive::$FLOAT->isInstance($value));
   }
@@ -100,7 +100,7 @@ class PrimitiveTest extends TestCase {
     $this->assertTrue(Primitive::$BOOL->isInstance($value));
   }
 
-  #[@test, @values(source= 'instances', args= [[false, true]])]
+  #[@test, @values(['source' => 'instances', 'args' => [[false, true]]])]
   public function notInstanceOfBoolean_primitive($value) {
     $this->assertFalse(Primitive::$BOOL->isInstance($value));
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/RuntimeTypeDefinitionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/RuntimeTypeDefinitionTest.class.php
@@ -1,8 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use lang\ClassLoader;
-use lang\DynamicClassLoader;
-use lang\XPClass;
+use lang\{ClassLoader, DynamicClassLoader, XPClass};
+use unittest\TestCase;
 
 /**
  * Base class for runtime type definitions
@@ -10,7 +9,7 @@ use lang\XPClass;
  * @see   xp://lang.ClassLoader
  * @see   https://github.com/xp-framework/xp-framework/issues/94
  */
-abstract class RuntimeTypeDefinitionTest extends \unittest\TestCase {
+abstract class RuntimeTypeDefinitionTest extends TestCase {
 
   /**
    * Wraps around a function which defines types, giving it unique names and
@@ -72,7 +71,7 @@ abstract class RuntimeTypeDefinitionTest extends \unittest\TestCase {
 
   #[@test]
   public function declares_passed_annotation_with_value() {
-    $this->assertEquals('/rest', $this->define(['annotations' => '#[@webservice(path= "/rest")]'])->getAnnotation('webservice', 'path'));
+    $this->assertEquals('/rest', $this->define(['annotations' => '#[@webservice(["path" => "/rest"])]'])->getAnnotation('webservice', 'path'));
   }
 
   #[@test, @values(['com.example.test.RTTDDotted', 'com\\example\\test\\RTTDNative'])]

--- a/src/test/php/net/xp_framework/unittest/reflection/TestClass.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TestClass.class.php
@@ -110,7 +110,7 @@ class TestClass extends AbstractTestClass implements \lang\Runnable {
    *
    * @return  int
    */
-  #[@webmethod, @security(roles= ['admin', 'god'])]
+  #[@webmethod, @security(['roles' => ['admin', 'god']])]
   public function currentTimestamp() {
     return time();
   }

--- a/src/test/php/net/xp_framework/unittest/util/DeferredInvokationHandlerTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DeferredInvokationHandlerTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace net\xp_framework\unittest\util;
 
+use lang\IllegalStateException;
+use lang\Runnable;
 use util\AbstractDeferredInvokationHandler;
 use util\DeferredInitializationException;
-use lang\Runnable;
-use lang\IllegalStateException;
 
 /**
  * TestCase for AbstractDeferredInvokationHandler
@@ -23,7 +23,7 @@ class DeferredInvokationHandlerTest extends \unittest\TestCase {
     $this->assertEquals($args, $handler->invoke($this, 'run', $args));
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= 'Test')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => 'Test'])]
   public function throwing_runnable_invokation() {
     $handler= new class() extends AbstractDeferredInvokationHandler {
       public function initialize() {
@@ -35,7 +35,7 @@ class DeferredInvokationHandlerTest extends \unittest\TestCase {
     $handler->invoke($this, 'run', ['Test']);
   }
 
-  #[@test, @expect(class= DeferredInitializationException::class, withMessage= 'run')]
+  #[@test, @expect(['class' => DeferredInitializationException::class, 'withMessage' => 'run'])]
   public function initialize_returns_null() {
     $handler= new class() extends AbstractDeferredInvokationHandler {
       public function initialize() {
@@ -45,7 +45,7 @@ class DeferredInvokationHandlerTest extends \unittest\TestCase {
     $handler->invoke($this, 'run', []);
   }
 
-  #[@test, @expect(class= DeferredInitializationException::class, withMessage= 'run')]
+  #[@test, @expect(['class' => DeferredInitializationException::class, 'withMessage' => 'run'])]
   public function initialize_throws_exception() {
     $handler= new class() extends AbstractDeferredInvokationHandler {
       public function initialize() {

--- a/src/test/php/net/xp_framework/unittest/util/FilesystemPropertySourceTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/FilesystemPropertySourceTest.class.php
@@ -46,7 +46,7 @@ class FilesystemPropertySourceTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect(class= IllegalArgumentException::class, withMessage= '/No properties @@non-existant@@ found at .+/')]
+  #[@test, @expect(['class' => IllegalArgumentException::class, 'withMessage' => '/No properties @@non-existant@@ found at .+/'])]
   public function fetch_non_existant_ini_file() {
     $this->fixture->fetch('@@non-existant@@');
   }

--- a/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use util\Objects;
 use lang\Value;
 use net\xp_framework\unittest\Name;
+use util\Objects;
 
 /**
  * TestCase for Objects class
@@ -128,57 +128,57 @@ class ObjectsTest extends \unittest\TestCase {
     $this->assertFalse(Objects::equal((object)['name' => self::class], new \ReflectionClass(self::class)));
   }
 
-  #[@test, @values(source= 'valuesExcept', args= [null])]
+  #[@test, @values(['source' => 'valuesExcept', 'args' => [null]])]
   public function null_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(null, $val));
   }
 
-  #[@test, @values(source= 'valuesExcept', args= [false])]
+  #[@test, @values(['source' => 'valuesExcept', 'args' => [false]])]
   public function false_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(false, $val));
   }
 
-  #[@test, @values(source= 'valuesExcept', args= [true])]
+  #[@test, @values(['source' => 'valuesExcept', 'args' => [true]])]
   public function true_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(true, $val));
   }
 
-  #[@test, @values(source= 'values')]
+  #[@test, @values(['source' => 'values'])]
   public function int_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(6100, $val));
   }
 
-  #[@test, @values(source= 'values')]
+  #[@test, @values(['source' => 'values'])]
   public function double_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(6100.0, $val));
   }
 
-  #[@test, @values(source= 'values')]
+  #[@test, @values(['source' => 'values'])]
   public function string_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal('More power', $val));
   }
 
-  #[@test, @values(source= 'values')]
+  #[@test, @values(['source' => 'values'])]
   public function array_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal([4, 5, 6], $val));
   }
 
-  #[@test, @values(source= 'values')]
+  #[@test, @values(['source' => 'values'])]
   public function hash_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(['color' => 'blue'], $val));
   }
 
-  #[@test, @values(source= 'values')]
+  #[@test, @values(['source' => 'values'])]
   public function object_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(new class() { }, $val));
   }
 
-  #[@test, @values(source= 'values')]
+  #[@test, @values(['source' => 'values'])]
   public function string_instance_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(new ValueObject('Binford 6100: More Power!'), $val));
   }
 
-  #[@test, @values(source= 'values')]
+  #[@test, @values(['source' => 'values'])]
   public function value_not_equal_to_other_values($val) {
     $this->assertFalse(Objects::equal(new Name('Binford 6100: More Power!'), $val));
   }

--- a/src/test/php/net/xp_framework/unittest/util/SecretTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/SecretTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace net\xp_framework\unittest\util;
 
-use util\Secret;
-use lang\IllegalStateException;
 use lang\IllegalArgumentException;
-use lang\XPException;
+use lang\IllegalStateException;
 use lang\Throwable;
+use lang\XPException;
+use util\Secret;
 
 /**
  * Baseclass for test cases for security.Secret
@@ -87,7 +87,7 @@ abstract class SecretTest extends \unittest\TestCase {
     $this->assertTrue($called);
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/An error occurred during storing the encrypted secret./')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/An error occurred during storing the encrypted secret./'])]
   public function decryption_throws_exception_if_creation_has_failed() {
     $called= false;
     Secret::setBacking(function($value) {


### PR DESCRIPTION
This pull request implements the first step in xp-framework/rfc#335 and deprecates annotation key/value pair syntax. Using the deprecated syntax will trigger a warning and thus make tests fail, but will not affect production code.

## Deprecated form:

```php
#[@expect(class= FormatException::class)]
```

## Rewrite to the following:

```php
#[@expect(['class' => FormatException::class])]
```

*See xp-framework/unittest#39 for an example of rewriting annotation syntax.*