### PR TITLE
Allow overwriting descriptors passed to proc_open()

### DIFF
--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -75,6 +75,8 @@ class Process {
           $options['bypass_shell']= false;
         } else if ('null' === $descriptor[0]) {
           $spec[$n]= ['file', CommandLine::$WINDOWS === $cmd ? 'NUL' : '/dev/null', 'w'];
+        } else {
+          $spec[$n]= $descriptor;
         }
       }
 

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -309,6 +309,7 @@ class Process {
     if (!$this->status['owner']) {
       throw new IllegalStateException('Cannot close not-owned process #'.$this->status['pid']);
     }
+
     if (null !== $this->handle) {
       $this->in && $this->in->isOpen() && $this->in->close();
       $this->out && $this->out->isOpen() && $this->out->close();
@@ -317,9 +318,8 @@ class Process {
       $this->handle= null;
     }
     
-    // If the process wasn't running when we entered this method,
-    // determine the exitcode from the previous proc_get_status()
-    // call.
+    // If the process wasn't running when we entered this method, determine
+    // the exitcode from the previous proc_get_status() call.
     if (!$this->status['running']) {
       $this->exitv= $this->status['exitcode'];
     }

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -80,6 +80,12 @@ class Process {
         }
       }
 
+      // For non-Windows systems, use `exec` to replace the extra /bin/sh between this and the
+      // executed process, see https://www.php.net/manual/de/function.proc-get-status.php#93382
+      if (CommandLine::$WINDOWS !== $cmd && $options['bypass_shell']) {
+        $exec= 'exec '.$exec;
+      }
+
       // Try creating a process from the given arguments and descriptors
       if (!is_resource($this->handle= proc_open($exec, $spec, $pipes, $cwd, $env, $options))) {
         throw new IOException('Could not execute "'.$exec.'"');

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -73,7 +73,6 @@ class Process {
         } else if ('redirect' === $descriptor[0]) {
           $exec.= ' '.$n.'>&'.$descriptor[1];
           $options['bypass_shell']= false;
-          $spec[$n]= ['pipe', 'w'];
         } else if ('null' === $descriptor[0]) {
           $spec[$n]= ['file', CommandLine::$WINDOWS === $cmd ? 'NUL' : '/dev/null', 'w'];
         }

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -38,12 +38,12 @@ class Process {
   /**
    * Constructor
    *
-   * @param   string command default NULL
-   * @param   string[] arguments default []
-   * @param   string cwd default NULL the working directory
-   * @param   [:string] default NULL the environment
-   * @param   var[] descriptors
-   * @throws  io.IOException in case the command could not be executed
+   * @param  string $command default NULL
+   * @param  string[] $arguments default []
+   * @param  ?string $cwd default NULL the working directory
+   * @param  ?[:string] $env default NULL the environment
+   * @param  ?var[] descriptors
+   * @throws io.IOException in case the command could not be executed
    */
   public function __construct($command= null, $arguments= [], $cwd= null, $env= null, $descriptors= null) {
     if (null === $command) return;
@@ -109,12 +109,12 @@ class Process {
   /**
    * Create a new instance of this process.
    *
-   * @param   string[] arguments default []
-   * @param   string cwd default NULL the working directory
-   * @param   [:string] default NULL the environment
-   * @param   var[] descriptors
-   * @return  self
-   * @throws  io.IOException in case the command could not be executed
+   * @param  string[] $arguments default []
+   * @param  ?string $cwd default NULL the working directory
+   * @param  ?[:string] $env default NULL the environment
+   * @param  ?var[] $descriptors
+   * @return self
+   * @throws io.IOException in case the command could not be executed
    */
   public function newInstance($arguments= [], $cwd= null, $env= null, $descriptors= null): self {
     return new self($this->status['exe'], $arguments, $cwd, $env, $descriptors);
@@ -124,9 +124,9 @@ class Process {
    * Resolve path for a command
    *
    * @deprecated Use lang.CommandLine::resolve() instead!
-   * @param   string command
-   * @return  string executable
-   * @throws  io.IOException in case the command is empty or could not be found
+   * @param  string $command
+   * @return string $executable
+   * @throws io.IOException in case the command is empty or could not be found
    */
   public static function resolve(string $command): string {
     foreach (CommandLine::forName(PHP_OS)->resolve($command) as $executable) {
@@ -142,10 +142,10 @@ class Process {
   /**
    * Get a process by process ID
    *
-   * @param   int pid process id
-   * @param   string exe
-   * @return  self
-   * @throws  lang.IllegalStateException
+   * @param  int $pid process id
+   * @param  ?string $exe
+   * @return self
+   * @throws lang.IllegalStateException
    */
   public static function getProcessById($pid, $exe= null): self {
     $self= new self();
@@ -273,7 +273,7 @@ class Process {
   /**
    * Get command line arguments
    *
-   * @return  string[]
+   * @return string[]
    */
   public function getArguments() {
     if (null === $this->status['arguments']) {
@@ -301,8 +301,8 @@ class Process {
   /**
    * Close this process
    *
-   * @return  int exit value of process
-   * @throws  lang.IllegalStateException if process is not owned
+   * @return int exit value of process
+   * @throws lang.IllegalStateException if process is not owned
    */
   public function close(): int {
     if (!$this->status['owner']) {

--- a/src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ProcessTest.class.php
@@ -114,6 +114,22 @@ class ProcessTest extends TestCase {
     $this->assertEquals('ERR', $err);
   }
 
+  #[Test]
+  public function stderr_redirected_to_stdout() {
+    $p= new Process($this->executable(), ['-r', 'fprintf(STDERR, "ERR");'], null, null, [2 => ['redirect', 1]]);
+    $out= $p->out->read();
+    $p->close();
+    $this->assertEquals('ERR', $out);
+  }
+
+  #[Test]
+  public function stderr_redirected_to_null() {
+    $p= new Process($this->executable(), ['-r', 'fprintf(STDERR, "ERR"); fprintf(STDOUT, "OK");'], null, null, [2 => ['null']]);
+    $out= $p->out->read();
+    $p->close();
+    $this->assertEquals('OK', $out);
+  }
+
   #[Test, Expect(IOException::class)]
   public function runningNonExistantFile() {
     new Process(':FILE_DOES_NOT_EXIST:');


### PR DESCRIPTION
Supports the argument types listed under https://www.php.net/manual/en/function.proc-open.php

## Usecase: Redirection

Allows redirection to another descriptor and/or the NUL device:

```php
// cmd 2>&1
new Process('cmd', [], null, null, [2 => ['redirect', 1]]);

// cmd 2>NUL or cmd 2>/dev/null, depending on platform
new Process('cmd', [], null, null, [2 => ['null']]);
```

*Supported natively by PHP 7.4 (see php/php-src@6285bb52faf407b07e71497723d13a1b08821352), simulated for lower PHP versions*

## Usecase: Passthru

By inheriting the handles for standard input, output and error, we can simulate the [passthru()](https://www.php.net/passthru) function:

```php
$p= new Process('cmd', [], null, null, [STDIN, STDOUT, STDERR]);
$p->close();
```

*No polling is needed, `close()` will wait for the command to finish*.