### PR TITLE
PSR autoloader and extensions support

### DIFF
--- a/src/main/php/xp/runtime/Code.class.php
+++ b/src/main/php/xp/runtime/Code.class.php
@@ -86,7 +86,7 @@ class Code {
   public function head() {
     return
       ($this->namespace ? 'namespace '.$this->namespace.';' : '').
-      (empty($this->imports) ? '' : 'use '.implode(', ', $this->imports).';')
+      (empty($this->imports) ? '' : 'use '.implode('; use ', $this->imports).';')
     ;
   }
 

--- a/src/main/php/xp/runtime/CouldNotLoadDependencies.class.php
+++ b/src/main/php/xp/runtime/CouldNotLoadDependencies.class.php
@@ -11,6 +11,9 @@ class CouldNotLoadDependencies extends XPException {
     $this->errors= $errors;
   }
 
-  /** Returns module modules */
+  /** Returns errors */
+  public function errors(): array { return $this->errors; }
+
+  /** Returns modules */
   public function modules(): array { return array_keys($this->errors); }
 }

--- a/src/main/php/xp/runtime/Evaluate.class.php
+++ b/src/main/php/xp/runtime/Evaluate.class.php
@@ -33,7 +33,12 @@ class Evaluate {
       $modules= $code->modules();
       $dir= $modules->userDir($code->namespace());
 
-      Console::$err->writeLine("\033[41;1;37mError: ", $e->getMessage(), "\033[0m\n");
+      Console::$err->writeLine("\033[41;1;37mCould not load script dependencies:\033[0m");
+      foreach ($e->errors() as $module => $error) {
+        Console::$err->writeLine('> ', $module, ': ', $error);
+      }
+      Console::$err->writeLine();
+
       Console::$err->writeLine("To install the missing dependencies, use:\n\n\033[36mmkdir -p '", $dir, "'");
       foreach ($e->modules() as $module) {
         $version= $modules->version($module);

--- a/src/main/php/xp/runtime/ExtensionNotLoaded.class.php
+++ b/src/main/php/xp/runtime/ExtensionNotLoaded.class.php
@@ -1,0 +1,16 @@
+<?php namespace xp\runtime;
+
+use lang\XPException;
+
+class ExtensionNotLoaded extends XPException {
+  private $extension;
+
+  /** Creates a new instance */
+  public function __construct(string $extension) {
+    parent::__construct('PHP extension '.$extension.' not loaded');
+    $this->extension= $extension;
+  }
+
+  /** Returns extension */
+  public function extension(): string { return $this->extension; }
+}

--- a/src/main/php/xp/runtime/Modules.class.php
+++ b/src/main/php/xp/runtime/Modules.class.php
@@ -145,7 +145,14 @@ class Modules {
 
       $errors= [];
       foreach ($defines['require'] as $dependency => $version) {
-        if ($e= $this->load($namespace, $dependency, $version)) $errors[$dependency]= $e;
+
+        // PHP extensions vs. userland dependencies
+        if (0 === strncmp($dependency, 'ext-', 4)) {
+          $extension= substr($dependency, 4);
+          extension_loaded($extension) || $errors[$dependency]= new ExtensionNotLoaded($extension);
+        } else {
+          if ($e= $this->load($namespace, $dependency, $version)) $errors[$dependency]= $e;
+        }
       }
       return $errors ? new CouldNotLoadDependencies($errors) : null;
     }

--- a/src/main/php/xp/runtime/Modules.class.php
+++ b/src/main/php/xp/runtime/Modules.class.php
@@ -150,6 +150,15 @@ class Modules {
         });
       }
 
+      // See https://getcomposer.org/doc/04-schema.md#classmap. Classmaps
+      // are generated for libraries and all of their dependencies, ensure
+      // we only it load once.
+      if (isset($defines['autoload']['classmap'])) {
+        if (is_array($map= require_once $base.'../../composer/autoload_classmap.php')) {
+          spl_autoload_register(function($class) use($map) { isset($map[$class]) && require $map[$class]; });
+        }
+      }
+
       $errors= [];
       foreach ($defines['require'] ?? [] as $dependency => $version) {
         if ($e= $this->load($namespace, $dependency, $version)) $errors[$dependency]= $e;

--- a/src/main/php/xp/runtime/Modules.class.php
+++ b/src/main/php/xp/runtime/Modules.class.php
@@ -141,7 +141,7 @@ class Modules {
       // See https://www.php-fig.org/psr/psr-4/: Prefix is stripped, e.g.
       // name\space\Class_Name with prefix "name" => space/Class_Name.php
       foreach ($defines['autoload']['psr-4'] ?? [] as $prefix => $source) {
-        $path= $base.strtr($source, '/', DIRECTORY_SEPARATOR);
+        $path= $base.rtrim(strtr($source, '/', DIRECTORY_SEPARATOR), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
         spl_autoload_register(function($class) use($prefix, $path) {
           $l= strlen($prefix);
           if (0 !== strncmp($class, $prefix, $l)) return false;

--- a/src/main/php/xp/runtime/Modules.class.php
+++ b/src/main/php/xp/runtime/Modules.class.php
@@ -119,7 +119,7 @@ class Modules {
 
       $this->loaded[$module]= true;
       foreach ($defines['autoload']['files'] ?? [] as $file) {
-        require($base.strtr($file, '/', DIRECTORY_SEPARATOR));
+        require $base.strtr($file, '/', DIRECTORY_SEPARATOR);
       }
 
       // See https://www.php-fig.org/psr/psr-0/: Underscores special case, e.g.

--- a/src/main/php/xp/runtime/Modules.class.php
+++ b/src/main/php/xp/runtime/Modules.class.php
@@ -125,7 +125,7 @@ class Modules {
       // See https://www.php-fig.org/psr/psr-0/: Underscores special case, e.g.
       // name\space\Class_Name => name/space/Class/Name.php
       foreach ($defines['autoload']['psr-0'] ?? [] as $prefix => $source) {
-        $path= $base.strtr($source, '/', DIRECTORY_SEPARATOR);
+        $path= $base.rtrim(strtr($source, '/', DIRECTORY_SEPARATOR), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
         spl_autoload_register(function($class) use($prefix, $path) {
           if (0 !== strncmp($class, $prefix, strlen($prefix))) return false;
 

--- a/src/main/php/xp/runtime/Modules.class.php
+++ b/src/main/php/xp/runtime/Modules.class.php
@@ -151,7 +151,7 @@ class Modules {
       }
 
       $errors= [];
-      foreach ($defines['require'] as $dependency => $version) {
+      foreach ($defines['require'] ?? [] as $dependency => $version) {
         if ($e= $this->load($namespace, $dependency, $version)) $errors[$dependency]= $e;
       }
       return $errors ? new CouldNotLoadDependencies($errors) : null;

--- a/src/main/php/xp/runtime/Modules.class.php
+++ b/src/main/php/xp/runtime/Modules.class.php
@@ -134,7 +134,8 @@ class Modules {
             $class= substr($class, $p + 1);
           }
 
-          require $path.strtr($class, '_', DIRECTORY_SEPARATOR).'.php';
+          $f= $path.strtr($class, '_', DIRECTORY_SEPARATOR).'.php';
+          is_file($f) && require $f;
         });
       }
 
@@ -146,7 +147,8 @@ class Modules {
           $l= strlen($prefix);
           if (0 !== strncmp($class, $prefix, $l)) return false;
 
-          require $path.substr(strtr($class, '\\', DIRECTORY_SEPARATOR), $l).'.php';
+          $f= $path.substr(strtr($class, '\\', DIRECTORY_SEPARATOR), $l).'.php';
+          is_file($f) && require $f;
         });
       }
 

--- a/src/test/php/net/xp_framework/unittest/runtime/CodeTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/runtime/CodeTest.class.php
@@ -97,7 +97,7 @@ class CodeTest extends \unittest\TestCase {
 
   #[Test, Values(['use util\Date, util\TimeZone; test()', 'use util\Date; use util\TimeZone; test()', 'use util\{Date, TimeZone}; test()', "use util\Date;\nuse util\TimeZone;\ntest()"])]
   public function head_with_multiple_imports($input) {
-    $this->assertEquals('use util\Date, util\TimeZone;', (new Code($input))->head());
+    $this->assertEquals('use util\Date; use util\TimeZone;', (new Code($input))->head());
   }
 
   #[Test]

--- a/src/test/php/net/xp_framework/unittest/runtime/ModulesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/runtime/ModulesTest.class.php
@@ -99,6 +99,34 @@ class ModulesTest extends TestCase {
   }
 
   #[Test, Values([['"test\\\\": "src/"'], ['"test\\\\": "src"'], ['"test": "src/"'], ['"test": "src"']])]
+  public function requiring_library_with_psr0($definition) {
+    $class= 'PSR0'.crc32($definition);
+    $s= ModulesTest::structure([
+      'test' => ['vendor' => [
+        'thekid' => ['library' => [
+          'composer.json' => '{"autoload": {"psr-0": {'.$definition.'} } }',
+          'src' => ['test' => [
+            "{$class}.php" => "<?php namespace test; class {$class} {
+              public static function loaded() { return true; }
+            }"
+          ]]
+        ]]
+      ]]
+    ]);
+
+    $fixture= newinstance(Modules::class, [], ['userDir' => $s]);
+    $fixture->add('thekid/library');
+    $fixture->require($namespace= 'test');
+
+    try {
+      $this->assertTrue((new XPClass("test\\{$class}"))->getMethod('loaded')->invoke(null));
+    } finally {
+      $loaders= spl_autoload_functions();
+      spl_autoload_unregister($loaders[sizeof($loaders) - 1]);
+    }
+  }
+
+  #[Test, Values([['"test\\\\": "src/"'], ['"test\\\\": "src"'], ['"test": "src/"'], ['"test": "src"']])]
   public function requiring_library_with_psr4($definition) {
     $class= 'PSR4'.crc32($definition);
     $s= ModulesTest::structure([

--- a/src/test/php/net/xp_framework/unittest/runtime/ModulesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/runtime/ModulesTest.class.php
@@ -126,7 +126,7 @@ class ModulesTest extends TestCase {
     }
   }
 
-  #[Test, Values([['"test\\\\": "src/"'], ['"test\\\\": "src"'], ['"test": "src/"'], ['"test": "src"']])]
+  #[Test, Values([['"test\\\\": "src/"'], ['"test\\\\": "src"'], ['"test": "src/"'], ['"test": "src"'], ['"test\\\\": ["lib", "src"]']])]
   public function requiring_library_with_psr0_underscore($definition) {
     $class= 'PSR0U'.crc32($definition);
     $s= ModulesTest::structure([
@@ -154,7 +154,7 @@ class ModulesTest extends TestCase {
     }
   }
 
-  #[Test, Values([['"test\\\\": "src/"'], ['"test\\\\": "src"'], ['"test": "src/"'], ['"test": "src"']])]
+  #[Test, Values([['"test\\\\": "src/"'], ['"test\\\\": "src"'], ['"test": "src/"'], ['"test": "src"'], ['"test\\\\": ["lib", "src"]']])]
   public function requiring_library_with_psr4($definition) {
     $class= 'PSR4'.crc32($definition);
     $s= ModulesTest::structure([

--- a/src/test/php/net/xp_framework/unittest/runtime/ModulesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/runtime/ModulesTest.class.php
@@ -63,6 +63,14 @@ class ModulesTest extends TestCase {
     $fixture->require($namespace= 'test');
   }
 
+  #[Test]
+  public function requiring_extension_works() {
+    $fixture= new Modules();
+    $fixture->add('ext-standard', '*');
+
+    $fixture->require($namespace= 'test');
+  }
+
   #[Test, Expect(CouldNotLoadDependencies::class)]
   public function requiring_non_existant() {
     $fixture= new Modules();
@@ -91,18 +99,30 @@ class ModulesTest extends TestCase {
     $fixture->require($namespace= 'test');
   }
 
-  #[Test, Expect(CouldNotLoadDependencies::class)]
-  public function requiring_library_with_missing_dependencies() {
+  #[Test, Values([['"ext-standard": "*"'], ['"php": ">=7.0"']])]
+  public function requiring_library_with($dependency) {
     $s= ModulesTest::structure([
       'test' => ['vendor' => [
         'thekid' => ['library' => [
-          'composer.json' => '{
-            "require": {
-              "perpetuum/mobile" : "^1.0"
-            }
-          }'
-        ]
-      ]]]
+          'composer.json' => '{"require": {'.$dependency.'} }'
+        ]]
+      ]]
+    ]);
+
+    $fixture= newinstance(Modules::class, [], ['userDir' => $s]);
+    $fixture->add('thekid/library');
+
+    $fixture->require($namespace= 'test');
+  }
+
+  #[Test, Expect(CouldNotLoadDependencies::class), Values([['"perpetuum/mobile": "^1.0"'], ['"ext-magic": "*"']])]
+  public function requiring_library_with_missing($dependency) {
+    $s= ModulesTest::structure([
+      'test' => ['vendor' => [
+        'thekid' => ['library' => [
+          'composer.json' => '{"require": {'.$dependency.'} }'
+        ]]
+      ]]
     ]);
 
     $fixture= newinstance(Modules::class, [], ['userDir' => $s]);


### PR DESCRIPTION
This pull request enables support for [PSR-0](https://www.php-fig.org/psr/psr-0/), [PSR-4](https://www.php-fig.org/psr/psr-4/) and [class map](https://getcomposer.org/doc/04-schema.md#classmap) autoloaders as well as extensions being specified via *composer.json* for XP scripts. The following now works:

```php
<?php

use Smalot\PdfParser\Parser from 'smalot/pdfparser';
use util\cmd\Console;

// See See https://github.com/smalot/pdfparser
$parser= new Parser();
$pdf= $parser->parseFile($argv[1]);

Console::writeLine($pdf->getText());
```

The reason we don't simply use Composer's autoloading mechanism here is that we cannot prevent it from loading XP Framework twice, which currently does not work. 