### PR TITLE
Add Process::locate() to find commands in PATH

### DIFF
--- a/src/test/php/net/xp_framework/unittest/core/ProcessResolveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ProcessResolveTest.class.php
@@ -119,4 +119,22 @@ class ProcessResolveTest extends TestCase {
   public function resolve() {
     $this->assertTrue(in_array(Process::resolve('ls'), ['/usr/bin/ls', '/bin/ls']));
   }
+
+  #[Test, Action(eval: 'new IsPlatform("WIN")')]
+  public function locate_multiple_windows() {
+    $result= [];
+    foreach (Process::locate(['explorer', 'winver']) as $command => $resolved) {
+      $result[$command]= is_executable($resolved);
+    }
+    $this->assertEquals(['explorer' => true, 'winver' => true], $result);
+  }
+
+  #[Test, Action(eval: 'new IsPlatform("!(WIN|ANDROID)")')]
+  public function locate_multiple_posix() {
+    $result= [];
+    foreach (Process::locate(['ls', 'ln']) as $command => $resolved) {
+      $result[$command]= is_executable($resolved);
+    }
+    $this->assertEquals(['ls' => true, 'ln' => true], $result);
+  }
 }


### PR DESCRIPTION
This pull request adds the ability to resolve multiple commands, like #279 but by adding a new method instead of overloading the existing one.

```php
use lang\Process;

// Resolve either docker or podman. Will contain NULL if neither is found.
$containers= Process::locate(['docker', 'podman'])->current();

// See which command was resolved and compose command line accordingly
$locate= Process::locate(['curl', 'wget']);
$download= match ($locate->key()) {
  'curl' => fn($url, $target) => $locate->current().' "-#" -L "'.$url.'" -o "'.$target.'"',
  'wget' => fn($url, $target) => $locate->current().' -nv "'.$url.'" -O "'.$target.'"',
  default => throw new IllegalArgumentException('Either curl or wget is required'),
};
```