### PR TITLE
Remove deprecated reader and writer methods from io.streams

### DIFF
--- a/src/main/php/io/streams/Reader.class.php
+++ b/src/main/php/io/streams/Reader.class.php
@@ -45,14 +45,6 @@ abstract class Reader implements InputStreamReader, Closeable, Value {
   /**
    * Returns the underlying stream
    *
-   * @deprecated Use stream() instead
-   * @return  io.streams.InputStream stream
-   */
-  public function getStream() { return $this->stream; }
-
-  /**
-   * Returns the underlying stream
-   *
    * @return  io.streams.InputStream stream
    */
   public function stream() { return $this->stream; }

--- a/src/main/php/io/streams/StringReader.class.php
+++ b/src/main/php/io/streams/StringReader.class.php
@@ -9,17 +9,6 @@
 class StringReader extends Reader {
 
   /**
-   * Set underlying input stream
-   *
-   * @deprecated Use redirect() instead
-   * @param  io.streams.InputStream $stream
-   * @return void
-   */
-  public function setStream(InputStream $stream) {
-    $this->redirect($stream);
-  }
-
-  /**
    * Read a number of bytes. Returns NULL if no more data is available.
    *
    * @param   int size default 8192

--- a/src/main/php/io/streams/StringWriter.class.php
+++ b/src/main/php/io/streams/StringWriter.class.php
@@ -11,17 +11,6 @@ use util\Objects;
 class StringWriter extends Writer {
 
   /**
-   * Return underlying output stream
-   *
-   * @deprecated Use redirect() instead
-   * @param  io.streams.OutputStream stream
-   * @return void
-   */
-  public function setStream(OutputStream $stream) {
-    $this->redirect($stream);
-  }
-
-  /**
    * Writes text
    *
    * @param  string $text

--- a/src/main/php/io/streams/TextWriter.class.php
+++ b/src/main/php/io/streams/TextWriter.class.php
@@ -47,26 +47,6 @@ class TextWriter extends Writer {
   }
 
   /**
-   * Sets newLine property's bytes
-   *
-   * @deprecated Use withNewLine() instead
-   * @param   string newLine
-   */
-  public function setNewLine($newLine) {
-    $this->newLine= $newLine;
-  }
-  
-  /**
-   * Gets newLine property's bytes
-   *
-   * @deprecated Use newLine() instead
-   * @return  string newLine
-   */
-  public function getNewLine() {
-    return $this->newLine;
-  }
-
-  /**
    * Writes text
    *
    * @param  string $text

--- a/src/main/php/io/streams/Writer.class.php
+++ b/src/main/php/io/streams/Writer.class.php
@@ -36,14 +36,6 @@ abstract class Writer implements OutputStreamWriter, Closeable, Value {
   /**
    * Returns the underlying stream
    *
-   * @deprecated Use stream() instead
-   * @return  io.streams.OutputStream stream
-   */
-  public function getStream() { return $this->stream; }
-
-  /**
-   * Returns the underlying stream
-   *
    * @return  io.streams.OutputStream stream
    */
   public function stream() { return $this->stream; }

--- a/src/test/php/net/xp_framework/unittest/io/streams/TextWriterTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/TextWriterTest.class.php
@@ -75,20 +75,13 @@ class TextWriterTest extends \unittest\TestCase {
 
   #[Test]
   public function unixLineSeparatorIsDefault() {
-    $this->assertEquals("\n", $this->newWriter()->getNewLine());
-  }
-
-  #[Test]
-  public function setNewLine() {
-    $w= $this->newWriter();
-    $w->setNewLine("\r");
-    $this->assertEquals("\r", $w->getNewLine());
+    $this->assertEquals("\n", $this->newWriter()->newLine());
   }
 
   #[Test]
   public function withNewLine() {
     $w= $this->newWriter()->withNewLine("\r");
-    $this->assertEquals("\r", $w->getNewLine());
+    $this->assertEquals("\r", $w->newLine());
   }
 
   #[Test]


### PR DESCRIPTION
Readers and writers

* [x] getStream() -> stream()
* [x] setStream() -> redirect()
* [x] getNewLine() -> newLine()
* [x] setNewLine() -> withNewLine()

All of the replacement methods have existed before, this PR only removes their deprecated aliases!