### PR TITLE
Add Type::resolve()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,13 @@ XP Framework Core ChangeLog
 
 ## ?.?.? / ????-??-??
 
+### Features
+
+* Added new method `lang.Type::resolve()` to correctly resolve types in
+  a given context. Adds support for `array<self>` and others for return
+  and parameter types.
+  (@thekid)
+
 ## 10.3.3 / 2020-11-22
 
 ### Bugfixes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,15 +6,16 @@ XP Framework Core ChangeLog
 ### Features
 
 * Added `lang.reflect.Field::getTypeRestriction()` which is consistent
-  with the API exposed by method parameter and return types
+  with the API exposed by method parameter and return types. This adds
+  support for PHP 7.4 property types.
   (@thekid)
 * Made field, method parameter and return types consistent in that they
   check for native type syntax before checking meta information except
-  for when that may yield a more specific type.
+  for when that may yield a more specific type
   (@thekid)
 * Added new method `lang.Type::resolve()` to correctly resolve types in
   a given context. Adds support for `array<self>` and others for return
-  and parameter types.
+  and parameter types
   (@thekid)
 
 ## 10.3.3 / 2020-11-22

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,13 @@ XP Framework Core ChangeLog
 
 ### Features
 
+* Added `lang.reflect.Field::getTypeRestriction()` which is consistent
+  with the API exposed by method parameter and return types
+  (@thekid)
+* Made field, method parameter and return types consistent in that they
+  check for native type syntax before checking meta information except
+  for when that may yield a more specific type.
+  (@thekid)
 * Added new method `lang.Type::resolve()` to correctly resolve types in
   a given context. Adds support for `array<self>` and others for return
   and parameter types.

--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -36,50 +36,83 @@ class Field implements Value {
 
   /** Get field's name */
   public function getName(): string { return $this->_reflect->getName(); }
-  
+
+  /**
+   * Resolution resolve handling `self` and `parent` (`static` is only for return
+   * types, see https://wiki.php.net/rfc/static_return_type#allowed_positions).
+   *
+   * @return [:(function(string): lang.Type)]
+   */
+  private function resolve() {
+    return [
+      'self'   => function() { return new XPClass($this->_reflect->getDeclaringClass()); },
+      'parent' => function() { return new XPClass($this->_reflect->getDeclaringClass()->getParentClass()); },
+    ];
+  }
+
   /** Gets field type */
   public function getType(): Type {
-    $details= XPClass::detailsForField($this->_reflect->getDeclaringClass(), $this->_reflect->getName());
+    $t= PHP_VERSION_ID >= 70400 ? $this->_reflect->getType() : null;
+    if (null === $t) {
 
-    if (isset($details[DETAIL_RETURNS])) {
-      $type= $details[DETAIL_RETURNS];
-    } else if (isset($details[DETAIL_ANNOTATIONS]['type'])) {
-      $type= $details[DETAIL_ANNOTATIONS]['type'];
-    } else if (PHP_VERSION_ID >= 70400 && ($t= $this->_reflect->getType())) {
-      if ($t instanceof \ReflectionUnionType) {
-        $union= [];
-        foreach ($t->getTypes() as $u) {
-          $union[]= Type::forName($u->getName());
-        }
-        return new TypeUnion($union);
+      // Check for type in api documentation, defaulting to `var`
+      $t= Type::$VAR;
+    } else if ($t instanceof \ReflectionUnionType) {
+      $union= [];
+      foreach ($t->getTypes() as $component) {
+        $union[]= Type::resolve($component->getName(), $this->resolve());
       }
-      return Type::forName($t->getName());
+      return new TypeUnion($union);
     } else {
-      return Type::$VAR;
+      $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
+
+      // Check array for more specific types, e.g. `string[]` in api documentation
+      if ('array' === $name) {
+        $t= Type::$ARRAY;
+      } else {
+        return Type::resolve($name, $this->resolve());
+      }
     }
 
-    return 'self' === $type ? new XPClass($this->_reflect->getDeclaringClass()) : Type::forName($type);
+    $details= XPClass::detailsForField($this->_reflect->getDeclaringClass(), $this->_reflect->getName());
+    $f= $details[DETAIL_RETURNS] ?? $details[DETAIL_ANNOTATIONS]['type'] ?? null;
+    return null === $f ? $t : Type::resolve(rtrim(ltrim($f, '&'), '.'), $this->resolve());
   }
 
   /** Gets field type's name */
   public function getTypeName(): string {
-    if ($details= XPClass::detailsForField($this->_reflect->getDeclaringClass(), $this->_reflect->getName())) {
-      if (isset($details[DETAIL_RETURNS])) {
-        return $details[DETAIL_RETURNS];
-      } else if (isset($details[DETAIL_ANNOTATIONS]['type'])) {
-        return $details[DETAIL_ANNOTATIONS]['type'];
-      } else if (PHP_VERSION_ID >= 70400 && ($t= $this->_reflect->getType())) {
-        if ($t instanceof \ReflectionUnionType) {
-          $union= '';
-          foreach ($t->getTypes() as $u) {
-            $union.= '|'.$u->getName();
-          }
-          return substr($union, 1);
-        }
-        return $t->getName();
+    static $map= [
+      'mixed'   => 'var',
+      'false'   => 'bool',
+      'boolean' => 'bool',
+      'double'  => 'float',
+      'integer' => 'int',
+    ];
+
+    $t= PHP_VERSION_ID >= 70400 ? $this->_reflect->getType() : null;
+    if (null === $t) {
+
+      // Check for type in api documentation
+      $name= 'var';
+    } else if ($t instanceof \ReflectionUnionType) {
+      $union= '';
+      foreach ($t->getTypes() as $component) {
+        $name= $component->getName();
+        $union.= '|'.($map[$name] ?? strtr($name, '\\', '.'));
+      }
+      return substr($union, 1);
+    } else {
+      $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
+
+      // Check array for more specific types, e.g. `string[]` in api documentation
+      if ('array' !== $name) {
+        return $map[$name] ?? strtr($name, '\\', '.');
       }
     }
-    return 'var';
+
+    $details= XPClass::detailsForField($this->_reflect->getDeclaringClass(), $this->_reflect->getName());
+    $f= $details[DETAIL_RETURNS] ?? $details[DETAIL_ANNOTATIONS]['type'] ?? null;
+    return null === $f ? $name : rtrim(ltrim($f, '&'), '.');
   }
 
   /**

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -102,6 +102,7 @@ class Parameter {
 
     $t= $this->_reflect->getType();
     if (null === $t) {
+
       // Check for type in api documentation
       $name= 'var';
     } else if ($t instanceof \ReflectionUnionType) {

--- a/src/test/php/net/xp_framework/unittest/reflection/FieldTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/FieldTypeTest.class.php
@@ -80,4 +80,14 @@ class FieldTypeTest extends FieldsTest {
     $this->assertEquals('string[]', $fixture->getField('fixture')->getTypeName());
     $this->assertEquals(new ArrayType(Primitive::$STRING), $fixture->getField('fixture')->getType());
   }
+
+  #[Test]
+  public function untyped_restriction() {
+    $this->assertNull($this->field('public $fixture;')->getTypeRestriction());
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  public function typed_restriction() {
+    $this->assertEquals(Primitive::$STRING, $this->field('public string $fixture;')->getTypeRestriction());
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/FieldTypeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/FieldTypeTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use lang\{ArrayType, MapType, Primitive, Type, Value, XPClass};
-use unittest\{Test, Values};
+use unittest\actions\RuntimeVersion;
+use unittest\{Action, Test, Values};
 
 class FieldTypeTest extends FieldsTest {
 
@@ -54,8 +55,29 @@ class FieldTypeTest extends FieldsTest {
   }
 
   #[Test]
-  public function self_type() {
+  public function self_type_via_apidoc() {
     $fixture= $this->type('{ /** @type self */ public $fixture; }');
+    $this->assertEquals('self', $fixture->getField('fixture')->getTypeName());
     $this->assertEquals($fixture, $fixture->getField('fixture')->getType());
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  public function self_type_via_syntax() {
+    $fixture= $this->type('{ public self $fixture; }');
+    $this->assertEquals('self', $fixture->getField('fixture')->getTypeName());
+    $this->assertEquals($fixture, $fixture->getField('fixture')->getType());
+  }
+
+  #[Test]
+  public function array_of_self_type() {
+    $fixture= $this->type('{ /** @type array<self> */ public $fixture; }');
+    $this->assertEquals(new ArrayType($fixture), $fixture->getField('fixture')->getType());
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  public function specific_array_type_determined_via_apidoc() {
+    $fixture= $this->type('{ /** @type string[] */ public array $fixture; }');
+    $this->assertEquals('string[]', $fixture->getField('fixture')->getTypeName());
+    $this->assertEquals(new ArrayType(Primitive::$STRING), $fixture->getField('fixture')->getType());
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -126,6 +126,12 @@ class MethodParametersTest extends MethodsTest {
   }
 
   #[Test]
+  public function array_of_self_parameter_type_via_apidoc() {
+    $fixture= $this->type('{ /** @param array<self> */ public function fixture($list) { } }');
+    $this->assertEquals(new ArrayType($fixture), $fixture->getMethod('fixture')->getParameter(0)->getType());
+  }
+
+  #[Test]
   public function parent_parameter_type() {
     $fixture= $this->type('{ public function fixture(parent $param) { } }', [
       'extends' => [Name::class]

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\{
   ArrayType,
-  ClassFormatException,
+  ClassNotFoundException,
   ElementNotFoundException,
   FunctionType,
   IllegalStateException,
@@ -74,6 +74,14 @@ class MethodParametersTest extends MethodsTest {
     $this->assertParamType(
       $type,
       $this->method('/** @param '.$declaration.' */ public function fixture(array $param) { }')->getParameter(0)
+    );
+  }
+
+  #[Test]
+  public function specific_callable_type_determined_via_apidoc_if_present() {
+    $this->assertParamType(
+      new FunctionType([], Primitive::$STRING),
+      $this->method('/** @param (function(): string) */ public function fixture(callable $param) { }')->getParameter(0)
     );
   }
 
@@ -163,7 +171,7 @@ class MethodParametersTest extends MethodsTest {
     $this->assertEquals('parent', $fixture->getMethod('fixture')->getParameter(0)->getTypeName());
   }
 
-  #[Test, Expect(ClassFormatException::class)]
+  #[Test, Expect(ClassNotFoundException::class)]
   public function nonexistant_type_class_parameter() {
     $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getType();
   }
@@ -205,7 +213,7 @@ class MethodParametersTest extends MethodsTest {
     );
   }
 
-  #[Test, Expect(ClassFormatException::class)]
+  #[Test, Expect(ClassNotFoundException::class)]
   public function nonexistant_restriction_class_parameter() {
     $this->method('public function fixture(UnknownTypeRestriction $param) { }')->getParameter(0)->getTypeRestriction();
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodReturnTypesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodReturnTypesTest.class.php
@@ -155,7 +155,7 @@ class MethodReturnTypesTest extends MethodsTest {
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
-  public function special_statuc_return_type_via_syntax() {
+  public function special_static_return_type_via_syntax() {
     $fixture= $this->type('{ public function fixture(): static { } }');
     $this->assertEquals($fixture, $fixture->getMethod('fixture')->getReturnType());
   }
@@ -183,5 +183,11 @@ class MethodReturnTypesTest extends MethodsTest {
 
     $this->assertEquals($base, $method->getReturnType(), 'type');
     $this->assertEquals('self', $method->getReturnTypeName(), 'name');
+  }
+
+  #[Test]
+  public function array_of_special_self_type() {
+    $fixture= $this->type('{ /** @return array<self> */ public function fixture() { } }');
+    $this->assertEquals(new ArrayType($fixture), $fixture->getMethod('fixture')->getReturnType());
   }
 }


### PR DESCRIPTION
This enables us to correctly resolve types such as `array<self>` for fields, method parameter and return types.

## Performance

Before:

```bash
$ xp test src/test/config/unittest/reflect.ini
# ...
♥: 1035/1056 run (21 skipped), 1035 succeeded, 0 failed
Memory used: 7330.53 kB (7388.80 kB peak)
Time taken: 0.156 seconds
```

After:

```bash
$ xp test src/test/config/unittest/reflect.ini
# ...
♥: 1043/1064 run (21 skipped), 1043 succeeded, 0 failed
Memory used: 7411.90 kB (7470.16 kB peak)
Time taken: 0.143 seconds
```