### PR TITLE
Add support for compact API documentation

### DIFF
--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -611,17 +611,17 @@ class ClassParser {
             DETAIL_ARGUMENTS    => [],
             DETAIL_RETURNS      => null,
             DETAIL_THROWS       => [],
-            DETAIL_COMMENT      => trim(preg_replace('/\n\s+\* ?/', "\n", "\n".substr(
+            DETAIL_COMMENT      => trim(preg_replace(['/\n\s+\* ?/', '/¶/'], "\n", "\n".substr(
               $comment, 
               4,                              // "/**\n"
-              strpos($comment, '* @')- 2      // position of first details token
+              max(strpos($comment, ' | @') - 4, strpos($comment, '* @') - 2)
             ))),
             DETAIL_ANNOTATIONS  => $annotations[0],
             DETAIL_TARGET_ANNO  => $annotations[1]
           ];
           $annotations= [0 => [], 1 => []];
           $matches= null;
-          preg_match_all('/@([a-z]+)\s*([^\r\n]+)?/', $comment, $matches, PREG_SET_ORDER);
+          preg_match_all('/@([a-z]+)\s*([^\r\n\|]+)?/', $comment, $matches, PREG_SET_ORDER);
           $comment= '';
           $arg= 0;
           foreach ($matches as $match) {

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -173,6 +173,24 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[Test]
+  public function compact_notation_with_comment() {
+    $details= $this->parseComment('/** Returns something | @return int */');
+    $this->assertEquals(['Returns something', 'int'], [$details[DETAIL_COMMENT], $details[DETAIL_RETURNS]]);
+  }
+
+  #[Test]
+  public function compact_notation_with_multiline_comment() {
+    $details= $this->parseComment('/** Exits¶Sets code 2 | @return int */');
+    $this->assertEquals(["Exits\nSets code 2", 'int'], [$details[DETAIL_COMMENT], $details[DETAIL_RETURNS]]);
+  }
+
+  #[Test]
+  public function compact_notation_with_two_parameters() {
+    $details= $this->parseComment('/** @param string | @param int */');
+    $this->assertEquals(['string', 'int'], $details[DETAIL_ARGUMENTS]);
+  }
+
+  #[Test]
   public function throwsList() {
     $details= $this->parseComment('
       /**


### PR DESCRIPTION
This pull request makes it possible to generate one-line apidoc comments for XP Compiler. 

## Example

Input using array component types, which PHP doesn't syntactically support:

```php
function main(array<string> $args): int { ... }
```

XP Compiler emits this type as *array*, erasing the component type. However, we still want IDEs and reflective access to pick up the more precise type, so apidoc is emitted. To ensure line number stay intact, we need to emit the comment as a single line on the same line as the function declaration:

```php
/** @param string[] */ function main(array $args): int { ... }
```