### PR TITLE
Support PHP 8.1 `never` type in reflection

### DIFF
--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -160,9 +160,9 @@ class Routine implements Value {
       $nullable= $t->allowsNull() ? '?' : '';
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
 
-      // Check array, self and callable for more specific types, e.g. `string[]`,
-      // `static` or `function(): string` in api documentation
-      if ('array' !== $name && 'callable' !== $name && 'self' !== $name) {
+      // Check array, self, void and callable for more specific types, e.g. `string[]`,
+      // `static`, `never` or `function(): string` in api documentation
+      if ('array' !== $name && 'callable' !== $name && 'self' !== $name && 'void' !== $name) {
         return $nullable.($map[$name] ?? strtr($name, '\\', '.'));
       }
     }

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodReturnTypesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodReturnTypesTest.class.php
@@ -90,6 +90,12 @@ class MethodReturnTypesTest extends MethodsTest {
     $this->assertReturnType(Type::$VOID, $fixture->getMethod('fixture'));
   }
 
+  #[Test, Ignore('php/php-src#6761 not yet merged'), Action(eval: 'new RuntimeVersion(">=8.1")')]
+  public function never_return_type() {
+    $fixture= $this->type('{ public function fixture(): never { exit(); } }');
+    $this->assertReturnType(Type::$NEVER, $fixture->getMethod('fixture'));
+  }
+
   #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
   public function nullable_return_type() {
     $fixture= $this->type('{ public function fixture(): ?string { } }');
@@ -179,6 +185,14 @@ class MethodReturnTypesTest extends MethodsTest {
 
     $this->assertEquals($fixture, $method->getReturnType(), 'type');
     $this->assertEquals('static', $method->getReturnTypeName(), 'name');
+  }
+
+  #[Test]
+  public function apidoc_supersedes_void_type_restriction() {
+    $method= $this->type('{ /** @return never */ public function fixture(): void { exit(); } }')->getMethod('fixture');
+
+    $this->assertEquals(Type::$NEVER, $method->getReturnType(), 'type');
+    $this->assertEquals('never', $method->getReturnTypeName(), 'name');
   }
 
   #[Test]

--- a/src/test/php/net/xp_framework/unittest/reflection/MethodReturnTypesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/MethodReturnTypesTest.class.php
@@ -187,7 +187,7 @@ class MethodReturnTypesTest extends MethodsTest {
     $this->assertEquals('static', $method->getReturnTypeName(), 'name');
   }
 
-  #[Test]
+  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
   public function apidoc_supersedes_void_type_restriction() {
     $method= $this->type('{ /** @return never */ public function fixture(): void { exit(); } }')->getMethod('fixture');
 


### PR DESCRIPTION
Forward compatible but also supports apidoc / syntax combination:

```php
/** @return never */
public function halt(): void { exit(); }
```

The reflection API lets apidoc take precedence over the `void` return type declared syntactically, as is done for e.g. callable and arrays

See https://wiki.php.net/rfc/noreturn_type. Implements runtime support for xp-framework/compiler#109