### PR TITLE
Fix qualified annotation names

### DIFF
--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang;
 
 use lang\ElementNotFoundException;
-use lang\reflect\{Method, Field, Constructor, Package};
+use lang\reflect\{Method, Field, Constructor, Package, ClassParser};
  
 /**
  * Represents classes. Every instance of an XP class has a method
@@ -702,8 +702,8 @@ class XPClass extends Type {
     $cl= self::_classLoaderFor($class);
     if (!$cl || !($bytes= $cl->loadClassBytes($class))) return null;
 
-    $parser ?? $parser= new \lang\reflect\ClassParser();
-    return \xp::$meta[$class]= $parser->parseDetails($bytes, $class);
+    $parser ?? $parser= new ClassParser();
+    return \xp::$meta[$class]= $parser->parseDetails($bytes);
   }
 
   /**

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -618,9 +618,11 @@ class ClassParser {
 
         case T_EXTENDS:
           if (T_NAME_FULLY_QUALIFIED === $tokens[$i + 2][0]) {
-            $context['parent']= $tokens[$i + 2][0];
-          } else if (T_NAME_QUALIFIED === $tokens[$i + 2][0] || T_STRING === $tokens[$i + 2][0]) {
-            $context['parent']= $context['namespace'].$tokens[$i + 2][0];
+            $context['parent']= $tokens[$i + 2][1];
+          } else if (T_NAME_QUALIFIED === $tokens[$i + 2][0]) {
+            $context['parent']= $context['namespace'].$tokens[$i + 2][1];
+          } else if (T_STRING === $tokens[$i + 2][0]) {
+            $context['parent']= $imports[$tokens[$i + 2][1]] ?? $context['namespace'].$tokens[$i + 2][1];
           } else {
             $context['parent']= '';
             while (T_NS_SEPARATOR === $tokens[$i + 2][0]) {

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -217,14 +217,19 @@ class ClassParser {
         throw new IllegalStateException('In `'.$code.'`: '.ucfirst($error['message']));
       }
       return $func;
-    } else if (T_STRING === $token) {     // constant vs. class::constant
+    } else if (T_STRING === $token) {     // constant vs. class::constant vs. qualified\Name
+      $type= $tokens[$i][1];
+      while (T_NS_SEPARATOR === $tokens[$i + 1][0]) {
+        $type.= '\\'.$tokens[$i + 2][1];
+        $i+= 2;
+      }
       if (T_DOUBLE_COLON === $tokens[$i + 1][0]) {
         $i+= 2;
-        return $this->memberOf($this->resolve($tokens[$i - 2][1], $context, $imports), $tokens[$i], $context);
-      } else if (defined($tokens[$i][1])) {
-        return constant($tokens[$i][1]);
+        return $this->memberOf($this->resolve($type, $context, $imports), $tokens[$i], $context);
+      } else if (defined($type)) {
+        return constant($type);
       } else {
-        throw new ElementNotFoundException('Undefined constant "'.$tokens[$i][1].'"');
+        throw new ElementNotFoundException('Undefined constant "'.$type.'"');
       }
     } else if (T_NEW === $token) {
       $type= '';

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -29,11 +29,12 @@ class ClassParser {
       return strtr(substr($tokens[$i][1], 1), '\\', '.');
     } else if (T_NS_SEPARATOR === $tokens[$i][0]) {
       $type= '';
-      while (T_NS_SEPARATOR === $tokens[$i][0]) {
+      do {
         $type.= '.'.$tokens[$i + 1][1];
         $i+= 2;
-      }
-      $i-= 1;
+      } while (T_NS_SEPARATOR === $tokens[$i][0]);
+
+      $i--; // Position at the last T_STRING token
       return substr($type, 1);
     } else if (T_NAME_QUALIFIED === $tokens[$i][0]) {
       return $context['namespace'].strtr($tokens[$i][1], '\\', '.');

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -39,8 +39,9 @@ class ClassParser {
       return $context['namespace'].strtr($tokens[$i][1], '\\', '.');
     } else if (T_STRING === $tokens[$i][0]) {
       $type= $tokens[$i][1];
-      if ('self' === $type) return $context['self'];
-      if ('parent' === $type) {
+      if ('self' === $type) {
+        return $context['self'];
+      } else if ('parent' === $type) {
         if (isset($context['parent'])) return $context['parent'];
         throw new IllegalStateException('Class does not have a parent');
       }
@@ -50,6 +51,8 @@ class ClassParser {
         $i+= 2;
       }
       return $imports[$type] ?? $context['namespace'].$type;
+    } else if (T_STATIC === $tokens[$i][0]) {
+      return $context['self'];
     } else {
       throw new IllegalStateException(sprintf(
         'Parse error: Unexpected %s',

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -622,7 +622,12 @@ class ClassParser {
           } else if (T_NAME_QUALIFIED === $tokens[$i + 2][0]) {
             $context['parent']= $context['namespace'].$tokens[$i + 2][1];
           } else if (T_STRING === $tokens[$i + 2][0]) {
-            $context['parent']= $imports[$tokens[$i + 2][1]] ?? $context['namespace'].$tokens[$i + 2][1];
+            $parent= $tokens[$i + 2][1];
+            while (T_NS_SEPARATOR === $tokens[$i + 3][0]) {
+              $parent.= '\\'.$tokens[$i + 4][1];
+              $i+= 2;
+            }
+            $context['parent']= $imports[$parent] ?? $context['namespace'].$parent;
           } else {
             $context['parent']= '';
             while (T_NS_SEPARATOR === $tokens[$i + 2][0]) {

--- a/src/test/php/net/xp_framework/unittest/annotations/BrokenAnnotationTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/annotations/BrokenAnnotationTest.class.php
@@ -47,21 +47,6 @@ class BrokenAnnotationTest extends TestCase {
     $this->parse('#[@attribute("value)]');
   }
 
-  #[Test, Expect(['class' => ClassFormatException::class, 'withMessage' => '/Expecting "@"/'])]
-  public function missing_annotation_after_comma_and_value() {
-    $this->parse('#[@ignore("Test"), ]');
-  }
-
-  #[Test, Expect(['class' => ClassFormatException::class, 'withMessage' => '/Expecting "@"/'])]
-  public function missing_annotation_after_comma() {
-    $this->parse('#[@ignore, ]');
-  }
-
-  #[Test, Expect(['class' => ClassFormatException::class, 'withMessage' => '/Expecting "@"/'])]
-  public function missing_annotation_after_second_comma() {
-    $this->parse('#[@ignore, @test, ]');
-  }
-
   #[Test, Expect(['class' => ClassFormatException::class, 'withMessage' => '/Parse error: Unterminated string/'])]
   public function unterminated_dq_string() {
     $this->parse('#[@ignore("Test)]');

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -252,9 +252,9 @@ class ClassDetailsTest extends \unittest\TestCase {
   #[Test]
   public function use_statements_with_alias_evaluated() {
     $actual= (new ClassParser())->parseDetails('<?php namespace test;
-      use net\xp_framework\unittest\Name as Value;
+      use net\xp_framework\unittest\Name as Named;
 
-      #[Value(new Value("test"))]
+      #[Value(new Named("test"))]
       class Test {
       }
     ');

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -38,7 +38,7 @@ class ClassDetailsTest extends \unittest\TestCase {
   public function parses($kind) {
     $details= (new ClassParser())->parseDetails('<?php '.$kind.' Test { }');
     $this->assertEquals(
-      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => [], DETAIL_ARGUMENTS => 'Test'],
+      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => []],
       $details['class']
     );
   }
@@ -329,10 +329,10 @@ class ClassDetailsTest extends \unittest\TestCase {
     $this->assertEquals(['test' => null, 'value' => 'test'], $actual['class'][DETAIL_ANNOTATIONS]);
   }
 
-  #[Test]
-  public function php8_attributes_with_named_arguments() {
-    $actual= (new ClassParser())->parseDetails('<?php
-      #[Expect(class: \net\xp_framework\unittest\Name::class)]
+  #[Test, Values(['\net\xp_framework\unittest\Name', 'unittest\Name'])]
+  public function php8_attributes_with_named_arguments($name) {
+    $actual= (new ClassParser())->parseDetails('<?php namespace net\xp_framework;
+      #[Expect(class: '.$name.'::class)]
       class Test {
       }
     ');
@@ -476,11 +476,13 @@ class ClassDetailsTest extends \unittest\TestCase {
   public function field_initializer_with_class_keyword() {
     $details= (new ClassParser())->parseDetails('<?php
       class Test {
+
+        /** Property */
         private $classes= [self::class, parent::class];
       }
     ');
     $this->assertEquals(
-      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => [], DETAIL_ARGUMENTS => 'Test'],
+      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => []],
       $details['class']
     );
   }
@@ -587,7 +589,7 @@ class ClassDetailsTest extends \unittest\TestCase {
       }
     ');
     $this->assertEquals(
-      [DETAIL_COMMENT => 'Comment', DETAIL_ANNOTATIONS => [], DETAIL_ARGUMENTS => 'Test'],
+      [DETAIL_COMMENT => 'Comment', DETAIL_ANNOTATIONS => []],
       $details['class']
     );
   }

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -467,8 +467,7 @@ class ClassDetailsTest extends \unittest\TestCase {
       class Test {
         #[Fixture(new parent())]
         public function fixture() { }
-      }',
-      Name::class
+      }'
     );
   }
 

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -329,9 +329,11 @@ class ClassDetailsTest extends \unittest\TestCase {
     $this->assertEquals(['test' => null, 'value' => 'test'], $actual['class'][DETAIL_ANNOTATIONS]);
   }
 
-  #[Test, Values(['\net\xp_framework\unittest\Name', 'unittest\Name'])]
+  #[Test, Values(['\net\xp_framework\unittest\Name', 'unittest\Name', 'Name'])]
   public function php8_attributes_with_named_arguments($name) {
     $actual= (new ClassParser())->parseDetails('<?php namespace net\xp_framework;
+      use net\xp_framework\unittest\Name;
+
       #[Expect(class: '.$name.'::class)]
       class Test {
       }
@@ -459,6 +461,19 @@ class ClassDetailsTest extends \unittest\TestCase {
       }
     ');
     $this->assertEquals(['test' => null], $details[0]['fixture'][DETAIL_ANNOTATIONS]);
+  }
+
+  #[Test, Values(['\net\xp_framework\unittest\Name', 'unittest\Name', 'Name'])]
+  public function annotation_with_reference_to($parent) {
+    $details= (new ClassParser())->parseDetails('<?php namespace net\xp_framework;
+      use net\xp_framework\unittest\Name;
+
+      class Test extends '.$parent.' {
+        #[Fixture(new parent("Test"))]
+        public function fixture() { }
+      }'
+    );
+    $this->assertEquals(['fixture' => new Name('Test')], $details[1]['fixture'][DETAIL_ANNOTATIONS]);
   }
 
   #[Test, Expect(['class' => ClassFormatException::class, 'withMessage' => '/Class does not have a parent/'])]

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -320,6 +320,16 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[Test]
+  public function php8_attributes_with_trailing_comma() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[Test, Value("test"),]
+      class Test {
+      }
+    ');
+    $this->assertEquals(['test' => null, 'value' => 'test'], $actual['class'][DETAIL_ANNOTATIONS]);
+  }
+
+  #[Test]
   public function php8_attributes_with_named_arguments() {
     $actual= (new ClassParser())->parseDetails('<?php
       #[Expect(class: \net\xp_framework\unittest\Name::class)]
@@ -337,6 +347,26 @@ class ClassDetailsTest extends \unittest\TestCase {
       }
     ');
     $this->assertEquals('test', $actual['class'][DETAIL_ANNOTATIONS]['value']());
+  }
+
+  #[Test]
+  public function absolute_compound_php8_attributes() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[\unittest\annotations\Test]
+      class Test {
+      }
+    ');
+    $this->assertEquals(['test' => null], $actual['class'][DETAIL_ANNOTATIONS]);
+  }
+
+  #[Test]
+  public function relative_compound_php8_attributes() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[unittest\annotations\Test]
+      class Test {
+      }
+    ');
+    $this->assertEquals(['test' => null], $actual['class'][DETAIL_ANNOTATIONS]);
   }
 
   #[Test]


### PR DESCRIPTION
E.g. `[#\unittest\annotations\Test]` or `[#annotations\Test]`. Includes consistent namespace and imports resolution which did not take annotation names into consideration, and handling of trailing commas inside grouped annotations.