### PR TITLE
Delay expansion of values in property files until values are read

### DIFF
--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\{InputStream, OutputStream, MemoryInputStream, FileInputStream, TextReader};
 use io\{IOException, File};
-use lang\{FormatException, IllegalStateException, ElementNotFoundException};
+use lang\{FormatException, IllegalStateException, Value};
 
 /**
  * An interface to property-files (aka "ini-files")
@@ -25,7 +25,7 @@ use lang\{FormatException, IllegalStateException, ElementNotFoundException};
  * @test    xp://net.xp_framework.unittest.util.FileBasedPropertiesTest
  * @see     php://parse_ini_file
  */
-class Properties implements PropertyAccess {
+class Properties implements PropertyAccess, Value {
   private static $env;
   public $_file, $_data;
   private $expansion= null;
@@ -519,16 +519,28 @@ class Properties implements PropertyAccess {
     unset($this->_data[$section][$key]);
   }
 
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    if ($value instanceof self) {
+
+      // If based on files, and both base on the same file, then they're equal
+      if (null === $this->_data && null === $value->_data) {
+        return $this->_file <=> $value->_file;
+      } else {
+        return Objects::compare($this->_data, $value->_data);
+      }
+    }
+    return 1;
+  }
+
   /** Check if is equal to other object */
   public function equals($cmp): bool {
-    if (!$cmp instanceof self) return false;
-
-    // If based on files, and both base on the same file, then they're equal
-    if (null === $this->_data && null === $cmp->_data) {
-      return $this->_file === $cmp->_file;
-    } else {
-      return Objects::equal($this->_data, $cmp->_data);
-    }
+    return 0 === $this->compareTo($cmp);
   }
 
   /** Creates hashcode */

--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -229,9 +229,10 @@ class Properties implements PropertyAccess, Value {
    */
   public function readSection($name, $default= []) {
     $this->_load();
-    $expansion= $this->expansion ?? self::$env;
+    if (null === ($value= $this->_data[$name] ?? null)) return $default;
 
-    return $expansion->in($this->_data[$name] ?? null) ?? $default;
+    $expansion= $this->expansion ?? self::$env;
+    return $expansion->in($value);
   }
   
   /**
@@ -244,10 +245,10 @@ class Properties implements PropertyAccess, Value {
    */ 
   public function readString($section, $key, $default= '') {
     $this->_load();
-    if (!isset($this->_data[$section][$key])) return $default;
+    if (null === ($value= $this->_data[$section][$key] ?? null)) return $default;
 
     $expansion= $this->expansion ?? self::$env;
-    return $expansion->in($this->_data[$section][$key]);
+    return $expansion->in($value);
   }
   
   /**

--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -1,7 +1,7 @@
 <?php namespace util;
 
-use io\streams\{InputStream, OutputStream, MemoryInputStream, FileInputStream, TextReader};
-use io\{IOException, File};
+use io\File;
+use io\streams\{FileInputStream, OutputStream, TextReader};
 use lang\{FormatException, IllegalStateException, Value};
 
 /**

--- a/src/main/php/util/PropertyExpansion.class.php
+++ b/src/main/php/util/PropertyExpansion.class.php
@@ -36,10 +36,12 @@ class PropertyExpansion {
   /**
    * Expand strings
    *
-   * @param  string $string
+   * @param  ?string|array $value
    * @return string
    */
-  public function in($string) {
+  public function in($value) {
+    if (null === $value) return null;
+
     return preg_replace_callback(
       '/\$\{([^.}]*)\.([^}|]*)(?:\|([^}]*))?\}/',
       function($match) {
@@ -50,7 +52,7 @@ class PropertyExpansion {
         $f= $this->impl[$match[1]];
         return $f($match[2], $match[3] ?? null);
       },
-      $string
+      $value
     );
   }
 }

--- a/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
@@ -350,4 +350,14 @@ abstract class AbstractPropertiesTest extends TestCase {
     putenv('TEST');
     $this->assertEquals(['key' => 'this'], $value);
   }
+
+  #[Test]
+  public function compare_by_data() {
+    $p1= $this->fixture('key=value');
+    $p2= $this->fixture('key=value');
+    $p3= $this->fixture('test=this');
+
+    $this->assertEquals($p1, $p2);
+    $this->assertNotEquals($p1, $p3);
+  }
 }

--- a/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/AbstractPropertiesTest.class.php
@@ -303,7 +303,7 @@ abstract class AbstractPropertiesTest extends TestCase {
 
   #[Test, Expect(FormatException::class)]
   public function resolve_unsupported_type() {
-    $this->fixture('test=${not.supported}');
+    $this->fixture('test=${not.supported}')->readString('section', 'test');
   }
 
   #[Test]
@@ -317,7 +317,7 @@ abstract class AbstractPropertiesTest extends TestCase {
   #[Test, Expect(ElementNotFoundException::class)]
   public function resolve_non_existant_environment_variable() {
     putenv('TEST');
-    $this->fixture('test=${env.TEST}');
+    $this->fixture('test=${env.TEST}')->readString('section', 'test');
   }
 
   #[Test]
@@ -325,5 +325,29 @@ abstract class AbstractPropertiesTest extends TestCase {
     putenv('TEST');
     $value= $this->fixture('test=${env.TEST|this}')->readString('section', 'test');
     $this->assertEquals('this', $value);
+  }
+
+  #[Test]
+  public function resolve_with_sections() {
+    putenv('TEST=this');
+    $value= $this->fixture('test=${env.TEST}')->readSection('section');
+    putenv('TEST');
+    $this->assertEquals(['test' => 'this'], $value);
+  }
+
+  #[Test]
+  public function resolve_with_arrays() {
+    putenv('TEST=this');
+    $value= $this->fixture('test[]=${env.TEST}')->readArray('section', 'test');
+    putenv('TEST');
+    $this->assertEquals(['this'], $value);
+  }
+
+  #[Test]
+  public function resolve_with_maps() {
+    putenv('TEST=this');
+    $value= $this->fixture('test[key]=${env.TEST}')->readMap('section', 'test');
+    putenv('TEST');
+    $this->assertEquals(['key' => 'this'], $value);
   }
 }


### PR DESCRIPTION
This PR prevents invoking toString() on `util.Properties` instances from including potentially secret values, see https://github.com/xp-framework/core/issues/312#issuecomment-1217969070. Also, the class now implements `lang.Value` so its `toString()` method will be correctly called from e.g. `util.Objects::stringOf()`.

## Before

```bash
# Create properties containing an expanded value
$ cat > test.ini
[global]
db.pass={$env.DB_PASS}

# Export the environment variable
$ export DB_PASS=secret!

# Unfortunately, our secret is shown!
$ xp -w '$p= new \util\Properties("test.ini"); $p->reset(); return $p->toString()'
util.Properties(test.ini)@{[global => [db.pass => "secret!"]]}
```

## After

```bash
$ xp -w '$p= new \util\Properties("test.ini"); $p->reset(); return $p->toString()'
util.Properties(test.ini)@{[global => [db.pass => "${env.DB_PASS}"]]}
```