### PR TITLE
Convert PHP 8 type, method and field attributes into XP annotations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ XP Framework Core ChangeLog
 * Implemented first step of xp-framwwork/rfc#336 by converting PHP 8
   attributes into XP annotations: `#[Test(true)]` will beinterpreted the
   same as `#[@test(true)]`. This way, converting libraries over to the
-  new syntax can start now.
+  new syntax can start now. Implementation details in pull request #245.
   (@thekid)
 
 ### Bugfixes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,14 @@ XP Framework Core ChangeLog
 
 ## ?.?.? / ????-??-??
 
+### RFCs
+
+* Implemented first step of xp-framwwork/rfc#336 by converting PHP 8
+  attributes into XP annotations: `#[Test(true)]` will beinterpreted the
+  same as `#[@test(true)]`. This way, converting libraries over to the
+  new syntax can start now.
+  (@thekid)
+
 ### Bugfixes
 
 * Fixed grouped imports when used inside generics in PHP 8.0 - @thekid

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -434,8 +434,8 @@ define('MODIFIER_PRIVATE',   \ReflectionMethod::IS_PRIVATE);
 defined('PHP_INT_MIN') || define('PHP_INT_MIN', ~PHP_INT_MAX);
 
 defined('T_FN') || define('T_FN', -346);
-defined('T_FN') || define('T_FN', -346);
 defined('T_ATTRIBUTE') || define('T_ATTRIBUTE', -383);
+defined('T_NAME_FULLY_QUALIFIED') || define('T_NAME_FULLY_QUALIFIED', -312)
 defined('T_NAME_QUALIFIED') || define('T_NAME_QUALIFIED', -314);
 
 xp::$loader= new xp();

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -435,7 +435,7 @@ defined('PHP_INT_MIN') || define('PHP_INT_MIN', ~PHP_INT_MAX);
 
 defined('T_FN') || define('T_FN', -346);
 defined('T_ATTRIBUTE') || define('T_ATTRIBUTE', -383);
-defined('T_NAME_FULLY_QUALIFIED') || define('T_NAME_FULLY_QUALIFIED', -312)
+defined('T_NAME_FULLY_QUALIFIED') || define('T_NAME_FULLY_QUALIFIED', -312);
 defined('T_NAME_QUALIFIED') || define('T_NAME_QUALIFIED', -314);
 
 xp::$loader= new xp();

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -434,7 +434,8 @@ define('MODIFIER_PRIVATE',   \ReflectionMethod::IS_PRIVATE);
 defined('PHP_INT_MIN') || define('PHP_INT_MIN', ~PHP_INT_MAX);
 
 defined('T_FN') || define('T_FN', -346);
-defined('T_NAME_FULLY_QUALIFIED') || define('T_NAME_FULLY_QUALIFIED', -312);
+defined('T_FN') || define('T_FN', -346);
+defined('T_ATTRIBUTE') || define('T_ATTRIBUTE', -383);
 defined('T_NAME_QUALIFIED') || define('T_NAME_QUALIFIED', -314);
 
 xp::$loader= new xp();

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -363,7 +363,7 @@ class ClassParser {
               $code= $this->valueOf($tokens, $i, $context, $imports);
               $eval= token_get_all('<?php '.$code);
               $j= 1;
-              $value[$key]= $this->valueOf($eval, $j, $context, $imports);
+              $value= $this->valueOf($eval, $j, $context, $imports);
             } else {
               $value= [];
               $state= 3;

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -355,6 +355,10 @@ class ClassParser {
         } else if (2 === $state) {              // Inside braces of @attr(...)
           if (')' === $tokens[$i]) {
             $state= 1;
+          } else if ($i + 2 < $s && (':' === $tokens[$i + 1] || ':' === $tokens[$i + 2])) {
+            $key= $tokens[$i][1];
+            $value= [];
+            $state= 3;
           } else if ($i + 2 < $s && ('=' === $tokens[$i + 1] || '=' === $tokens[$i + 2])) {
             $key= $tokens[$i][1];
             $value= [];
@@ -368,7 +372,7 @@ class ClassParser {
             $state= 1;
           } else if (',' === $tokens[$i]) {
             $key= null;
-          } else if ('=' === $tokens[$i]) {
+          } else if ('=' === $tokens[$i] || ':' === $tokens[$i]) {
             $state= 4;
           } else if (is_array($tokens[$i])) {
             $key= $tokens[$i][1];

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -312,12 +312,17 @@ class ClassParser {
       for ($state= 0, $i= 1, $s= sizeof($tokens); $i < $s; $i++) {
         if (T_WHITESPACE === $tokens[$i][0]) {
           continue;
-        } else if (0 === $state) {             // Initial state, expecting @attr or @$param: attr
+        } else if (0 === $state) {              // Initial state, expecting @attr or @$param: attr
           if ('@' === $tokens[$i]) {
             $annotation= $tokens[$i + 1][1];
             $param= null;
             $value= null;
             $i++;
+            $state= 1;
+          } else if (T_STRING === $tokens[$i][0]) {
+            $annotation= strtolower($tokens[$i][1]);
+            $param= null;
+            $value= null;
             $state= 1;
           } else {
             throw new IllegalStateException('Parse error: Expecting "@"');

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -506,6 +506,19 @@ class ClassParser {
           $comment= $tokens[$i][1];
           break;
 
+        case T_ATTRIBUTE:                       // PHP 8 attributes
+          $b= 1;
+          $parsed= '';
+          while ($i++ < $s) {
+            $parsed.= is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i];
+            if ('[' === $tokens[$i]) {
+              $b++;
+            } else if (']' === $tokens[$i]) {
+              if (0 === --$b) break;
+            }
+          }
+          break;
+
         case T_COMMENT:
           if ('#' === $tokens[$i][1][0]) {      // Annotations, #[@test]
             if ('[' === $tokens[$i][1][1]) {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -302,6 +302,16 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function php8_attributes_with_eval_argument() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[Value(eval: "function() { return \"test\"; }")]
+      class Test {
+      }
+    ');
+    $this->assertEquals('test', $actual['class'][DETAIL_ANNOTATIONS]['value']['eval']());
+  }
+
+  #[@test]
   public function closure_use_not_evaluated() {
     (new ClassParser())->parseDetails('<?php 
       class Test {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -282,6 +282,16 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function php8_attributes_converted_to_xp_annotations() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[Value("test")]
+      class Test {
+      }
+    ');
+    $this->assertEquals(['value' => 'test'], $actual['class'][DETAIL_ANNOTATIONS]);
+  }
+
+  #[@test]
   public function closure_use_not_evaluated() {
     (new ClassParser())->parseDetails('<?php 
       class Test {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -308,7 +308,7 @@ class ClassDetailsTest extends \unittest\TestCase {
       class Test {
       }
     ');
-    $this->assertEquals('test', $actual['class'][DETAIL_ANNOTATIONS]['value']['eval']());
+    $this->assertEquals('test', $actual['class'][DETAIL_ANNOTATIONS]['value']());
   }
 
   #[@test]

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -292,6 +292,16 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function php8_attributes_with_named_arguments() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[Expect(class: \net\xp_framework\unittest\Name::class)]
+      class Test {
+      }
+    ');
+    $this->assertEquals(['expect' => ['class' => Name::class]], $actual['class'][DETAIL_ANNOTATIONS]);
+  }
+
+  #[@test]
   public function closure_use_not_evaluated() {
     (new ClassParser())->parseDetails('<?php 
       class Test {


### PR DESCRIPTION
Implements first step of xp-framework/rfc#336 by converting PHP 8 attributes into XP annotations: `#[Test(true)]` will beinterpreted the same as `#[@test(true)]`. This way, converting codebases over to the new syntax can start now. Another step to adopting PHP 8 - see #211

* * * 

Simple annotations must be rewritten as follows:

```diff
-  #[@test]
+  #[Test]
```

Annotations with named arguments can (*but do not have to*) be rewritten using named arguments:

```diff
-  #[@expect(['class' => IllegalStateException::class])]
+  #[Expect(class: IllegalStateException::class)]
```

Multiline annotations need to be folded:

```diff
-  #[@test, @values([
-  #  [0, []],
-  #  [1, [1]],
-  #  [4, [1, 2, 3, 4]]
-  #])]
+  #[Test, Values([[0, []], [1, [1]], [4, [1, 2, 3, 4]]])]
```

Annotations with unsupported values like `new` and `function` expressions need to be rewritten to use *eval*:

```diff
-  #[@test, @action([new RuntimeVersion('>=7.1.0')])]
+  #[Test, Action(eval: 'new RuntimeVersion(">=7.1.0")')]
```