### PR TITLE
Add support for PHP 8.1 readonly properties

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -455,6 +455,7 @@ define('MODIFIER_FINAL',     \ReflectionMethod::IS_FINAL);
 define('MODIFIER_PUBLIC',    \ReflectionMethod::IS_PUBLIC);
 define('MODIFIER_PROTECTED', \ReflectionMethod::IS_PROTECTED);
 define('MODIFIER_PRIVATE',   \ReflectionMethod::IS_PRIVATE);
+define('MODIFIER_READONLY',  128); // PHP 8.1: \ReflectionProperty::IS_READONLY
 
 define('DETAIL_ARGUMENTS',   1);
 define('DETAIL_RETURNS',     2);

--- a/src/main/php/lang/reflect/Field.class.php
+++ b/src/main/php/lang/reflect/Field.class.php
@@ -291,6 +291,8 @@ class Field implements Value {
       return $this->_reflect->setValue($instance, $value);
     } catch (Throwable $e) {
       throw $e;
+    } catch (\Error $e) {
+      throw new IllegalAccessException($e->getMessage(), $e); // PHP 8.1 raises errors when modifying readonly properties
     } catch (\Throwable $e) {
       throw new XPException($e->getMessage());
     }

--- a/src/main/php/lang/reflect/Modifiers.class.php
+++ b/src/main/php/lang/reflect/Modifiers.class.php
@@ -72,6 +72,16 @@ abstract class Modifiers {
   }
 
   /**
+   * Returns TRUE when the given modifiers include the readonly modifier.
+   *
+   * @param   int m modifiers bitfield
+   * @return  bool
+   */
+  public static function isReadonly($m) {
+    return MODIFIER_READONLY == ($m & MODIFIER_READONLY);
+  }
+
+  /**
    * Retrieves modifier names as an array. The order in which the 
    * modifiers are returned is the following:
    *
@@ -93,6 +103,7 @@ abstract class Modifiers {
     if ($m & MODIFIER_STATIC) $names[]= 'static';
     if ($m & MODIFIER_ABSTRACT) $names[]= 'abstract';
     if ($m & MODIFIER_FINAL) $names[]= 'final';
+    if ($m & MODIFIER_READONLY) $names[]= 'readonly';
     return $names;
   }
 

--- a/src/test/php/net/xp_framework/unittest/reflection/FieldAccessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/FieldAccessTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
 use lang\{IllegalAccessException, IllegalArgumentException};
-use unittest\{Expect, Test, Values};
+use unittest\actions\RuntimeVersion;
+use unittest\{Action, Expect, Test, Values};
 
 class FieldAccessTest extends FieldsTest {
 
@@ -69,5 +70,27 @@ class FieldAccessTest extends FieldsTest {
   public function cannot_write_instance_method_with_incompatible() {
     $fixture= $this->type('{ public $fixture; }');
     $fixture->getField('fixture')->set($this, 'Test');
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  public function can_modify_uninitialized_readonly_property() {
+    $fixture= $this->type('{ public readonly string $fixture; }');
+    $field= $fixture->getField('fixture');
+    $instance= $fixture->newInstance();
+
+    $field->set($instance, 'Modified');
+    $this->assertEquals('Modified', $field->get($instance));
+  }
+
+  #[Test, Expect(IllegalAccessException::class), Action(eval: 'new RuntimeVersion(">=8.1")')]
+  public function cannot_write_readonly_property_after_initialization() {
+    $fixture= $this->type('{ public readonly int $fixture; public function __construct() { $this->fixture= 1; } }');
+    $fixture->getField('fixture')->set($fixture->newInstance(), 2);
+  }
+
+  #[Test, Expect(IllegalAccessException::class), Action(eval: 'new RuntimeVersion(">=8.1")')]
+  public function cannot_write_readonly_property_after_initialization_via_argument_promotiom() {
+    $fixture= $this->type('{ public function __construct(public readonly int $fixture) { } }');
+    $fixture->getField('fixture')->set($fixture->newInstance(1), 2);
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/FieldModifiersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/FieldModifiersTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use unittest\Test;
+use unittest\actions\RuntimeVersion;
+use unittest\{Action, Test};
 
 class FieldModifiersTest extends FieldsTest {
 
@@ -22,5 +23,10 @@ class FieldModifiersTest extends FieldsTest {
   #[Test]
   public function static_modifier() {
     $this->assertEquals(MODIFIER_STATIC | MODIFIER_PUBLIC, $this->field('public static $fixture;')->getModifiers());
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  public function readonly_modifier() {
+    $this->assertEquals(MODIFIER_READONLY | MODIFIER_PUBLIC, $this->field('public readonly int $fixture;')->getModifiers());
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/ModifiersTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ModifiersTest.class.php
@@ -114,4 +114,14 @@ class ModifiersTest extends \unittest\TestCase {
   public function staticModifierNames() {
     $this->assertEquals(['public', 'static'], Modifiers::namesOf(MODIFIER_STATIC));
   }
+
+  #[Test]
+  public function readonlyModifier() {
+    $this->assertTrue(Modifiers::isReadonly(MODIFIER_READONLY));
+  }
+
+  #[Test]
+  public function readonlyModifierNames() {
+    $this->assertEquals(['public', 'readonly'], Modifiers::namesOf(MODIFIER_READONLY));
+  }
 }


### PR DESCRIPTION
This pull request implements support PHP 8.1 readonly properties as defined in https://wiki.php.net/rfc/readonly_properties_v2

```php
class Test {
  public function __construct(public readonly int $prop = 0) { }
}

$test= new Test(6100);
$test->prop; // 6100
$test->prop= 6101; // Raises error
```

* [x] Global MODIFIER_READONLY constant
* [x] lang.reflect.Modifiers::isReadonly()
* [x] Modifier names
* [x] Reflective access via lang.reflect.Field