### PR TITLE
Add support for PHP 8.1 intersection types

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -203,6 +203,8 @@ function is($type, $object) {
     return \lang\FunctionType::forName(substr($type, 1, -1))->isInstance($object);
   } else if (strstr($type, '|')) {
     return \lang\TypeUnion::forName($type)->isInstance($object);
+  } else if (strstr($type, '&')) {
+    return \lang\TypeIntersection::forName($type)->isInstance($object);
   } else if (strstr($type, '?')) {
     return \lang\WildcardType::forName($type)->isInstance($object);
   } else {

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -237,6 +237,12 @@ class Type implements Value {
         }
       }
       $t= new TypeUnion($union);
+    } else if ($type instanceof \ReflectionIntersectionType) {
+      $intersection= [];
+      foreach ($type->getTypes() as $c) {
+        $intersection[]= self::named($c->getName(), $context);
+      }
+      $t= new TypeIntersection($intersection);
     } else if ($type instanceof \ReflectionType) {
       $name= PHP_VERSION_ID >= 70100 ? $type->getName() : $type->__toString();
 

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -270,7 +270,7 @@ class Type implements Value {
     //   card type.
     // * Anything else is a qualified or unqualified class name
     $l= strlen($name);
-    $p= strcspn($name, '<|[*(');
+    $p= strcspn($name, '<&|[*(');
     if ($p === $l) {
       return isset($context[$name]) ? $context[$name]() : ((isset($context['*']) && strcspn($name, '.\\') === $l)
         ? $context['*']($name)
@@ -333,6 +333,12 @@ class Type implements Value {
           $components[]= self::named($arg, $context);
         }
         return new TypeUnion($components);
+      } else if ('&' === $name[0]) {
+        $components= [$t];
+        foreach (self::split(substr($name, 1), '&') as $arg) {
+          $components[]= self::named($arg, $context);
+        }
+        return new TypeIntersection($components);
       } else if (0 === substr_compare($name, '[]', 0, 2)) {
         $t= new ArrayType($t);
         $name= trim(substr($name, 2));

--- a/src/main/php/lang/TypeIntersection.class.php
+++ b/src/main/php/lang/TypeIntersection.class.php
@@ -1,0 +1,150 @@
+<?php namespace lang;
+
+/**
+ * Represents a Intersection of types
+ *
+ * @see   xp://lang.Type
+ * @test  xp://net.xp_framework.unittest.core.TypeIntersectionTest
+ */
+class TypeIntersection extends Type {
+  private $types;
+
+  static function __static() { }
+
+  /**
+   * Creates a new type untersection instance
+   *
+   * @param  lang.Type[] $types
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct(array $types) {
+    if (sizeof($types) < 2) {
+      throw new IllegalArgumentException('A type intersection consists of at least 2 types');
+    }
+    $this->types= $types;
+    parent::__construct(implode('&', array_map(function($type) { return $type->getName(); }, $types)), null);
+  }
+
+  /** @return lang.Type[] */
+  public function types() { return $this->types; }
+
+  /** Returns type literal */
+  public function literal(): string {
+    return "\xb5".implode("\xb9", array_map(function($type) { return $type->literal(); }, $this->types));
+  }
+
+  /** Determines whether the specified object is an instance of this type */
+  public function isInstance($obj): bool {
+    foreach ($this->types as $type) {
+      if (!$type->isInstance($obj)) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns a new instance of this type
+   *
+   * @param   var... $args
+   * @return  var
+   */
+  public function newInstance(... $args) {
+    $value= $args[0] ?? null;
+    foreach ($this->types as $type) {
+      if (!$type->isInstance($value)) {
+        throw new IllegalArgumentException('Cannot create instances of the '.$this->getName().' type from '.typeof($value)->getName());
+      }
+    }
+    return clone $value;
+  }
+
+  /**
+   * Cast a value to this type
+   *
+   * @param   var value
+   * @return  var
+   * @throws  lang.ClassCastException
+   */
+  public function cast($value) {
+    if (null === $value) {
+      return null;
+    } else {
+      foreach ($this->types as $type) {
+        if (!$type->isInstance($value)) {
+          throw new ClassCastException('Cannot cast to the '.$this->getName().' type from '.typeof($value)->getName());
+        }
+      }
+    }
+    return $type->cast($value);
+  }
+
+  /**
+   * Get a type instance for a given name
+   *
+   * @param   string name
+   * @return  self
+   * @throws  lang.IllegalArgumentException if the given name does not correspond to a function type
+   */
+  public static function forName($name) {
+    $t= parent::forName($name);
+    if ($t instanceof self) return $t;
+
+    throw new IllegalArgumentException($name.' is not an intersection type');
+  }
+
+  /**
+   * Tests whether this type is assignable from another type
+   *
+   * ```php
+   * $t= TypeIntersection::forName('Countable&Traversable');
+   *
+   * // It's assignable to intersections if the intersection consists completely
+   * // of types assignable to types in this intersection.
+   * $intersection->isAssignableFrom('Countable&Traversable')        // TRUE
+   * $intersection->isAssignableFrom('Countable&IteratorAggregate')  // TRUE
+   * ```
+   *
+   * @param   var $from Either a type or a type name
+   * @return  bool
+   */
+  public function isAssignableFrom($from): bool {
+    $t= $from instanceof Type ? $from : Type::forName($from);
+    if (!($t instanceof self)) return false;
+
+    $assignableFrom= function($type) {
+      foreach ($this->types as $compare) {
+        echo $type, " isAssignableFrom ", $compare, "\n";
+        if ($type->isAssignableFrom($compare)) return true;
+      }
+      return false;
+    };
+    foreach ($t->types as $type) {
+      if (!$assignableFrom($type)) return false;
+    } 
+    return true;
+  }
+
+  /**
+   * Returns a sorted list of the given types' names.
+   *
+   * @param  parent[] $types
+   * @return string[]
+   */
+  private function sorted($types) {
+    $n= [];
+    foreach ($types as $type) {
+      $n[]= $type->name;
+    }
+    sort($n);
+    return $n;
+  }
+
+  /** Compares to another value */
+  public function compareTo($value): int {
+    return $value instanceof self ? $this->sorted($this->types) <=> $this->sorted($value->types) : 1;
+  }
+
+  /** Checks for equality with another value */
+  public function equals($value): bool {
+    return $value instanceof static && $this->sorted($this->types) === $this->sorted($value->types);
+  }
+}

--- a/src/main/php/lang/TypeIntersection.class.php
+++ b/src/main/php/lang/TypeIntersection.class.php
@@ -112,7 +112,6 @@ class TypeIntersection extends Type {
 
     $assignableFrom= function($type) {
       foreach ($this->types as $compare) {
-        echo $type, " isAssignableFrom ", $compare, "\n";
         if ($type->isAssignableFrom($compare)) return true;
       }
       return false;

--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -87,6 +87,13 @@ class Field implements Value {
         }
       }
       return $nullable.substr($union, 1);
+    } else if ($t instanceof \ReflectionIntersectionType) {
+      $intersection= '';
+      foreach ($t->getTypes() as $component) {
+        $name= $component->getName();
+        $intersection.= '&'.($map[$name] ?? strtr($name, '\\', '.'));
+      }
+      return substr($intersection, 1);
     } else {
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
 

--- a/src/main/php/lang/reflect/Parameter.class.php
+++ b/src/main/php/lang/reflect/Parameter.class.php
@@ -95,6 +95,13 @@ class Parameter {
         }
       }
       return $nullable.substr($union, 1);
+    } else if ($t instanceof \ReflectionIntersectionType) {
+      $intersection= '';
+      foreach ($t->getTypes() as $component) {
+        $name= $component->getName();
+        $intersection.= '&'.($map[$name] ?? strtr($name, '\\', '.'));
+      }
+      return ($t->allowsNull() ? '?' : '').substr($intersection, 1);
     } else {
       $nullable= $t->allowsNull() ? '?' : '';
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();

--- a/src/main/php/lang/reflect/Routine.class.php
+++ b/src/main/php/lang/reflect/Routine.class.php
@@ -156,6 +156,13 @@ class Routine implements Value {
         }
       }
       return $nullable.substr($union, 1);
+    } else if ($t instanceof \ReflectionIntersectionType) {
+      $intersection= '';
+      foreach ($t->getTypes() as $component) {
+        $name= $component->getName();
+        $intersection.= '&'.($map[$name] ?? strtr($name, '\\', '.'));
+      }
+      return ($t->allowsNull() ? '?' : '').substr($intersection, 1);
     } else {
       $nullable= $t->allowsNull() ? '?' : '';
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();

--- a/src/test/config/unittest/core.ini
+++ b/src/test/config/unittest/core.ini
@@ -145,6 +145,9 @@ class="net.xp_framework.unittest.core.FunctionTypeVarArgsTest"
 [typeunion]
 class="net.xp_framework.unittest.core.TypeUnionTest"
 
+[typeintersection]
+class="net.xp_framework.unittest.core.TypeIntersectionTest"
+
 [systemexit]
 class="net.xp_framework.unittest.core.SystemExitTest"
 

--- a/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/IsTest.class.php
@@ -328,4 +328,9 @@ class IsTest extends TestCase {
   public function closures_are_objects($val) {
     $this->assertTrue(is('object', $val));
   }
+
+  #[Test]
+  public function type_intersection() {
+    $this->assertTrue(is('Countable&Traversable', new \ArrayObject([])));
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/core/TypeIntersectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeIntersectionTest.class.php
@@ -15,22 +15,22 @@ class TypeIntersectionTest extends TestCase {
   /** @return Countable&Traversable */
   private function intersection() {
     return new class() implements \Countable, \IteratorAggregate {
-      public function count() { return 0; }
-      public function getIterator() { while (false) yield; }
+      public function count(): int { return 0; }
+      public function getIterator(): \Traversable { while (false) yield; }
     };
   }
 
   /** @return Countable */
   private function countable() {
     return new class() implements \Countable {
-      public function count() { return 0; }
+      public function count(): int { return 0; }
     };
   }
 
   /** @return Traversable */
   private function traversable() {
     return new class() implements \IteratorAggregate {
-      public function getIterator() { while (false) yield; }
+      public function getIterator(): \Traversable { while (false) yield; }
     };
   }
 

--- a/src/test/php/net/xp_framework/unittest/core/TypeIntersectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeIntersectionTest.class.php
@@ -114,28 +114,22 @@ class TypeIntersectionTest extends TestCase {
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
   public function php81_native_intersection_field_type() {
-    $f= eval('return new class() { public Countable&Traversable $fixture; };');
-    $this->assertEquals(
-      new TypeIntersection($this->types),
-      typeof($f)->getField('fixture')->getType()
-    );
+    $f= typeof(eval('return new class() { public Countable&Traversable $fixture; };'))->getField('fixture');
+    $this->assertEquals(new TypeIntersection($this->types), $f->getType());
+    $this->assertEquals('Countable&Traversable', $f->getTypeName());
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
   public function php81_native_intersection_param_type() {
-    $f= eval('return new class() { public function fixture(Countable&Traversable $arg) { } };');
-    $this->assertEquals(
-      new TypeIntersection($this->types),
-      typeof($f)->getMethod('fixture')->getParameter(0)->getType()
-    );
+    $m= typeof(eval('return new class() { public function fixture(Countable&Traversable $arg) { } };'))->getMethod('fixture');
+    $this->assertEquals(new TypeIntersection($this->types), $m->getParameter(0)->getType());
+    $this->assertEquals('Countable&Traversable', $m->getParameter(0)->getTypeName());
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
   public function php81_native_intersection_return_type() {
-    $f= eval('return new class() { public function fixture(): Countable&Traversable { } };');
-    $this->assertEquals(
-      new TypeIntersection($this->types),
-      typeof($f)->getMethod('fixture')->getReturnType()
-    );
+    $m= typeof(eval('return new class() { public function fixture(): Countable&Traversable { } };'))->getMethod('fixture');
+    $this->assertEquals(new TypeIntersection($this->types), $m->getReturnType());
+    $this->assertEquals('Countable&Traversable', $m->getReturnTypeName());
   }
 }

--- a/src/test/php/net/xp_framework/unittest/core/TypeIntersectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeIntersectionTest.class.php
@@ -1,0 +1,113 @@
+<?php namespace net\xp_framework\unittest\core;
+
+use lang\{Type, TypeIntersection, XPClass, IllegalArgumentException, ClassCastException};
+use net\xp_framework\unittest\Name;
+use unittest\{Expect, Test, TestCase, Values};
+
+class TypeIntersectionTest extends TestCase {
+  private $types;
+
+  /** @return void */
+  public function setUp() {
+    $this->types= [new XPClass('Countable'), new XPClass('Traversable')];
+  }
+
+  /** @return Countable&Traversable */
+  private function intersection() {
+    return new class() implements \Countable, \IteratorAggregate {
+      public function count() { return 0; }
+      public function getIterator() { while (false) yield; }
+    };
+  }
+
+  /** @return Countable */
+  private function countable() {
+    return new class() implements \Countable {
+      public function count() { return 0; }
+    };
+  }
+
+  /** @return Traversable */
+  private function traversable() {
+    return new class() implements \IteratorAggregate {
+      public function getIterator() { while (false) yield; }
+    };
+  }
+
+  /** @return iterable */
+  private function values() {
+    yield [0];
+    yield [false];
+    yield [''];
+    yield [[]];
+    yield [$this->countable()];
+    yield [$this->traversable()];
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function cannot_create_from_empty() {
+    new TypeIntersection([]);
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function cannot_create_from_single() {
+    new TypeIntersection([Type::$VAR]);
+  }
+
+  #[Test]
+  public function can_create() {
+    new TypeIntersection($this->types);
+  }
+
+  #[Test, Values(['Countable&Traversable', 'Countable & Traversable', 'Traversable&Countable'])]
+  public function forName($literal) {
+    $this->assertEquals(new TypeIntersection($this->types), TypeIntersection::forName($literal));
+  }
+
+  #[Test, Values(['Countable&Traversable', 'Countable & Traversable', '(Countable&Traversable)', '(Countable & Traversable)'])]
+  public function forName_from_Type_class($literal) {
+    $this->assertEquals(new TypeIntersection($this->types), Type::forName($literal));
+  }
+
+  #[Test]
+  public function types() {
+    $this->assertEquals($this->types, (new TypeIntersection($this->types))->types());
+  }
+
+  #[Test]
+  public function is_instance() {
+    $this->assertTrue((new TypeIntersection($this->types))->isInstance($this->intersection()));
+  }
+
+  #[Test, Values('values')]
+  public function is_not_instance($value) {
+    $this->assertFalse((new TypeIntersection($this->types))->isInstance($value));
+  }
+
+  #[Test]
+  public function new_instance() {
+    $i= $this->intersection();
+    $this->assertEquals($i, (new TypeIntersection($this->types))->newInstance($i));
+  }
+
+  #[Test]
+  public function cast() {
+    $i= $this->intersection();
+    $this->assertEquals($i, (new TypeIntersection($this->types))->cast($i));
+  }
+
+  #[Test]
+  public function cast_null() {
+    $this->assertNull((new TypeIntersection($this->types))->cast(null));
+  }
+
+  #[Test, Expect(ClassCastException::class), Values('values')]
+  public function cannot_cast($value) {
+    (new TypeIntersection($this->types))->cast($value);
+  }
+
+  #[Test, Values(['Traversable&Countable', 'Countable&Traversable', 'Countable&IteratorAggregate', 'Countable&Traversable&ArrayAccess'])]
+  public function is_assignable_from($type) {
+    $this->assertTrue(TypeIntersection::forName($type)->isAssignableFrom(new TypeIntersection($this->types)));
+  }
+}

--- a/src/test/php/net/xp_framework/unittest/core/TypeIntersectionTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeIntersectionTest.class.php
@@ -108,8 +108,13 @@ class TypeIntersectionTest extends TestCase {
   }
 
   #[Test, Values(['Traversable&Countable', 'Countable&Traversable', 'Countable&IteratorAggregate', 'Countable&Traversable&ArrayAccess'])]
-  public function is_assignable_from($type) {
+  public function is_assignable_from_intersection($type) {
     $this->assertTrue(TypeIntersection::forName($type)->isAssignableFrom(new TypeIntersection($this->types)));
+  }
+
+  #[Test, Values(['ArrayObject', 'SplFixedArray'])]
+  public function is_assignable_from_class($type) {
+    $this->assertTrue((new TypeIntersection($this->types))->isAssignableFrom($type));
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]


### PR DESCRIPTION
```php
function fixture(Countable&Traversable $t) { ... }
```

See https://wiki.php.net/rfc/pure-intersection-types

* [x] Add new `lang.TypeIntersection` class
* [x] Add support for parsing `T1&T2` inside `lang.Type`
* [x] Support PHP 8.1 native reflection for field, parameter and return types
* [x] Add support to `is()` core functionality