### PR TITLE
Support reflective access to non-constant expressions for parameter defaults

### DIFF
--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -171,8 +171,8 @@ class Parameter {
 
       $value= $this->_reflect->getDefaultValue();
       if (null === $value) {
-        $details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1]);
-        return $details[DETAIL_TARGET_ANNO]['$'.$this->_reflect->getName()]['default'] ?? null;
+        $class= strtr($this->_reflect->getDeclaringClass()->getName(), '\\', '.');
+        return \xp::$meta[$class][1][$this->_details[1]][DETAIL_TARGET_ANNO]['$'.$this->_reflect->getName()]['default'] ?? null;
       }
       return $value;
     }

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflect;
 
-use lang\{ElementNotFoundException, ClassLoadingException, ClassNotFoundException, XPClass, Type, TypeUnion};
+use lang\{ElementNotFoundException, IllegalStateException, ClassLoadingException, ClassNotFoundException, XPClass, Type, TypeUnion};
 use util\Objects;
 
 /**
@@ -160,17 +160,24 @@ class Parameter {
   }
 
   /**
-   * Get default value.
+   * Get default value. Additionally checks `default` annotation for NULL defaults.
    *
    * @throws  lang.IllegalStateException in case this argument is not optional
    * @return  var
    */
   public function getDefaultValue() {
     if ($this->_reflect->isOptional()) {
-      return $this->_reflect->isDefaultValueAvailable() ? $this->_reflect->getDefaultValue() : null;
+      if (!$this->_reflect->isDefaultValueAvailable()) return null;
+
+      $value= $this->_reflect->getDefaultValue();
+      if (null === $value) {
+        $details= XPClass::detailsForMethod($this->_reflect->getDeclaringClass(), $this->_details[1]);
+        return $details[DETAIL_TARGET_ANNO]['$'.$this->_reflect->getName()]['default'] ?? null;
+      }
+      return $value;
     }
 
-    throw new \lang\IllegalStateException('Parameter "'.$this->_reflect->getName().'" has no default value');
+    throw new IllegalStateException('Parameter "'.$this->_reflect->getName().'" has no default value');
   }
 
   /**

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -320,7 +320,7 @@ class MethodParametersTest extends MethodsTest {
     $this->assertEquals([], $this->method('public function fixture($param) { }')->getParameter(0)->getAnnotations());
   }
 
-  #[Test, Expect(['class' => ElementNotFoundException::class, 'withMessage' => 'Annotation "test" does not exist'])]
+  #[Test, Expect(class: ElementNotFoundException::class, withMessage: 'Annotation "test" does not exist')]
   public function cannot_get_test_annotation_for_un_annotated_parameter() {
     $this->method('public function fixture($param) { }')->getParameter(0)->getAnnotation('test');
   }
@@ -335,7 +335,7 @@ class MethodParametersTest extends MethodsTest {
     $this->assertTrue($this->method('public function fixture($param= true) { }')->getParameter(0)->isOptional());
   }
 
-  #[Test, Expect(['class' => IllegalStateException::class, 'withMessage' => 'Parameter "param" has no default value'])]
+  #[Test, Expect(class: IllegalStateException::class, withMessage: 'Parameter "param" has no default value')]
   public function required_parameter_does_not_have_default_value() {
     $this->method('public function fixture($param) { }')->getParameter(0)->getDefaultValue();
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodParametersTest.class.php
@@ -346,6 +346,19 @@ class MethodParametersTest extends MethodsTest {
   }
 
   #[Test]
+  public function default_annotation_may_supply_default_value() {
+    $method= $this->method('public function fixture($param= null) { }');
+
+    // Directly modify meta information for this test's purpose
+    // See https://github.com/xp-framework/compiler/pull/104#issuecomment-791924395
+    \xp::$meta[$method->getDeclaringClass()->getName()][1][$method->getName()]= [
+      DETAIL_TARGET_ANNO => ['$param' => ['default' => $this]]
+    ];
+
+    $this->assertEquals($this, $method->getParameter(0)->getDefaultValue());
+  }
+
+  #[Test]
   public function vararg_parameters_default_value() {
     $this->assertEquals(null, $this->method('public function fixture(... $param) { }')->getParameter(0)->getDefaultValue());
   }


### PR DESCRIPTION
See https://github.com/xp-framework/compiler/pull/104#issuecomment-791924395, empowers the following when using the XP Compiler:

```php
  #[Test]
  public function parameter_default_reflective_access() {
    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
      public function run($h= new Handle(0)) {
        return typeof($this)->getMethod("run")->getParameter(0)->getDefaultValue();
      }
    }');
    Assert::equals(new Handle(0), $r);
  }
```