### PR TITLE
Replace $_ENV with $_SERVER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: com_dotnet
-        ini-values: date.timezone=Europe/Berlin, variables_order=EGPCS
+        ini-values: date.timezone=Europe/Berlin
 
     - name: Setup Problem Matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/src/main/php/lang/Environment.class.php
+++ b/src/main/php/lang/Environment.class.php
@@ -14,7 +14,7 @@ abstract class Environment {
    * @return bool
    */
   private static function xdgCompliant() {
-    foreach ($_ENV as $name => $value) {
+    foreach ($_SERVER as $name => $value) {
       if (0 === strncmp($name, 'XDG_', 4)) return true;
     }
     return false;
@@ -29,15 +29,15 @@ abstract class Environment {
    * @return  [:string]
    */
   public static function variables($filter= null) {
-    if (null === $filter) return $_ENV;
+    if (null === $filter) return $_SERVER;
 
     $r= [];
     if (is_array($filter)) {
       foreach ($filter as $name) {
-        isset($_ENV[$name]) && $r[$name]= $_ENV[$name];
+        isset($_SERVER[$name]) && $r[$name]= $_SERVER[$name];
       }
     } else {
-      foreach ($_ENV as $name => $value) {
+      foreach ($_SERVER as $name => $value) {
         preg_match($filter, $name) && $r[$name]= $value;
       }
     }
@@ -82,10 +82,10 @@ abstract class Environment {
     foreach ($variables as $name => $value) {
       if (null === $value) {
         putenv($name);
-        unset($_ENV[$name]);
+        unset($_SERVER[$name]);
       } else {
         putenv($name.'='.$value);
-        $_ENV[$name]= $value;
+        $_SERVER[$name]= $value;
       }
     }
   }

--- a/src/test/php/net/xp_framework/unittest/core/EnvironmentSet.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnvironmentSet.class.php
@@ -21,10 +21,10 @@ class EnvironmentSet implements \lang\Closeable {
       $this->original[$name]= getenv($name);
       if (null === $value) {
         putenv($name);
-        unset($_ENV[$name]);
+        unset($_SERVER[$name]);
       } else {
         putenv($name.'='.$value);
-        $_ENV[$name]= $value;
+        $_SERVER[$name]= $value;
       }
     }
   }
@@ -34,10 +34,10 @@ class EnvironmentSet implements \lang\Closeable {
     foreach ($this->original as $name => $value) {
       if (false === $value) {
         putenv($name);
-        unset($_ENV[$name]);
+        unset($_SERVER[$name]);
       } else {
         putenv($name.'='.$value);
-        $_ENV[$name]= $value;
+        $_SERVER[$name]= $value;
       }
     }
   }

--- a/src/test/php/net/xp_framework/unittest/core/EnvironmentTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnvironmentTest.class.php
@@ -9,7 +9,7 @@ class EnvironmentTest extends \unittest\TestCase {
   #[BeforeClass]
   public static function clearXDG() {
     $remove= [];
-    foreach ($_ENV as $variable => $value) {
+    foreach ($_SERVER as $variable => $value) {
       if (0 === strncmp('XDG_', $variable, 4)) $remove[$variable]= null;
     }
     self::$set= new EnvironmentSet($remove);


### PR DESCRIPTION
The $_ENV global is only populated if the php.ini setting variables_order contains an "E", while $_SERVER always contains the environment variables. php.ini from the PHP GIT repo contains this:

```ini
; variables_order
;   Default Value: "EGPCS"
;   Development Value: "GPCS"
;   Production Value: "GPCS"
```

On Ubuntu, it's explicitely set as follows: `/etc/php/7.4/cli/php.ini:variables_order = "GPCS"`

See issue #265