### PR TITLE
Enhance Process::resolve() to be able to resolve multiple commands

### DIFF
--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -107,10 +107,11 @@ class Process {
    * Resolve path for a command
    *
    * @param   string|string[] commands
-   * @return  string executable
+   * @param   bool optional Controls whether to return NULL or raise exceptions
+   * @return  ?string executable
    * @throws  io.IOException in case the command could not be found or is not an executable
    */
-  public static function resolve($commands): string {
+  public static function resolve($commands, $optional= false) {
     clearstatcache();
 
     // PATHEXT is in form ".{EXT}[;.{EXT}[;...]]"
@@ -145,6 +146,7 @@ class Process {
       }
     }
 
+    if ($optional) return null;
     throw new IOException('Could not find '.implode(', ', (array)$commands).' in path');
   }
 

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -114,7 +114,7 @@ class Process {
     clearstatcache();
 
     // PATHEXT is in form ".{EXT}[;.{EXT}[;...]]"
-    $extensions= [''] + explode(PATH_SEPARATOR, getenv('PATHEXT'));
+    $extensions= array_merge([''], explode(PATH_SEPARATOR, getenv('PATHEXT')));
     $paths= explode(PATH_SEPARATOR, getenv('PATH'));
 
     foreach ((array)$commands as $command) {

--- a/src/test/php/net/xp_framework/unittest/core/ProcessResolveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ProcessResolveTest.class.php
@@ -119,4 +119,14 @@ class ProcessResolveTest extends TestCase {
   public function resolve() {
     $this->assertTrue(in_array(Process::resolve('ls'), ['/usr/bin/ls', '/bin/ls']));
   }
+
+  #[Test, Action(eval: 'new IsPlatform("WIN")')]
+  public function resolveCommandLineInterpreter() {
+    $this->assertTrue(is_executable(Process::resolve(['command.com', 'cmd.exe'])));
+  }
+
+  #[Test, Action(eval: 'new IsPlatform("!(WIN|ANDROID)")')]
+  public function resolveUnixShell() {
+    $this->assertTrue(is_executable(Process::resolve(['zsh', 'bash', 'dash', 'sh'])));
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/core/ProcessResolveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ProcessResolveTest.class.php
@@ -104,6 +104,11 @@ class ProcessResolveTest extends TestCase {
     Process::resolve('/@@non-existant@@');
   }
 
+  #[Test]
+  public function resolveNonExistantOptionally() {
+    $this->assertNull(Process::resolve('/@@non-existant@@', true));
+  }
+
   #[Test, Action(eval: 'new IsPlatform("ANDROID")')]
   public function resolveFullyQualifiedOnAndroid() {
     $fq= getenv('ANDROID_ROOT').'/framework/core.jar';


### PR DESCRIPTION
This pull request adds the ability to resolve multiple commands, and control whether an exception should be raised or NULL returned instead.

```php
use lang\Process;

// Resolve either docker or podman, raise an exception if neither is found
$containers= Process::resolve(['docker', 'podman']);

// Optionally resolve commands by passing true
$download= match (true) {
  !is_null($cmd= Process::resolve('curl', true)) => fn($url, $target) => $cmd.' "-#" -L "'.$url.'" -o "'.$target.'"',
  !is_null($cmd= Process::resolve('wget', true)) => fn($url, $target) => $cmd.' -nv "'.$url.'" -O "'.$target.'"',
  default => throw new IllegalArgumentException('Either curl or wget is required'),
};
```