### PR TITLE
Remove xp::errorAt()

### DIFF
--- a/src/main/php/io/File.class.php
+++ b/src/main/php/io/File.class.php
@@ -386,7 +386,7 @@ class File implements Channel, Value {
    */
   public function eof() {
     $result= feof($this->_fd);
-    if (\xp::errorAt(__FILE__, __LINE__ - 1)) {
+    if (isset(\xp::$errors[__FILE__][__LINE__ - 1])) {
       $e= new IOException('Cannot determine eof of '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -85,17 +85,6 @@ final class xp {
   }
   // }}}
 
-  // {{{ proto var errorAt(string file [, int line])
-  //     Returns errors that occured at the specified position or null
-  static function errorAt($file, $line= -1) {
-    if ($line < 0) {    // If no line is given, check for an error in the file
-      return xp::$errors[$file] ?? null;
-    } else {            // Otherwise, check for an error in the file on a certain line
-      return xp::$errors[$file][$line] ?? null;
-    }
-  }
-  // }}}
-  
   // {{{ proto string version()
   //     Retrieves current XP version
   static function version() {

--- a/src/test/php/net/xp_framework/unittest/core/ErrorsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/ErrorsTest.class.php
@@ -57,24 +57,24 @@ class ErrorsTest extends TestCase {
 
   #[Test]
   public function errorAt_given_a_file_without_error() {
-    $this->assertFalse((bool)\xp::errorAt(__FILE__));
+    $this->assertFalse(isset(\xp::$errors[__FILE__]));
   }
 
   #[Test]
   public function errorAt_given_a_file_with_error() {
     trigger_error('Test error');
-    $this->assertTrue((bool)\xp::errorAt(__FILE__));
+    $this->assertTrue(isset(\xp::$errors[__FILE__]));
   }
 
   #[Test]
   public function errorAt_given_a_file_and_line_without_error() {
-    $this->assertFalse((bool)\xp::errorAt(__FILE__, __LINE__ - 1));
+    $this->assertFalse(isset(\xp::$errors[__FILE__][__LINE__ - 1]));
   }
 
   #[Test]
   public function errorAt_given_a_file_and_line_with_error() {
     trigger_error('Test error');
-    $this->assertTrue((bool)\xp::errorAt(__FILE__, __LINE__ - 1));
+    $this->assertTrue(isset(\xp::$errors[__FILE__][__LINE__ - 1]));
   }
 
   #[Test, Expect(NullPointerException::class)]

--- a/src/test/php/net/xp_framework/unittest/core/XpTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/XpTest.class.php
@@ -2,39 +2,11 @@
 
 use unittest\{Test, TestCase};
 
-/**
- * Tests the <xp> functions
- */
 class XpTest extends TestCase {
 
   #[Test]
   public function version() {
     $this->assertEquals(3, sscanf(\xp::version(), '%d.%d.%d', $series, $major, $minor));
-  }
-
-  #[Test]
-  public function no_error_here() {
-    $this->assertNull(\xp::errorAt(__FILE__));
-  }
-
-  #[Test]
-  public function triggered_error_at_file() {
-    trigger_error('Test');
-    $this->assertEquals(
-      [__LINE__ - 2 => ['Test' => ['class' => NULL, 'method' => 'trigger_error', 'cnt' => 1]]],
-      \xp::errorAt(__FILE__)
-    );
-    \xp::gc();
-  }
-
-  #[Test]
-  public function triggered_error_at_file_and_line() {
-    trigger_error('Test');
-    $this->assertEquals(
-      ['Test' => ['class' => NULL, 'method' => 'trigger_error', 'cnt' => 1]],
-      \xp::errorAt(__FILE__, __LINE__ - 3)
-    );
-    \xp::gc();
   }
 
   #[Test]


### PR DESCRIPTION
This PR removes the `xp::errorAt()` function in favor of directly checking `xp::$errors`. This function is used in *exactly one place* outside of xp-framework/core:

```bash
zip/src/main/php/io/archive/zip/AbstractZipReaderImpl.class.php:145:      if (!\xp::errorAt(__FILE__, __LINE__ - 1)) {
```