### PR TITLE
Fall back to wmic command line tool if com_dotnet extension is not loaded

### DIFF
--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -194,16 +194,16 @@ class Process {
             return false;
           };
         } else {
-          exec('wmic process where handle='.$pid.' get ExecutablePath,CommandLine /format:list 2>NUL', $out, $r);
-          if (0 !== $r) {
-            throw new IllegalStateException(implode(' ', $out));
-          }
-
+          exec('wmic process where handle='.$pid.' get ExecutablePath,CommandLine /format:list 2>&1', $out, $r);
           $p= [];
           foreach ($out as $line) {
             if (2 === sscanf($line, "%[^=]=%[^\r]", $key, $value)) {
               $p[$key]= $value;
             }
+          }
+
+          if (0 !== $r || !isset($p['ExecutablePath'])) {
+            throw new IllegalStateException(implode(' ', $out));
           }
 
           if (null === $exe) $self->status['exe']= $p['ExecutablePath'];


### PR DESCRIPTION
The `wmic` tool lets us run Windows Management queries without `com_dotnet` enabled, fixing ugly *Cannot find executable: Class "Com" not found* errors when using `lang.Process::getProcessById()`.

## Dependencies
We've now reduced the dependencies for running XP core even further:

```bash
$ grep -Hrn 'new \\Com' src/main/php/
src/main/php/lang/Process.class.php:183:        $c= new \Com('winmgmts://./root/cimv2');
```

## Performance
The fallback is slightly slower.

With `com_dotnet` extension loaded:
```bash
$ xp test src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
# ...
Time taken: 0.897 seconds
```

Without:
```bash
$ xp test src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
# ...
Time taken: 1.384 seconds
```