### PR TITLE
Add support for sealed classes and interfaces

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -433,8 +433,8 @@ define('MODIFIER_FINAL',     \ReflectionMethod::IS_FINAL);
 define('MODIFIER_PUBLIC',    \ReflectionMethod::IS_PUBLIC);
 define('MODIFIER_PROTECTED', \ReflectionMethod::IS_PROTECTED);
 define('MODIFIER_PRIVATE',   \ReflectionMethod::IS_PRIVATE);
-define('MODIFIER_READONLY',  128); // PHP 8.1: \ReflectionProperty::IS_READONLY
-define('MODIFIER_SEALED',    256); // PHP 8.2: \ReflectionClass::IS_SEALED
+define('MODIFIER_READONLY',  128);  // PHP 8.1: \ReflectionProperty::IS_READONLY
+define('MODIFIER_SEALED',    2048); // PHP 8.2: \ReflectionClass::IS_SEALED
 
 define('DETAIL_ARGUMENTS',   1);
 define('DETAIL_RETURNS',     2);

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -434,6 +434,7 @@ define('MODIFIER_PUBLIC',    \ReflectionMethod::IS_PUBLIC);
 define('MODIFIER_PROTECTED', \ReflectionMethod::IS_PROTECTED);
 define('MODIFIER_PRIVATE',   \ReflectionMethod::IS_PRIVATE);
 define('MODIFIER_READONLY',  128); // PHP 8.1: \ReflectionProperty::IS_READONLY
+define('MODIFIER_SEALED',    256); // PHP 8.2: \ReflectionClass::IS_SEALED
 
 define('DETAIL_ARGUMENTS',   1);
 define('DETAIL_RETURNS',     2);

--- a/src/main/php/lang/DynamicClassLoader.class.php
+++ b/src/main/php/lang/DynamicClassLoader.class.php
@@ -128,8 +128,8 @@ class DynamicClassLoader extends AbstractClassLoader {
   /**
    * Get package contents
    *
-   * @param   string package
-   * @return  string[] filenames
+   * @param  ?string $package
+   * @return string[]
    */
   public function packageContents($package) {
     return [];

--- a/src/main/php/lang/IClassLoader.class.php
+++ b/src/main/php/lang/IClassLoader.class.php
@@ -8,75 +8,75 @@ interface IClassLoader extends Value {
   /**
    * Checks whether this loader can provide the requested class
    *
-   * @param   string class
-   * @return  bool
+   * @param  string $class
+   * @return bool
    */
   public function providesClass($class);
   
   /**
    * Checks whether this loader can provide the requested resource
    *
-   * @param   string filename
-   * @return  bool
+   * @param  string $filename
+   * @return bool
    */
   public function providesResource($filename);
 
   /**
    * Checks whether this loader can provide the requested package
    *
-   * @param   string package
-   * @return  bool
+   * @param  string $package
+   * @return bool
    */
   public function providesPackage($package);
 
   /**
    * Get package contents
    *
-   * @param   string package
-   * @return  string[] filenames
+   * @param  ?string $package
+   * @return string[]
    */
   public function packageContents($package);
 
   /**
    * Load the class by the specified name
    *
-   * @param   string class fully qualified class name io.File
-   * @return  lang.XPClass
-   * @throws  lang.ClassNotFoundException in case the class can not be found
+   * @param  string $class fully qualified class name
+   * @return lang.XPClass
+   * @throws lang.ClassNotFoundException in case the class can not be found
    */
   public function loadClass($class);
 
   /**
-   * Load the class by the specified name
+   * Load the class by the specified name and return its name
    *
-   * @param   string class fully qualified class name io.File
-   * @return  string class name
-   * @throws  lang.ClassNotFoundException in case the class can not be found
+   * @param  string $class fully qualified class name
+   * @return string
+   * @throws lang.ClassNotFoundException in case the class can not be found
    */
   public function loadClass0($class);
   
   /**
    * Loads a resource.
    *
-   * @param   string string name of resource
-   * @return  string
-   * @throws  lang.ElementNotFoundException in case the resource cannot be found
+   * @param  string $name name of resource
+   * @return string
+   * @throws lang.ElementNotFoundException in case the resource cannot be found
    */
-  public function getResource($string);
+  public function getResource($name);
   
   /**
    * Retrieve a stream to the resource
    *
-   * @param   string string name of resource
-   * @return  io.Stream
-   * @throws  lang.ElementNotFoundException in case the resource cannot be found
+   * @param  string $name name of resource
+   * @return io.File
+   * @throws lang.ElementNotFoundException in case the resource cannot be found
    */
-  public function getResourceAsStream($string);
+  public function getResourceAsStream($name);
 
   /**
    * Returns a unique identifier for this class loader instance
    *
-   * @return  string
+   * @return string
    */
   public function instanceId();
 

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -607,7 +607,10 @@ class XPClass extends Type {
     $m & \ReflectionClass::IS_EXPLICIT_ABSTRACT && $r |= MODIFIER_ABSTRACT;
     $m & \ReflectionClass::IS_IMPLICIT_ABSTRACT && $r |= MODIFIER_ABSTRACT;
     $m & \ReflectionClass::IS_FINAL && $r |= MODIFIER_FINAL;
-    
+
+    // TODO: \ReflectionClass::IS_SEALED once PR is merged
+    if ($this->hasAnnotation('sealed')) $r |= MODIFIER_SEALED;
+
     return $r;
   }
 
@@ -757,6 +760,36 @@ class XPClass extends Type {
       $creator= new GenericTypes();
     }
     return $creator->newType($this, $arguments);
+  }
+
+  /**
+   * Returns subclasses of this sealed class
+   *
+   * @return  self[]
+   * @throws  lang.IllegalStateException if this class is not a sealed definition
+   */
+  public function sealedSubclasses() {
+    if (!$this->isSealedDefinition()) {
+      throw new IllegalStateException('Class '.$this->name.' is not a sealed definition');
+    }
+
+    // TODO: Check for ReflectionClass::getPermittedClasses() once PR is merged
+    $classes= [];
+    foreach ($this->getAnnotation('sealed') as $name) {
+      $classes[]= new self($name);
+    }
+    return $classes;
+  }
+
+  /**
+   * Returns whether this class is a sealed definition
+   *
+   * @return  bool
+   */
+  public function isSealedDefinition(): bool {
+
+    // TODO: Check for ReflectionClass::isSealed() once PR is merged
+    return $this->hasAnnotation('sealed');
   }
 
   /**

--- a/src/main/php/lang/archive/ArchiveClassLoader.class.php
+++ b/src/main/php/lang/archive/ArchiveClassLoader.class.php
@@ -185,8 +185,8 @@ class ArchiveClassLoader extends AbstractClassLoader {
   /**
    * Get package contents
    *
-   * @param   string package
-   * @return  string[] filenames
+   * @param  ?string $package
+   * @return string[]
    */
   public function packageContents($package) {
     $contents= [];

--- a/src/main/php/lang/reflect/Modifiers.class.php
+++ b/src/main/php/lang/reflect/Modifiers.class.php
@@ -82,6 +82,16 @@ abstract class Modifiers {
   }
 
   /**
+   * Returns TRUE when the given modifiers include the sealed modifier.
+   *
+   * @param  int $m
+   * @return bool
+   */
+  public static function isSealed($m) {
+    return MODIFIER_SEALED === ($m & MODIFIER_SEALED);
+  }
+
+  /**
    * Retrieves modifier names as an array. The order in which the 
    * modifiers are returned is the following:
    *
@@ -99,6 +109,7 @@ abstract class Modifiers {
       case MODIFIER_PROTECTED: $names[]= 'protected'; break;
       case MODIFIER_PUBLIC: default: $names[]= 'public'; break;
     }
+    if ($m & MODIFIER_SEALED) $names[]= 'sealed';
     if ($m & MODIFIER_STATIC) $names[]= 'static';
     if ($m & MODIFIER_ABSTRACT) $names[]= 'abstract';
     if ($m & MODIFIER_FINAL) $names[]= 'final';


### PR DESCRIPTION
Based on https://wiki.php.net/rfc/sealed_classes. For PHP versions < 8.2, the following (*also suggested in https://externals.io/message/117350#117356*) is supported:

```php
use lang\Sealed;

#[Sealed([Exception::class, Throwable::class])]
abstract class Throwable {
  // ...
}
```

* [x] Add `lang.XPClass::isSealedDefinition(): bool`
* [x] Add `lang.XPClass::sealedSubclasses(): lang.XPClass[]`
* [x] Add `MODIFIER_SEALED`
* [x] Add `lang.reflect.Modifiers::isSealed()`
* [ ] Add support for `ReflectionClass::IS_SEALED` modifier
* [ ] Add support for `ReflectionClass::isSealed()`
* [ ] Add support for `ReflectionClass::getPermittedClasses()`

See also #304