### PR TITLE
Make all InputStream & OutputStream implementations implement Value

### DIFF
--- a/src/main/php/io/streams/BufferedInputStream.class.php
+++ b/src/main/php/io/streams/BufferedInputStream.class.php
@@ -1,19 +1,24 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * Buffered InputStream
+ *
+ * @test  net.xp_framework.unittest.io.streams.BufferedInputStreamTest
  */
-class BufferedInputStream implements InputStream {
-  protected 
-    $in   = null,
-    $buf  = '',
-    $size = 0;
+class BufferedInputStream implements InputStream, Value {
+  use Comparison;
+
+  protected $in, $size;
+  protected $buf= '';
 
   /**
    * Constructor
    *
-   * @param   io.streams.InputStream in
-   * @param   int size default 512
+   * @param  io.streams.InputStream $in
+   * @param  int $size
    */
   public function __construct($in, $size= 512) {
     $this->in= $in;
@@ -61,6 +66,7 @@ class BufferedInputStream implements InputStream {
    * @return void
    */
   public function close() {
+    // NOOP
   }
 
   /** @return string */

--- a/src/main/php/io/streams/BufferedOutputStream.class.php
+++ b/src/main/php/io/streams/BufferedOutputStream.class.php
@@ -1,16 +1,21 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * OuputStream that writes to another OutputStream but buffers the
  * results internally. This means not every single byte passed to
  * write() will be written.
+ * 
+ * @test  net.xp_framework.unittest.io.streams.BufferedOutputStreamTest
  */
-class BufferedOutputStream implements OutputStream {
-  protected 
-    $out  = null,
-    $buf  = '',
-    $size = 0;
-  
+class BufferedOutputStream implements OutputStream, Value {
+  use Comparison;
+
+  protected $out, $size;
+  protected $buf= '';
+
   /**
    * Constructor
    *

--- a/src/main/php/io/streams/Bz2CompressingOutputStream.class.php
+++ b/src/main/php/io/streams/Bz2CompressingOutputStream.class.php
@@ -1,30 +1,37 @@
 <?php namespace io\streams;
 
+use io\IOException;
+use lang\{Value, IllegalArgumentException};
+use util\Comparison;
+
 /**
  * OuputStream that compresses content using bzip2
  *
  * @ext   bz2
  * @test  xp://net.xp_framework.unittest.io.streams.Bz2CompressingOutputStreamTest
  */
-class Bz2CompressingOutputStream implements OutputStream {
-  protected $out= null;
+class Bz2CompressingOutputStream implements OutputStream, Value {
+  use Comparison;
+
+  protected $out;
   
   /**
    * Constructor
    *
-   * @param   io.streams.OutputStream out
-   * @param   int level default 6
-   * @throws  lang.IllegalArgumentException if the level is not between 0 and 9
+   * @param  io.streams.OutputStream $out
+   * @param  int $level
+   * @throws lang.IllegalArgumentException if the level is not between 0 and 9
    */
   public function __construct(OutputStream $out, $level= 6) {
     if ($level < 0 || $level > 9) {
-      throw new \lang\IllegalArgumentException('Level '.$level.' out of range [0..9]');
+      throw new IllegalArgumentException('Level '.$level.' out of range [0..9]');
     }
+
     $this->out= Streams::writeableFd($out);
     if (!stream_filter_append($this->out, 'bzip2.compress', STREAM_FILTER_WRITE, ['blocks' => $level])) {
       fclose($this->out);
       $this->out= null;
-      throw new \io\IOException('Could not append stream filter');
+      throw new IOException('Could not append stream filter');
     }
   }
   

--- a/src/main/php/io/streams/Bz2DecompressingInputStream.class.php
+++ b/src/main/php/io/streams/Bz2DecompressingInputStream.class.php
@@ -1,23 +1,29 @@
 <?php namespace io\streams;
 
+use io\IOException;
+use lang\Value;
+use util\Comparison;
+
 /**
  * InputStream that decompresses 
  *
  * @ext   bz2
- * @test  xp://net.xp_framework.unittest.io.streams.Bz2DecompressingInputStreamTest
+ * @test  net.xp_framework.unittest.io.streams.Bz2DecompressingInputStreamTest
  */
-class Bz2DecompressingInputStream implements InputStream {
-  protected $in = null;
+class Bz2DecompressingInputStream implements InputStream, Value {
+  use Comparison;
+
+  protected $in;
   
   /**
    * Constructor
    *
-   * @param   io.streams.InputStream in
+   * @param  io.streams.InputStream $in
    */
   public function __construct(InputStream $in) {
     $this->in= Streams::readableFd($in);
     if (!stream_filter_append($this->in, 'bzip2.decompress', STREAM_FILTER_READ)) {
-      throw new \io\IOException('Could not append stream filter');
+      throw new IOException('Could not append stream filter');
     }
   }
 

--- a/src/main/php/io/streams/ChannelInputStream.class.php
+++ b/src/main/php/io/streams/ChannelInputStream.class.php
@@ -15,10 +15,8 @@ use util\Comparison;
 class ChannelInputStream implements InputStream, Value {
   use Comparison;
 
-  protected
-    $name = null,
-    $fd   = null;
-  
+  protected $fd, $name;
+
   /**
    * Constructor
    *
@@ -29,6 +27,7 @@ class ChannelInputStream implements InputStream, Value {
       if (!($this->fd= fopen('php://'.$arg, 'rb'))) {
         throw new IOException('Could not open '.$arg.' channel for reading');
       }
+      $this->name= $arg;
     } else if (is_resource($arg)) {
       $this->fd= $arg;
       $this->name= '#'.(int)$arg;

--- a/src/main/php/io/streams/ChannelInputStream.class.php
+++ b/src/main/php/io/streams/ChannelInputStream.class.php
@@ -1,16 +1,20 @@
 <?php namespace io\streams;
 
 use io\IOException;
+use lang\Value;
+use util\Comparison;
 
 /**
  * Input stream that reads from one of the "stdin", "input" channels
  * provided as PHP input/output streams.
  *
- * @test  xp://net.xp_framework.unittest.io.streams.ChannelStreamTest
+ * @test  net.xp_framework.unittest.io.streams.ChannelStreamTest
  * @see   php://wrappers
- * @see   xp://io.streams.ChannelOutputStream
+ * @see   io.streams.ChannelOutputStream
  */
-class ChannelInputStream implements InputStream {
+class ChannelInputStream implements InputStream, Value {
+  use Comparison;
+
   protected
     $name = null,
     $fd   = null;

--- a/src/main/php/io/streams/ChannelOutputStream.class.php
+++ b/src/main/php/io/streams/ChannelOutputStream.class.php
@@ -1,16 +1,20 @@
 <?php namespace io\streams;
 
 use io\IOException;
+use lang\Value;
+use util\Comparison;
 
 /**
  * Output stream that writes to one of the "stdout", "stderr", "output"
  * channels provided as PHP input/output streams.
  *
- * @test  xp://net.xp_framework.unittest.io.streams.ChannelStreamTest
+ * @test  net.xp_framework.unittest.io.streams.ChannelStreamTest
  * @see   php://wrappers
- * @see   xp://io.streams.ChannelInputStream
+ * @see   io.streams.ChannelInputStream
  */
-class ChannelOutputStream implements OutputStream {
+class ChannelOutputStream implements OutputStream, Value {
+  use Comparison;
+
   protected
     $name = null,
     $fd   = null;

--- a/src/main/php/io/streams/ChannelOutputStream.class.php
+++ b/src/main/php/io/streams/ChannelOutputStream.class.php
@@ -26,8 +26,8 @@ class ChannelOutputStream implements OutputStream, Value {
    */
   public function __construct($arg) {
     if ('stdout' === $arg || 'stderr' === $arg || 'output' === $arg) {
-      if (!($this->fd= fopen('php://'.$arg, 'rb'))) {
-        throw new IOException('Could not open '.$arg.' channel for reading');
+      if (!($this->fd= fopen('php://'.$arg, 'wb'))) {
+        throw new IOException('Could not open '.$arg.' channel for writing');
       }
     } else if (is_resource($arg)) {
       $this->fd= $arg;

--- a/src/main/php/io/streams/ChannelOutputStream.class.php
+++ b/src/main/php/io/streams/ChannelOutputStream.class.php
@@ -15,9 +15,7 @@ use util\Comparison;
 class ChannelOutputStream implements OutputStream, Value {
   use Comparison;
 
-  protected
-    $name = null,
-    $fd   = null;
+  protected $fd, $name;
 
   /**
    * Constructor
@@ -29,6 +27,7 @@ class ChannelOutputStream implements OutputStream, Value {
       if (!($this->fd= fopen('php://'.$arg, 'wb'))) {
         throw new IOException('Could not open '.$arg.' channel for writing');
       }
+      $this->name= $arg;
     } else if (is_resource($arg)) {
       $this->fd= $arg;
       $this->name= '#'.(int)$arg;

--- a/src/main/php/io/streams/ConsoleInputStream.class.php
+++ b/src/main/php/io/streams/ConsoleInputStream.class.php
@@ -1,5 +1,8 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * InputStream that reads from the console
  *
@@ -8,7 +11,9 @@
  * $in= new ConsoleInputStream(STDIN);
  * ```
  */
-class ConsoleInputStream implements InputStream {
+class ConsoleInputStream implements InputStream, Value {
+  use Comparison;
+
   private $descriptor, $close;
   
   /**

--- a/src/main/php/io/streams/ConsoleOutputStream.class.php
+++ b/src/main/php/io/streams/ConsoleOutputStream.class.php
@@ -1,5 +1,8 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * OuputStream that writes to the console
  *
@@ -9,7 +12,9 @@
  * $err= new ConsoleOutputStream(STDERR);
  * ```
  */
-class ConsoleOutputStream implements OutputStream {
+class ConsoleOutputStream implements OutputStream, Value {
+  use Comparison;
+
   private $descriptor, $close;
   
   /**

--- a/src/main/php/io/streams/DeflatingOutputStream.class.php
+++ b/src/main/php/io/streams/DeflatingOutputStream.class.php
@@ -1,12 +1,17 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * OuputStream that deflates 
  *
  * @ext   zlib
- * @test  xp://net.xp_framework.unittest.io.streams.DeflatingOutputStreamTest
+ * @test  net.xp_framework.unittest.io.streams.DeflatingOutputStreamTest
  */
-class DeflatingOutputStream implements OutputStream {
+class DeflatingOutputStream implements OutputStream, Value {
+  use Comparison;
+
   protected $out= null;
   
   /**

--- a/src/main/php/io/streams/FileInputStream.class.php
+++ b/src/main/php/io/streams/FileInputStream.class.php
@@ -1,13 +1,17 @@
 <?php namespace io\streams;
 
 use io\File;
+use lang\Value;
+use util\Comparison;
 
 /**
  * InputStream that reads from a file
  *
  * @test     xp://net.xp_framework.unittest.io.streams.FileInputStreamTest
  */
-class FileInputStream implements InputStream, Seekable {
+class FileInputStream implements InputStream, Seekable, Value {
+  use Comparison;
+
   protected $file;
   
   /**

--- a/src/main/php/io/streams/FileOutputStream.class.php
+++ b/src/main/php/io/streams/FileOutputStream.class.php
@@ -1,13 +1,17 @@
 <?php namespace io\streams;
 
 use io\File;
+use lang\Value;
+use util\Comparison;
 
 /**
  * OuputStream that writes to files
  *
  * @test  xp://net.xp_framework.unittest.io.streams.FileOutputStreamTest
  */
-class FileOutputStream implements OutputStream, Seekable, Truncation {
+class FileOutputStream implements OutputStream, Seekable, Truncation, Value {
+  use Comparison;
+
   protected $file;
   
   /**

--- a/src/main/php/io/streams/GzCompressingOutputStream.class.php
+++ b/src/main/php/io/streams/GzCompressingOutputStream.class.php
@@ -1,5 +1,8 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * OuputStream that compresses content using GZIP encoding. Data
  * produced with this stream can be read with the "gunzip" command
@@ -9,7 +12,9 @@
  * @see   rfc://1952
  * @test  xp://net.xp_framework.unittest.io.streams.GzCompressingOutputStreamTest
  */
-class GzCompressingOutputStream implements OutputStream {
+class GzCompressingOutputStream implements OutputStream, Value {
+  use Comparison;
+
   protected $out= null;
   protected $md= null;
   protected $length= null;

--- a/src/main/php/io/streams/GzDecompressingInputStream.class.php
+++ b/src/main/php/io/streams/GzDecompressingInputStream.class.php
@@ -1,6 +1,8 @@
 <?php namespace io\streams;
 
 use io\IOException;
+use lang\Value;
+use util\Comparison;
 
 /**
  * InputStream that decompresses data compressed using GZIP encoding.
@@ -9,7 +11,9 @@ use io\IOException;
  * @see   rfc://1952
  * @test  xp://net.xp_framework.unittest.io.streams.GzDecompressingInputStreamTest
  */
-class GzDecompressingInputStream implements InputStream {
+class GzDecompressingInputStream implements InputStream, Value {
+  use Comparison;
+
   private $in, $header;
   public static $wrapped= [];
 
@@ -20,7 +24,7 @@ class GzDecompressingInputStream implements InputStream {
       public $context = null;
       
       public function stream_open($path, $mode, $options, $opened_path) {
-        $this->st= \io\streams\GzDecompressingInputStream::$wrapped[$path];
+        $this->st= GzDecompressingInputStream::$wrapped[$path];
         $this->id= $path;
         return true;
       }
@@ -51,7 +55,7 @@ class GzDecompressingInputStream implements InputStream {
       
       public function stream_close() {
         $this->st->close();
-        unset(\io\streams\GzDecompressingInputStream::$wrapped[$this->id]);
+        unset(GzDecompressingInputStream::$wrapped[$this->id]);
       }
     }));
   }

--- a/src/main/php/io/streams/InflatingInputStream.class.php
+++ b/src/main/php/io/streams/InflatingInputStream.class.php
@@ -1,13 +1,18 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * InputStream that inflates 
  *
  * @ext   zlib
- * @test  xp://net.xp_framework.unittest.io.streams.InflatingInputStreamTest
+ * @test  net.xp_framework.unittest.io.streams.InflatingInputStreamTest
  */
-class InflatingInputStream implements InputStream {
-  protected $in = null;
+class InflatingInputStream implements InputStream, Value {
+  use Comparison;
+
+  protected $in;
   
   /**
    * Constructor

--- a/src/main/php/io/streams/MemoryInputStream.class.php
+++ b/src/main/php/io/streams/MemoryInputStream.class.php
@@ -1,11 +1,16 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * InputStream that reads from a given string.
  *
  * @test  net.xp_framework.unittest.io.streams.MemoryInputStreamTest
  */
-class MemoryInputStream implements InputStream, Seekable {
+class MemoryInputStream implements InputStream, Seekable, Value {
+  use Comparison;
+
   protected $pos= 0;
   protected $bytes;
 

--- a/src/main/php/io/streams/MemoryOutputStream.class.php
+++ b/src/main/php/io/streams/MemoryOutputStream.class.php
@@ -1,11 +1,16 @@
 <?php namespace io\streams;
 
+use lang\Value;
+use util\Comparison;
+
 /**
  * OuputStream writes to memory, which can be retrieved via `bytes()`
  *
- * @test  xp://net.xp_framework.unittest.io.streams.MemoryOutputStreamTest
+ * @test  net.xp_framework.unittest.io.streams.MemoryOutputStreamTest
  */
-class MemoryOutputStream implements OutputStream, Seekable, Truncation {
+class MemoryOutputStream implements OutputStream, Seekable, Truncation, Value {
+  use Comparison;
+
   protected $pos, $bytes;
 
   /** @param string $bytes */

--- a/src/test/php/net/xp_framework/unittest/io/streams/ChannelStreamTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/io/streams/ChannelStreamTest.class.php
@@ -130,4 +130,16 @@ class ChannelStreamTest extends \unittest\TestCase {
     }, ['input' => '+OK Piped input']);      
     $this->assertEquals('+OK Piped input', $r['stdout']);
   }
+
+  #[Test]
+  public function input_name() {
+    $s= new ChannelInputStream('input');
+    $this->assertEquals('io.streams.ChannelInputStream(channel=input)', $s->toString());
+  }
+
+  #[Test]
+  public function output_name() {
+    $s= new ChannelOutputStream('output');
+    $this->assertEquals('io.streams.ChannelOutputStream(channel=output)', $s->toString());
+  }
 }


### PR DESCRIPTION
See issue #310

## Before

```bash
$ xp -w 'new \io\streams\FileOutputStream("composer.json")'
io.streams.FileOutputStream {
  *file => io.File(uri= C:\...\core\composer.json, mode= wb)
}
```

## After

```bash
$ xp -w 'new \io\streams\FileOutputStream("composer.json")'
io.streams.FileOutputStream<io.File(uri= C:\...\core\composer.json, mode= wb)>
```