### PR TITLE
Add CommandLine::resolve()

### DIFF
--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -25,7 +25,7 @@
  */
 abstract class CommandLine extends Enum {
   public static $WINDOWS, $UNIX;
-  private static $PATH;
+  protected static $PATH;
 
   static function __static() {
     self::$WINDOWS= new class(0, 'WINDOWS') extends CommandLine {

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -66,14 +66,14 @@ abstract class CommandLine extends Enum {
         if (strlen($command) === strcspn($command, '/\\')) {
           foreach (parent::$PATH ?? parent::$PATH= explode(';', getenv('PATH')) as $path) {
             foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
-              $q= $path.'\\'.$command.$ext;
-              is_executable($q) && yield realpath($q);
+              $q= rtrim($path, '\\').'\\'.$command.$ext;
+              is_executable($q) && yield $q;
             }
           }
         } else {
           foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
             $q= $command.$ext;
-            is_executable($q) && yield realpath($q);
+            is_executable($q) && yield $q;
           }
         }
       }
@@ -126,11 +126,11 @@ abstract class CommandLine extends Enum {
           // NOOP
         } else if (false === strpos($command, DIRECTORY_SEPARATOR)) {
           foreach (parent::$PATH ?? parent::$PATH= explode(PATH_SEPARATOR, getenv('PATH')) as $path) {
-            $q= $path.DIRECTORY_SEPARATOR.$command;
-            is_file($q) && is_executable($q) && yield realpath($q);
+            $q= rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$command;
+            is_file($q) && is_executable($q) && yield $q;
           }
         } else {
-          is_file($command) && is_executable($command) && yield realpath($command);
+          is_file($command) && is_executable($command) && yield $command;
         }
       }
 

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -47,7 +47,7 @@ abstract class CommandLine extends Enum {
                 break;
               }
               $q= $p;
-              if ($triple === substr($cmd, $q, 3)) {
+              if (0 === substr_compare($cmd, $triple, $q, 3)) {
                 false === ($p= strpos($cmd, $triple, $q+= 3)) || $q= $p + 3;
                 continue;
               }

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -29,8 +29,6 @@ abstract class CommandLine extends Enum {
 
   static function __static() {
     self::$WINDOWS= new class(0, 'WINDOWS') extends CommandLine {
-      private static $EXT;
-
       static function __static() { }
 
       public function parse($cmd) {
@@ -73,15 +71,15 @@ abstract class CommandLine extends Enum {
         if ('' === $command) return;
 
         $dot= strrpos($command, '.') > 0;
-        if ('\\' === $command[0] || '/' === $command[0] || 2 === sscanf($command, '%c%[:]', $drive, $colon)) {
-          foreach ($dot ? [''] : self::$EXT ?? self::$EXT= explode(';', getenv('PATHEXT')) as $ext) {
+        if ('.' === $command[0] || '\\' === $command[0] || '/' === $command[0] || 2 === sscanf($command, '%c%[:]', $drive, $colon)) {
+          foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
             $q= $command.$ext;
             is_file($q) && is_executable($q) && yield realpath($q);
           }
         } else {
           parent::$PATH ?? parent::$PATH= explode(';', getenv('PATH'));
           foreach (parent::$PATH as $path) {
-            foreach ($dot ? [''] : self::$EXT ?? self::$EXT= explode(';', getenv('PATHEXT')) as $ext) {
+            foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
               $q= $path.'\\'.$command.$ext;
               is_file($q) && is_executable($q) && yield realpath($q);
             }
@@ -135,7 +133,7 @@ abstract class CommandLine extends Enum {
       public function resolve($command) {
         if ('' === $command) {
           // NOOP
-        } else if ('/' === $command[0]) {
+        } else if ('.' === $command[0] || '/' === $command[0]) {
           is_file($command) && yield realpath($command);
         } else {
           foreach (parent::$PATH ?? parent::$PATH= explode(PATH_SEPARATOR, getenv('PATH')) as $path) {

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -48,16 +48,12 @@ abstract class CommandLine extends Enum {
               }
               $q= $p;
               if ($triple === substr($cmd, $q, 3)) {
-                if (false === ($p= strpos($cmd, $triple, $q+ 3))) {
-                  $q= $q+ 3;
-                  continue;
-                }
-                $q= $p+ 3;
+                false === ($p= strpos($cmd, $triple, $q+= 3)) || $q= $p + 3;
                 continue;
               }
               break;
             } while ($q < $s);
-            $r.= str_replace($triple, '"', substr($cmd, $i+ 1, $q- $i- 1));
+            $r.= str_replace($triple, '"', substr($cmd, $i + 1, $q - $i - 1));
             $i= $q;
           } else {
             $r.= $cmd[$i];

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -63,18 +63,18 @@ abstract class CommandLine extends Enum {
         if ('' === $command) return;
 
         $dot= strrpos($command, '.') > 0;
-        if ('.' === $command[0] || '\\' === $command[0] || '/' === $command[0] || 2 === sscanf($command, '%c%[:]', $drive, $colon)) {
-          foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
-            $q= $command.$ext;
-            is_executable($q) && yield realpath($q);
-          }
-        } else {
+        if (false === strpos($command, '\\') && false === strpos($command, '/')) {
           parent::$PATH ?? parent::$PATH= explode(';', getenv('PATH'));
           foreach (parent::$PATH as $path) {
             foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
               $q= $path.'\\'.$command.$ext;
               is_executable($q) && yield realpath($q);
             }
+          }
+        } else {
+          foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
+            $q= $command.$ext;
+            is_executable($q) && yield realpath($q);
           }
         }
       }
@@ -125,13 +125,13 @@ abstract class CommandLine extends Enum {
       public function resolve($command) {
         if ('' === $command) {
           // NOOP
-        } else if ('.' === $command[0] || '/' === $command[0]) {
-          is_file($command) && yield realpath($command);
-        } else {
+        } else if (false === strpos($command, DIRECTORY_SEPARATOR)) {
           foreach (parent::$PATH ?? parent::$PATH= explode(PATH_SEPARATOR, getenv('PATH')) as $path) {
             $q= $path.DIRECTORY_SEPARATOR.$command;
             is_file($q) && is_executable($q) && yield realpath($q);
           }
+        } else {
+          is_file($command) && is_executable($q) && yield realpath($command);
         }
       }
 

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -62,6 +62,7 @@ abstract class CommandLine extends Enum {
       public function resolve($command) {
         if ('' === $command) return;
 
+        clearstatcache();
         $dot= strrpos($command, '.') > 0;
         if (strlen($command) === strcspn($command, '/\\')) {
           foreach (parent::$PATH ?? parent::$PATH= explode(';', getenv('PATH')) as $path) {
@@ -122,9 +123,10 @@ abstract class CommandLine extends Enum {
       }
 
       public function resolve($command) {
-        if ('' === $command) {
-          // NOOP
-        } else if (false === strpos($command, DIRECTORY_SEPARATOR)) {
+        if ('' === $command) return;
+
+        clearstatcache();
+        if (false === strpos($command, DIRECTORY_SEPARATOR)) {
           foreach (parent::$PATH ?? parent::$PATH= explode(PATH_SEPARATOR, getenv('PATH')) as $path) {
             $q= rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$command;
             is_file($q) && is_executable($q) && yield $q;

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -1,11 +1,7 @@
 <?php namespace lang;
 
 /**
- * Handles command line quoting
- *
- * Composing a command line
- * ------------------------
- * Handled by the <tt>compose</tt> method.
+ * Handles command line parsing, quoting and composing.
  *
  * For Windows
  * ~~~~~~~~~~~
@@ -20,8 +16,8 @@
  *   a backslash. So: he said: 'Hello' will become the following:
  *   'he said: '\''Hello'\''
  *
- * @see      xp://lang.Process
- * @test     xp://net.xp_framework.unittest.core.CommandLineTest
+ * @see   lang.Process
+ * @test  net.xp_framework.unittest.core.CommandLineTest
  */
 abstract class CommandLine extends Enum {
   public static $WINDOWS, $UNIX;
@@ -159,8 +155,8 @@ abstract class CommandLine extends Enum {
    * Returns the command line implementation for the given operating 
    * system.
    *
-   * @param   string os operating system name, e.g. PHP_OS
-   * @return  lang.CommandLine
+   * @param  string $os operating system name, e.g. PHP_OS
+   * @return self
    */
   public static function forName(string $os): self {
     if (0 === strncasecmp($os, 'Win', 3)) {
@@ -173,15 +169,15 @@ abstract class CommandLine extends Enum {
   /**
    * Parse command line
    *
-   * @param   string cmd
-   * @return  string[] parts
+   * @param  string $line
+   * @return string[] parts
    */
-  public abstract function parse($cmd);
+  public abstract function parse($line);
 
   /**
    * Resolve a command
    *
-   * @param  string command
+   * @param  string $command
    * @return iterable
    */
   public abstract function resolve($command);
@@ -189,9 +185,9 @@ abstract class CommandLine extends Enum {
   /**
    * Build command line from a command and - optionally - arguments
    *
-   * @param   string command
-   * @param   string[] arguments default []
-   * @return  string
+   * @param  string $command
+   * @param  string[] $arguments default []
+   * @return string
    */
   public abstract function compose($command, $arguments= []);
 }

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -64,8 +64,7 @@ abstract class CommandLine extends Enum {
 
         $dot= strrpos($command, '.') > 0;
         if (false === strpos($command, '\\') && false === strpos($command, '/')) {
-          parent::$PATH ?? parent::$PATH= explode(';', getenv('PATH'));
-          foreach (parent::$PATH as $path) {
+          foreach (parent::$PATH ?? parent::$PATH= explode(';', getenv('PATH')) as $path) {
             foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
               $q= $path.'\\'.$command.$ext;
               is_executable($q) && yield realpath($q);

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -130,7 +130,7 @@ abstract class CommandLine extends Enum {
             is_file($q) && is_executable($q) && yield realpath($q);
           }
         } else {
-          is_file($command) && is_executable($q) && yield realpath($command);
+          is_file($command) && is_executable($command) && yield realpath($command);
         }
       }
 

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -74,14 +74,14 @@ abstract class CommandLine extends Enum {
         if ('.' === $command[0] || '\\' === $command[0] || '/' === $command[0] || 2 === sscanf($command, '%c%[:]', $drive, $colon)) {
           foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
             $q= $command.$ext;
-            is_file($q) && is_executable($q) && yield realpath($q);
+            is_executable($q) && yield realpath($q);
           }
         } else {
           parent::$PATH ?? parent::$PATH= explode(';', getenv('PATH'));
           foreach (parent::$PATH as $path) {
             foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
               $q= $path.'\\'.$command.$ext;
-              is_file($q) && is_executable($q) && yield realpath($q);
+              is_executable($q) && yield realpath($q);
             }
           }
         }

--- a/src/main/php/lang/CommandLine.class.php
+++ b/src/main/php/lang/CommandLine.class.php
@@ -63,7 +63,7 @@ abstract class CommandLine extends Enum {
         if ('' === $command) return;
 
         $dot= strrpos($command, '.') > 0;
-        if (false === strpos($command, '\\') && false === strpos($command, '/')) {
+        if (strlen($command) === strcspn($command, '/\\')) {
           foreach (parent::$PATH ?? parent::$PATH= explode(';', getenv('PATH')) as $path) {
             foreach ($dot ? [''] : ['.com', '.exe'] as $ext) {
               $q= $path.'\\'.$command.$ext;

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -295,9 +295,9 @@ class Process {
       throw new IllegalStateException('Cannot close not-owned process #'.$this->status['pid']);
     }
     if (null !== $this->handle) {
-      $this->in->isOpen() && $this->in->close();
-      $this->out->isOpen() && $this->out->close();
-      $this->err->isOpen() && $this->err->close();
+      $this->in && $this->in->isOpen() && $this->in->close();
+      $this->out && $this->out->isOpen() && $this->out->close();
+      $this->err && $this->err->isOpen() && $this->err->close();
       $this->exitv= proc_close($this->handle);
       $this->handle= null;
     }

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -1,18 +1,18 @@
 <?php namespace lang;
 
-use io\File;
+use io\{File, IOException};
 
 /**
  * Process
  *
  * Example (get uptime information on a *NIX system)
- * <code>
- *   $p= new Process('uptime');
- *   $uptime= $p->out->readLine();
- *   $p->close();
+ * ```php
+ * $p= new Process('uptime');
+ * $uptime= $p->out->readLine();
+ * $p->close();
  *
- *   var_dump($uptime);
- * </code>
+ * var_dump($uptime);
+ * ```
  *
  * @test  xp://net.xp_framework.unittest.core.ProcessResolveTest
  * @test  xp://net.xp_framework.unittest.core.ProcessTest
@@ -56,9 +56,9 @@ class Process {
 
     // Short-circuit
     if ('' === $command) {
-      throw new \io\IOException('Empty command not resolveable');
+      throw new IOException('Empty command not resolveable');
     } else if (self::$DISABLED) {
-      throw new \io\IOException('Process execution has been disabled');
+      throw new IOException('Process execution has been disabled');
     }
 
     $cmd= CommandLine::forName(PHP_OS);
@@ -67,7 +67,7 @@ class Process {
       // Resolved binary, try creating a process from it
       $exec= $cmd->compose($binary, $arguments);
       if (!is_resource($this->handle= proc_open($exec, $spec, $pipes, $cwd, $env, ['bypass_shell' => true]))) {
-        throw new \io\IOException('Could not execute "'.$exec.'"');
+        throw new IOException('Could not execute "'.$exec.'"');
       }
 
       $this->status= proc_get_status($this->handle);
@@ -90,7 +90,7 @@ class Process {
       return;
     }
 
-    throw new \io\IOException('Could not find "'.$command.'" in path');
+    throw new IOException('Could not find "'.$command.'" in path');
   }
 
   /**
@@ -119,7 +119,7 @@ class Process {
       return $executable;
     }
 
-    throw new \io\IOException('' === $command
+    throw new IOException('' === $command
       ? 'Empty command not resolveable'
       : 'Could not find "'.$command.'" in path'
     );
@@ -231,7 +231,7 @@ class Process {
         if (0 !== $exit) {
           throw new IllegalStateException('Cannot find executable: '.implode('', $out));
         }
-      } catch (\io\IOException $e) {
+      } catch (IOException $e) {
         throw new IllegalStateException($e->getMessage());
       }
       $self->status['running?']= function() use($pid) {

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -109,6 +109,7 @@ class Process {
   /**
    * Resolve path for a command
    *
+   * @deprecated Use lang.CommandLine::resolve() instead!
    * @param   string command
    * @return  string executable
    * @throws  io.IOException in case the command is empty or could not be found

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -63,9 +63,10 @@ class Process {
 
     $cmd= CommandLine::forName(PHP_OS);
     foreach ($cmd->resolve($command) as $binary) {
+      $binary= realpath($binary);
 
       // Resolved binary, try creating a process from it
-      $exec= $cmd->compose(realpath($binary), $arguments);
+      $exec= $cmd->compose($binary, $arguments);
       if (!is_resource($this->handle= proc_open($exec, $spec, $pipes, $cwd, $env, ['bypass_shell' => true]))) {
         throw new IOException('Could not execute "'.$exec.'"');
       }

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -65,7 +65,7 @@ class Process {
     foreach ($cmd->resolve($command) as $binary) {
 
       // Resolved binary, try creating a process from it
-      $exec= $cmd->compose($binary, $arguments);
+      $exec= $cmd->compose(realpath($binary), $arguments);
       if (!is_resource($this->handle= proc_open($exec, $spec, $pipes, $cwd, $env, ['bypass_shell' => true]))) {
         throw new IOException('Could not execute "'.$exec.'"');
       }
@@ -116,7 +116,7 @@ class Process {
    */
   public static function resolve(string $command): string {
     foreach (CommandLine::forName(PHP_OS)->resolve($command) as $executable) {
-      return $executable;
+      return realpath($executable);
     }
 
     throw new IOException('' === $command


### PR DESCRIPTION
This pull request adds a new method `resolve()` to the `lang.CommandLine` class which finds executables in the system path. This method supersedes `lang.Process::resolve()` which is therefore deprecated.

```bash
# Windows
$ xp -w '[...lang\CommandLine::forName(PHP_OS)->resolve("curl")]'
["C:\Tools\Cygwin\bin\curl.exe", "C:\Windows\System32\curl.exe"]

# Un*x
$ xp -w '[...lang\CommandLine::forName(PHP_OS)->resolve("which")]'
["/usr/bin/which", "/bin/which"]
```

## Windows

* If the given name does not contain a ".", try `[name].exe` and `[name].com` for both of the following
* If the given argument contains a "\\" or "/", check whether a file by the given name exists
* Otherwise, iterate over paths in %PATH% and check for qualified file names

*Note: If you want to execute .bat files, you need to use `cmd /c [file].bat` in order for this to work!*

## Un\*x

* If the name contains the directory separato char (typically "/"), check whether a file by the given name exists and has executable bit set
* Otherwise, iterate over paths in $PATH and check for qualified file names

*Note: The executable bit must be set effectively for the current user for a file to be regarded executable*