### PR TITLE
Add handling for `T_NAME_FULLY_QUALIFIED` and `T_NAME_QUALIFIED` tokens

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@ XP Framework Core ChangeLog
 
 ## ?.?.? / ????-??-??
 
+### Bugfixes
+
+* Add handling for `T_NAME_FULLY_QUALIFIED` and `T_NAME_QUALIFIED` tokens
+  introduced in PHP 8 by https://wiki.php.net/rfc/namespaced_names_as_token
+  (@thekid)
+
 ## 10.1.0 / 2020-05-31
 
 ### Features

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -433,6 +433,10 @@ define('MODIFIER_PRIVATE',   \ReflectionMethod::IS_PRIVATE);
 
 defined('PHP_INT_MIN') || define('PHP_INT_MIN', ~PHP_INT_MAX);
 
+defined('T_FN') || define('T_FN', -346);
+defined('T_NAME_FULLY_QUALIFIED') || define('T_NAME_FULLY_QUALIFIED', -312);
+defined('T_NAME_QUALIFIED') || define('T_NAME_QUALIFIED', -314);
+
 xp::$loader= new xp();
 
 // Paths are passed via class loader API from *-main.php. Retaining BC:

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -302,9 +302,9 @@ class GenericTypes {
               $i++;
             }
             $i--;
-            '\\' === $rel[0] || $rel= isset($imports[$rel]) ? $imports[$rel] : $namespace.'\\'.$rel;
+            '\\' === $rel[0] || $rel= isset($imports[$rel]) ? $imports[$rel] : '\\'.$namespace.'\\'.$rel;
           } else if (T_NAME_QUALIFIED === $tokens[$i][0]) {
-            $rel= isset($imports[$tokens[$i][1]]) ? $imports[$tokens[$i][1]] : $namespace.'\\'.$tokens[$i][1];
+            $rel= isset($imports[$tokens[$i][1]]) ? $imports[$tokens[$i][1]] : '\\'.$namespace.'\\'.$tokens[$i][1];
           } else if (T_NAME_FULLY_QUALIFIED === $tokens[$i][0]) {
             $rel= $tokens[$i][1];
           } else {

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -104,7 +104,7 @@ class GenericTypes {
           } else if (T_USE === $tokens[$i][0]) {
             $i+= 2;
             $use= '';
-            while ((T_STRING === $tokens[$i][0] || T_NS_SEPARATOR === $tokens[$i][0]) && $i < $s) {
+            while ((T_STRING === $tokens[$i][0] || T_NS_SEPARATOR === $tokens[$i][0] || T_NAME_QUALIFIED === $tokens[$i][0]) && $i < $s) {
               $use.= $tokens[$i][1];
               $i++;
             }
@@ -137,7 +137,7 @@ class GenericTypes {
           if (T_EXTENDS === $tokens[$i][0]) {
             $i+= 2;
             $parent= '';
-            while ((T_STRING === $tokens[$i][0] || T_NS_SEPARATOR === $tokens[$i][0]) && $i < $s) {
+            while ((T_STRING === $tokens[$i][0] || T_NS_SEPARATOR === $tokens[$i][0] || T_NAME_QUALIFIED === $tokens[$i][0]) && $i < $s) {
               $parent.= $tokens[$i][1];
               $i++;
             }

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -102,12 +102,11 @@ class GenericTypes {
             $src.= $tokens[$i][1].' '.$decl;
             array_unshift($state, $tokens[$i][0]);
           } else if (T_USE === $tokens[$i][0]) {
-            $i+= 2;
             $use= '';
-            while ((T_STRING === $tokens[$i][0] || T_NS_SEPARATOR === $tokens[$i][0] || T_NAME_QUALIFIED === $tokens[$i][0]) && $i < $s) {
+            for ($i+= 2; $i < $s, !(';' === $tokens[$i] || '{' === $tokens[$i] || T_WHITESPACE === $tokens[$i][0]); $i++) {
               $use.= $tokens[$i][1];
-              $i++;
             }
+
             if ('{' === $tokens[$i]) {
               $import= $use;
               $i++;
@@ -127,6 +126,9 @@ class GenericTypes {
                 }
                 $i++;
               }
+            } else if (T_AS === $tokens[++$i][0]) {
+              $imports[$tokens[$i + 2][1]]= strtr($use, '\\', '.');
+              $src.= 'use '.$use.' as '.$tokens[$i + 2][1].';';
             } else {
               $imports[substr($use, strrpos($use, '\\')+ 1)]= $use;
               $src.= 'use '.$use.';';

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -450,12 +450,8 @@ class ClassParser {
     for ($i= 0, $s= sizeof($tokens); $i < $s; $i++) {
       switch ($tokens[$i][0]) {
         case T_NAMESPACE:
-          $i++;
-          for (
-            $i+= 2;
-            (T_NS_SEPARATOR === $tokens[$i][0] || T_STRING === $tokens[$i][0] || T_NAME_QUALIFIED === $tokens[$i][0]) && $i < $s;
-            ++$i
-          ) {
+          $namespace= '';
+          for ($i+= 2; $i < $s, !(';' === $tokens[$i] || T_WHITESPACE === $tokens[$i][0]); $i++) {
             $namespace.= $tokens[$i][1];
           }
           $namespace.= '\\';
@@ -465,11 +461,7 @@ class ClassParser {
           if (isset($details['class'])) break;  // Inside class, e.g. function() use(...) {}
 
           $type= '';
-          for (
-            $i+= 2;
-            (T_NS_SEPARATOR === $tokens[$i][0] || T_STRING === $tokens[$i][0] || T_NAME_QUALIFIED === $tokens[$i][0]) && $i < $s;
-            ++$i
-          ) {
+          for ($i+= 2; $i < $s, !(';' === $tokens[$i] || '{' === $tokens[$i] || T_WHITESPACE === $tokens[$i][0]); $i++) {
             $type.= $tokens[$i][1];
           }
 
@@ -492,9 +484,10 @@ class ClassParser {
                 $group.= $tokens[$i][1];
               }
             }
+          } else if (T_AS === $tokens[++$i][0]) {
+            $imports[$tokens[$i + 2][1]]= strtr($type, '\\', '.');
           } else {
-            $alias= (T_AS === $tokens[++$i][0]) ? $tokens[$i + 2][1] : substr($type, strrpos($type, '\\')+ 1);
-            $imports[$alias]= strtr($type, '\\', '.');
+            $imports[substr($type, strrpos($type, '\\')+ 1)]= strtr($type, '\\', '.');
           }
           break;
 

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -14,10 +14,6 @@ use lang\{XPClass, IllegalStateException, IllegalAccessException, ElementNotFoun
  */
 class ClassParser {
 
-  static function __static() {
-    defined('T_FN') || define('T_FN', -1);
-  }
-
   /**
    * Resolves a type in a given context. Recognizes classes imported via
    * the `use` statement.
@@ -148,6 +144,9 @@ class ClassParser {
         $type.= '.'.$tokens[$i++][1];
       }
       return $this->memberOf(XPClass::forName(substr($type, 1)), $tokens[$i], $context);
+    } else if (T_NAME_FULLY_QUALIFIED === $token) {
+      $type= $tokens[$i++][1];
+      return $this->memberOf(XPClass::forName($type), $tokens[++$i], $context);
     } else if (T_FN === $token || T_STRING === $token && 'fn' === $tokens[$i][1]) {
       $s= sizeof($tokens);
       $b= 0;
@@ -224,10 +223,12 @@ class ClassParser {
       }
     } else if (T_NEW === $token) {
       $type= '';
-      while ('(' !== $tokens[$i++]) {
-        if (T_STRING === $tokens[$i][0]) $type.= '.'.$tokens[$i][1];
+      $i++;
+      while ('(' !== $tokens[++$i]) {
+        $type.= is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i];
       }
-      $class= $this->resolve(substr($type, 1), $context, $imports);
+      $i++;
+      $class= $this->resolve($type, $context, $imports);
       for ($args= [], $arg= null, $s= sizeof($tokens); ; $i++) {
         if (')' === $tokens[$i]) {
           $arg && $args[]= $arg[0];
@@ -449,7 +450,12 @@ class ClassParser {
     for ($i= 0, $s= sizeof($tokens); $i < $s; $i++) {
       switch ($tokens[$i][0]) {
         case T_NAMESPACE:
-          for ($i+= 2; (T_NS_SEPARATOR === $tokens[$i][0] || T_STRING === $tokens[$i][0]) && $i < $s; $i++) {
+          $i++;
+          for (
+            $i+= 2;
+            (T_NS_SEPARATOR === $tokens[$i][0] || T_STRING === $tokens[$i][0] || T_NAME_QUALIFIED === $tokens[$i][0]) && $i < $s;
+            ++$i
+          ) {
             $namespace.= $tokens[$i][1];
           }
           $namespace.= '\\';
@@ -457,8 +463,13 @@ class ClassParser {
 
         case T_USE:
           if (isset($details['class'])) break;  // Inside class, e.g. function() use(...) {}
+
           $type= '';
-          for ($i+= 2; (T_NS_SEPARATOR === $tokens[$i][0] || T_STRING === $tokens[$i][0]) && $i < $s; $i++) {
+          for (
+            $i+= 2;
+            (T_NS_SEPARATOR === $tokens[$i][0] || T_STRING === $tokens[$i][0] || T_NAME_QUALIFIED === $tokens[$i][0]) && $i < $s;
+            ++$i
+          ) {
             $type.= $tokens[$i][1];
           }
 

--- a/src/test/php/net/xp_framework/unittest/core/generics/AbstractDictionary.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/AbstractDictionary.class.php
@@ -4,7 +4,7 @@
  * Lookup map
  */
 #[@generic(['self' => 'K, V', 'implements' => ['K, V']])]
-abstract class AbstractDictionary implements IDictionary {
+abstract class AbstractDictionary implements IDictionary, Marker {
   
   /**
    * Constructor

--- a/src/test/php/net/xp_framework/unittest/core/generics/GenericTypesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/GenericTypesTest.class.php
@@ -1,24 +1,23 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
-use lang\Primitive;
-use lang\GenericTypes;
-use lang\XPClass;
+use lang\{GenericTypes, Primitive, XPClass};
+use unittest\TestCase;
 
 /**
  * TestCase for lang.GenericTypes
  */
-class GenericTypesTest extends \unittest\TestCase {
+class GenericTypesTest extends TestCase {
   private static $filter;
 
   #[@beforeClass]
   public static function defineBase() {
-    self::$filter= XPClass::forName('net.xp_framework.unittest.core.generics.NSFilter');
+    self::$filter= XPClass::forName('net.xp_framework.unittest.core.generics.ArrayFilter');
   }
   
   #[@test]
   public function newType0_returns_literal() {
     $this->assertEquals(
-      'net\xp_framework\unittest\core\generics\NSFilter··þint',
+      "net\\xp_framework\\unittest\\core\\generics\\ArrayFilter\xb7\xb7\xfeint",
       (new GenericTypes())->newType0(self::$filter, [Primitive::$INT])
     );
   }

--- a/src/test/php/net/xp_framework/unittest/core/generics/ImplementationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/ImplementationTest.class.php
@@ -1,10 +1,6 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
-use lang\Type;
-use lang\Primitive;
-use lang\XPClass;
-use lang\ElementNotFoundException;
-use lang\IllegalArgumentException;
+use lang\{ElementNotFoundException, IllegalArgumentException, Primitive, Type, XPClass};
 
 /**
  * TestCase for instance reflection
@@ -132,5 +128,11 @@ class ImplementationTest extends \unittest\TestCase {
   public function type_variable_available($expect, $value) {
     $fixture= create('new net.xp_framework.unittest.core.generics.Unserializer<string>');
     $this->assertEquals($expect, $fixture->newInstance($value));
+  }
+
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function type_aliasing() {
+    $fixture= create('new net.xp_framework.unittest.core.generics.TypeDictionary<string>');
+    $fixture->get(typeof($this));
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/generics/Marker.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/Marker.class.php
@@ -1,0 +1,5 @@
+<?php namespace net\xp_framework\unittest\core\generics;
+
+interface Marker {
+
+}

--- a/src/test/php/net/xp_framework/unittest/core/generics/TypeDictionary.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/generics/TypeDictionary.class.php
@@ -1,6 +1,6 @@
 <?php namespace net\xp_framework\unittest\core\generics;
 
-use util\NoSuchElementException;
+use lang\ElementNotFoundException as NoSuchKey;
 
 /**
  * Lookup map
@@ -33,7 +33,7 @@ class TypeDictionary extends AbstractTypeDictionary {
   public function get($key) {
     $offset= $key->literal();
     if (!isset($this->elements[$offset])) {
-      throw new NoSuchElementException('No such key '.$key->toString());
+      throw new NoSuchKey('No such key '.$key->toString());
     }
     return $this->elements[$offset];
   }


### PR DESCRIPTION
Introduced in PHP 8.0, see https://wiki.php.net/rfc/namespaced_names_as_token

See also #211 