### PR TITLE
Remove deprecated timezone methods

### DIFF
--- a/src/main/php/util/TimeZone.class.php
+++ b/src/main/php/util/TimeZone.class.php
@@ -58,16 +58,6 @@ class TimeZone implements Value {
   }
 
   /**
-   * Gets the name of the timezone
-   *
-   * @deprecated Use name() instead!
-   * @return  string name
-   */
-  public function getName() {
-    return $this->name();
-  }
-  
-  /**
    * Returns a TimeZone object by a time zone abbreviation.
    *
    * @param  string $abbrev
@@ -100,17 +90,6 @@ class TimeZone implements Value {
   }
 
   /**
-   * Offset as string
-   *
-   * @deprecated Use difference() instead
-   * @param  util.Date $date default NULL
-   * @return string offset
-   */
-  public function getOffset($date= null) {
-    return $this->difference($date);
-  }
-  
-  /**
    * Retrieve whether the timezone does have DST/non-DST mode
    *
    * @return  bool
@@ -132,17 +111,6 @@ class TimeZone implements Value {
     return timezone_offset_get($this->tz, $date instanceof Date ? $date->getHandle() : date_create('now'));
   }
 
-  /**
-   * Offset in seconds
-   *
-   * @deprecated Use offset() instead!
-   * @param   util.Date date default NULL
-   * @return  int offset
-   */
-  public function getOffsetInSeconds($date= null) {
-    return $this->offset($date);
-  }
-  
   /**
    * Translates a date from one timezone to a date of this timezone.
    * The value of the date is not changed by this operation.

--- a/src/main/php/util/TimeZoneTransition.class.php
+++ b/src/main/php/util/TimeZoneTransition.class.php
@@ -87,22 +87,6 @@ class TimeZoneTransition implements Value {
     return self::previousTransition($this->tz, $this->date);
   }
   
-  /**
-   * Gets timezone
-   *
-   * @deprecated Use timezone() instead!
-   * @return util.TimeZone
-   */
-  public function getTz() { return $this->tz; }
-
-  /**
-   * Gets date
-   *
-   * @deprecated Use date() instead!
-   * @return util.Date
-   */
-  public function getDate() { return $this->date; }
-
   /** @return util.TimeZone */
   public function timezone() { return $this->tz; }
 

--- a/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
@@ -74,15 +74,15 @@ class DateTest extends TestCase {
   #[Test]
   public function constructorParseTz() {
     $date= new Date('2007-01-01 01:00:00 Europe/Berlin');
-    $this->assertEquals('Europe/Berlin', $date->getTimeZone()->getName());
+    $this->assertEquals('Europe/Berlin', $date->getTimeZone()->name());
     $this->assertDateEquals('2007-01-01T01:00:00+01:00', $date);
     
     $date= new Date('2007-01-01 01:00:00 Europe/Berlin', new TimeZone('Europe/Athens'));
-    $this->assertEquals('Europe/Berlin', $date->getTimeZone()->getName());
+    $this->assertEquals('Europe/Berlin', $date->getTimeZone()->name());
     $this->assertDateEquals('2007-01-01T01:00:00+01:00', $date);
 
     $date= new Date('2007-01-01 01:00:00', new TimeZone('Europe/Athens'));
-    $this->assertEquals('Europe/Athens', $date->getTimeZone()->getName());
+    $this->assertEquals('Europe/Athens', $date->getTimeZone()->name());
     $this->assertDateEquals('2007-01-01T01:00:00+02:00', $date);
   }
   
@@ -96,10 +96,10 @@ class DateTest extends TestCase {
   #[Test]
   public function constructorParseNoTz() {
     $date= new Date('2007-01-01 01:00:00', new TimeZone('Europe/Athens'));
-    $this->assertEquals('Europe/Athens', $date->getTimeZone()->getName());
+    $this->assertEquals('Europe/Athens', $date->getTimeZone()->name());
     
     $date= new Date('2007-01-01 01:00:00');
-    $this->assertEquals('GMT', $date->getTimeZone()->getName());
+    $this->assertEquals('GMT', $date->getTimeZone()->name());
   }
   
   #[Test]
@@ -191,7 +191,7 @@ class DateTest extends TestCase {
   public function timeZoneSerialization() {
     date_default_timezone_set('Europe/Athens');
     $date= new Date('2007-11-20 21:45:33 Europe/Berlin');
-    $this->assertEquals('Europe/Berlin', $date->getTimeZone()->getName());
+    $this->assertEquals('Europe/Berlin', $date->getTimeZone()->name());
     $this->assertEquals('+0100', $date->getOffset());
     
     $copy= unserialize(serialize($date));
@@ -202,8 +202,8 @@ class DateTest extends TestCase {
   public function handlingOfTimezone() {
     $date= new Date('2007-07-18T09:42:08 Europe/Athens');
 
-    $this->assertEquals('Europe/Athens', $date->getTimeZone()->getName());
-    $this->assertEquals(3 * 3600, $date->getTimeZone()->getOffsetInSeconds($date));
+    $this->assertEquals('Europe/Athens', $date->getTimeZone()->name());
+    $this->assertEquals(3 * 3600, $date->getTimeZone()->offset($date));
   }
 
   /**
@@ -264,7 +264,7 @@ class DateTest extends TestCase {
   #[Test]
   public function testTimestampWithTZ() {
     $d= new Date(328336200, new TimeZone('Australia/Sydney'));
-    $this->assertEquals('Australia/Sydney', $d->getTimeZone()->getName());
+    $this->assertEquals('Australia/Sydney', $d->getTimeZone()->name());
   }
   
   /**
@@ -276,7 +276,7 @@ class DateTest extends TestCase {
   
     // Specific timezone id unknown, can be Europe/Paris, Europe/Berlin, ...
     $date= new Date('1980-05-28 06:30:00+0200');
-    $this->assertNotEquals('GMT', $date->getTimeZone()->getName());
+    $this->assertNotEquals('GMT', $date->getTimeZone()->name());
   }
   
   #[Test]
@@ -346,7 +346,7 @@ class DateTest extends TestCase {
   #[Test]
   public function createDateFromStaticNowFunctionWithZimeZone() {
     $d= Date::now(new TimeZone('Australia/Sydney'));
-    $this->assertEquals('Australia/Sydney', $d->getTimeZone()->getName());
+    $this->assertEquals('Australia/Sydney', $d->getTimeZone()->name());
   }
 
   #[Test]

--- a/src/test/php/net/xp_framework/unittest/util/TimeZoneTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/TimeZoneTest.class.php
@@ -81,48 +81,4 @@ class TimeZoneTest extends TestCase {
   public function unknownTimeZone() {
     new TimeZone('UNKNOWN');
   }
-
-  /** @deprecated */
-  #[Test]
-  public function name_getter() {
-    $this->assertEquals('Europe/Berlin', (new TimeZone('Europe/Berlin'))->getName());
-  }
-
-  /** @deprecated */
-  #[Test]
-  public function offsetDST() {
-    $this->assertEquals('+0200', (new TimeZone('Europe/Berlin'))->getOffset(new Date('2007-08-21')));
-  }
-
-  /** @deprecated */
-  #[Test]
-  public function offsetNoDST() {
-    $this->assertEquals('+0100', (new TimeZone('Europe/Berlin'))->getOffset(new Date('2007-01-21')));
-  }
-
-  /** @deprecated */
-  #[Test]
-  public function offsetWithHalfHourDST() {
-    // Australia/Adelaide is +10:30 in DST
-    $this->assertEquals('+1030', (new TimeZone('Australia/Adelaide'))->getOffset(new Date('2007-01-21')));
-  }
-
-  /** @deprecated */
-  #[Test]
-  public function offsetWithHalfHourNoDST() {
-    // Australia/Adelaide is +09:30 in non-DST
-    $this->assertEquals('+0930', (new TimeZone('Australia/Adelaide'))->getOffset(new Date('2007-08-21')));
-  }
-
-  /** @deprecated */
-  #[Test]
-  public function offsetInSecondsDST() {
-    $this->assertEquals(7200, (new TimeZone('Europe/Berlin'))->getOffsetInSeconds(new Date('2007-08-21')));
-  }
-
-  /** @deprecated */
-  #[Test]
-  public function offsetInSecondsNoDST() {
-    $this->assertEquals(3600, (new TimeZone('Europe/Berlin'))->getOffsetInSeconds(new Date('2007-01-21')));
-  }
 }


### PR DESCRIPTION
TimeZone

* [x] getName() -> name()
* [x] getOffset() -> difference()
* [x] getOffsetInSeconds() -> offset()

TimeZoneTransition

* [x] getTz() -> timezone()
* [x] getDate() -> date()