### PR TITLE
Pass NULL to Properties::expanding() to ignore expansion

### DIFF
--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -40,17 +40,20 @@ class Properties implements PropertyAccess {
   }
 
   /**
-   * Add expansion `${kind.X}` with a given expansion function `f(X)`
+   * Add expansion `${kind.X}` with a given expansion function `f(X)`. Pass NULL
+   * as expansion to ignore any expansions of this type.
    *
    * @param  string $kind
-   * @param  [:var]|function(string): string $expansion
+   * @param  ?[:var]|function(string): string $expansion
    * @return self
    */
   public function expanding($kind, $expansion) {
     $this->expansion= $this->expansion ?: clone self::$env;
 
-    if ($expansion instanceof \ArrayAccess || (is_array($expansion) && 0 !== key($expansion))) {
-      $func= function($name) use($expansion) { return isset($expansion[$name]) ? $expansion[$name] : null; };
+    if (null === $expansion) {
+      $func= function($name) { return ''; };
+    } else if ($expansion instanceof \ArrayAccess || (is_array($expansion) && 0 !== key($expansion))) {
+      $func= function($name) use($expansion) { return $expansion[$name] ?? null; };
     } else {
       $func= cast($expansion, 'function(string): string');
     }

--- a/src/test/php/net/xp_framework/unittest/util/PropertyExpansionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/PropertyExpansionTest.class.php
@@ -49,6 +49,12 @@ class PropertyExpansionTest extends TestCase {
     $this->assertEquals('test', $prop->readString('section', 'test'));
   }
 
+  #[Test]
+  public function null_lookup_ignores_missing_expansion() {
+    $prop= $this->newFixture(null);
+    $this->assertEquals('', $prop->readString('section', 'test'));
+  }
+
   #[Test, Expect(ElementNotFoundException::class), Values([null, false])]
   public function non_existant_lookup($return) {
     $this->newFixture(function($name) use($return) { return $return; })->readString('section', 'test');


### PR DESCRIPTION
When working with injection files used in web applications outside of these applications, a property expansion named *app* needs to be registered for them to parse, even when values are not accessed!

An example is the following *inject.ini*:

```ini
string[sessions]=${app.tempdir}
```

To read these files, the following code is necessary:

```php
$config= (new Properties('inject.ini'))->expanding('app', fn($n) => '*'));
```

This pull request adds the ability to ignore any expansions as follows:

```php
$config= (new Properties('inject.ini'))->expanding('app', null);
```