### PR TITLE
Add Environment::platform() and Environment::path()

### DIFF
--- a/src/main/php/lang/AbstractClassLoader.class.php
+++ b/src/main/php/lang/AbstractClassLoader.class.php
@@ -145,43 +145,14 @@ abstract class AbstractClassLoader implements IClassLoader {
   }
 
   /**
-   * Compacts paths by replacing base directories by placeholders
-   *
-   * @param  string $path
-   * @param  [:string] $bases
-   * @return string
-   */
-  private function compactPath($path, $bases) {
-    foreach ($bases as $base => $replace) {
-      $base= realpath($base);
-      if (false !== $base && 0 === strpos($path, $base)) {
-        $path= $replace.substr($path, strlen($base));
-      }
-    }
-    return $path;
-  }
-
-  /**
    * Creates a string representation
    *
    * @return  string
    */
   public function toString() {
-    if ($home= getenv('HOME')) {    // Un*x or Cygwin
-      $separator= '/';
-      $bases= [getcwd() => '.', $home => '~', getenv('APPDATA') => '$APPDATA'];
-    } else if (0 === strncasecmp(PHP_OS, 'Win', 3)) {
-      $separator= '\\';
-      $bases= [getcwd() => '.', getenv('APPDATA') => '%APPDATA%'];
-    } else {
-      $separator= DIRECTORY_SEPARATOR;
-      $bases= [getcwd() => '.'];
-    }
-
-    $path= $this->compactPath(rtrim($this->path, DIRECTORY_SEPARATOR), $bases);
     return
       str_replace('ClassLoader', 'CL', typeof($this)->getSimpleName()).
-      '<'.strtr($path, DIRECTORY_SEPARATOR, $separator).'>'
+      '<'.Environment::path($this->path).'>'
     ;
   }
 }

--- a/src/main/php/lang/Environment.class.php
+++ b/src/main/php/lang/Environment.class.php
@@ -120,7 +120,7 @@ abstract class Environment {
    * Platform accepts one of the values returned from `platform()` or NULL
    * to use the platform we're currently operating on.
    */
-  public static function path(string $dir= '.', $platform= null): string {
+  public static function path(string $dir= '.', string $platform= null): string {
     if ('.' === $dir || '..' === $dir) return $dir; // Short-circuit well-known names
 
     // Based on platform, define shorthands for replacements
@@ -186,7 +186,7 @@ abstract class Environment {
    *
    * Pass NULL to retrieve configuration base directory
    */
-  public static function configDir(string $named= null, $home= null): string {
+  public static function configDir(string $named= null, string $home= null): string {
     $home ?? $home= getenv('HOME');
 
     if (!$home) {

--- a/src/main/php/lang/Environment.class.php
+++ b/src/main/php/lang/Environment.class.php
@@ -117,11 +117,10 @@ abstract class Environment {
    * and parent directories with `.` and `..`, the user's home directory with
    * `~` and use `%USERPROFILE%` and `%APPDATA%` on Windows.
    *
-   * @param  string $dir
-   * @param  ?string $platform Use NULL to detect
-   * @return string
+   * Platform accepts one of the values returned from `platform()` or NULL
+   * to use the platform we're currently operating on.
    */
-  public static function path($dir= '.', $platform= null): string {
+  public static function path(string $dir= '.', $platform= null): string {
     if ('.' === $dir || '..' === $dir) return $dir; // Short-circuit well-known names
 
     // Based on platform, define shorthands for replacements

--- a/src/test/php/net/xp_framework/unittest/core/EnvironmentTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/EnvironmentTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use lang\{Environment, IllegalArgumentException, IllegalStateException};
-use unittest\{AfterClass, BeforeClass, Expect, Test, Values};
+use unittest\{AfterClass, BeforeClass, Expect, Test, TestCase, Values};
 
-class EnvironmentTest extends \unittest\TestCase {
+class EnvironmentTest extends TestCase {
   private static $set;
 
   #[BeforeClass]


### PR DESCRIPTION
The `platform()` method detects the current platform and is comparable with the PHP constant [PHP_OS_FAMILY](https://github.com/php/php-src/blob/7db146eea70e4c96ab57ca005f7e499884c14ecb/main/php.h#L39) - however, it recognizes Cygwin and also works for PHP 7.0 and PHP 7.1, where this constant is not yet defined.

```bash
$ xp -w '\lang\Environment::platform()'
Cygwin
```

Values returned can be one of:

* Windows
* Linux
* Darwin
* BSD
* Solaris
* Cygwin
* Unknown

* * * 

The `path()` method formats a path to a short format usable in the given platform, e.g. using ".", ".." and "~" to reference the current, parent and home directories, as well as $USERPOFILE and $APPDATA on Windows

```bash
# Current directory is always "."
$ xp -w '\lang\Environment::path()'
.

# Works for Cygwin and any Un*x system
$ xp -w '\lang\Environment::path(getenv("HOME"))'
~

# Uses forward slashes on Cygwin, backslash on "pure" Windows
$ xp -w '\lang\Environment::path("C:\\Windows")'
C:/Windows
```