### PR TITLE
Compact maps with a single key/value pair into one line

### DIFF
--- a/src/main/php/util/Objects.class.php
+++ b/src/main/php/util/Objects.class.php
@@ -34,8 +34,7 @@ abstract class Objects {
       return $a->compareTo($b);
     } else if (is_array($a)) {
       if (!is_array($b)) return 1;
-      if (sizeof($a) < sizeof($b)) return -1;
-      if (sizeof($a) > sizeof($b)) return 1;
+      if (0 !== $r= sizeof($a) <=> sizeof($b)) return $r;
       foreach ($a as $key => $val) {
         if (!array_key_exists($key, $b)) return 1;
         if (0 !== $r= self::compare($val, $b[$key])) return $r;
@@ -81,13 +80,16 @@ abstract class Objects {
       $hash= print_r($val, true);
       if (isset($protect[$hash])) return '->{:recursion:}';
       $protect[$hash]= true;
-      if (0 === key($val)) {
+      if (0 === $key= key($val)) {
         $r= '';
         foreach ($val as $val) {
           $r.= ', '.self::stringOf($val, $indent);
         }
         unset($protect[$hash]);
         return '['.substr($r, 2).']';
+      } else if (1 === sizeof($val)) {
+        unset($protect[$hash]);
+        return '['.$key.' => '.self::stringOf($val[$key], $indent.'  ').']';
       } else {
         $r= "[\n";
         foreach ($val as $key => $val) {

--- a/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/ObjectsTest.class.php
@@ -242,11 +242,22 @@ class ObjectsTest extends TestCase {
     $this->assertEquals($expected, Objects::compare($a, $b));
   }
 
-  #[Test, Values([[null, 'null'], [true, 'true'], [false, 'false'], [-1, '-1'], [0, '0'], [1, '1'], [-1.0, '-1'], [0.0, '0'], [1.0, '1'], [6.1, '6.1'], ['', '""'], ['Test', '"Test"'], ['"Hello World"', '""Hello World""'], [[], '[]'], [[1, 2, 3], '[1, 2, 3]'], [['key' => 'value'], "[\n  key => \"value\"\n]"]])]
+  #[Test, Values([[null, 'null'], [true, 'true'], [false, 'false'], [-1, '-1'], [0, '0'], [1, '1'], [-1.0, '-1'], [0.0, '0'], [1.0, '1'], [6.1, '6.1'], ['', '""'], ['Test', '"Test"'], ['"Hello World"', '""Hello World""'], [[], '[]'], [[1, 2, 3], '[1, 2, 3]']])]
   public function stringOf($val, $expected) {
     $this->assertEquals($expected, Objects::stringOf($val));
   }
 
+  #[Test]
+  public function stringOf_single_pair_map() {
+    $this->assertEquals("[key => \"value\"]", Objects::stringOf(['key' => 'value']));
+  }
+
+  #[Test]
+  public function stringOf_map() {
+    $this->assertEquals("[\n  a => 1\n  b => 2\n]", Objects::stringOf(['a' => 1, 'b' => 2]));
+  }
+
+  #[Test]
   public function stringOf_function() {
     $this->assertEquals('<function()>',  Objects::stringOf(function() { }));
   }


### PR DESCRIPTION
Before:

```sh
$ xp -w 'use util\Objects; Objects::stringOf(["key" => "value"])'
[
  key => "value"
]
```

After:

```sh
$ xp -w 'use util\Objects; Objects::stringOf(["key" => "value"])'
[key => "value"]
```