### PR TITLE
Make Type::named() consistent with reflection for nullable union types

### DIFF
--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -344,6 +344,10 @@ class Type implements Value {
         foreach (self::split(substr($name, 1), '|') as $arg) {
           $components[]= self::named($arg, $context);
         }
+        if ($p= array_search(Type::$VOID, $components)) {
+          unset($components[$p]);
+          return new Nullable(new TypeUnion(array_values($components)));
+        }
         return new TypeUnion($components);
       } else if ('&' === $name[0]) {
         $components= [$t];

--- a/src/test/php/net/xp_framework/unittest/core/TypeResolveTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/TypeResolveTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\core;
 
 use Countable;
-use lang\{Type, Primitive, ArrayType, MapType, XPClass, Nullable, ClassNotFoundException};
+use lang\{Type, Primitive, ArrayType, MapType, XPClass, Nullable, ClassNotFoundException, TypeUnion};
 use net\xp_framework\unittest\core\generics\Lookup;
 use unittest\{Test, Values, TestCase};
 
@@ -91,6 +91,22 @@ class TypeResolveTest extends TestCase {
     $this->assertEquals(
       Type::forName('net.xp_framework.unittest.core.generics.Lookup<string, ?>'),
       Type::named('Lookup<string, ?>', $this->context)
+    );
+  }
+
+  #[Test]
+  public function resolve_union() {
+    $this->assertEquals(
+      new TypeUnion([Primitive::$STRING, Primitive::$INT]),
+      Type::named('int|string', $this->context)
+    );
+  }
+
+  #[Test]
+  public function resolve_nullable_union() {
+    $this->assertEquals(
+      new Nullable(new TypeUnion([Primitive::$STRING, Primitive::$INT])),
+      Type::named('int|string|null', $this->context)
     );
   }
 }

--- a/src/test/php/net/xp_framework/unittest/reflection/TypeSyntaxTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/TypeSyntaxTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace net\xp_framework\unittest\reflection;
 
-use lang\{ClassLoader, Primitive, TypeUnion};
+use lang\{ClassLoader, Primitive, Nullable, TypeUnion};
 use unittest\actions\RuntimeVersion;
 use unittest\{Action, Test, TestCase};
 
@@ -55,6 +55,13 @@ class TypeSyntaxTest extends TestCase {
     $d= $this->field('private string|int $fixture;');
     $this->assertEquals(new TypeUnion([Primitive::$STRING, Primitive::$INT]), $d->getType());
     $this->assertEquals('string|int', $d->getTypeName());
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  public function nullable_union_type() {
+    $d= $this->field('private string|int|null $fixture;');
+    $this->assertEquals(new Nullable(new TypeUnion([Primitive::$STRING, Primitive::$INT])), $d->getType());
+    $this->assertEquals('?string|int', $d->getTypeName());
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]


### PR DESCRIPTION
This PR makes `Type::named()` behave consistently with reflection for [nullable union types](https://wiki.php.net/rfc/union_types_v2#nullable_union_types).

## Syntax

```php
interface T { public function fixture(): int|string|null; }

$t= (new XPClass(T::class))->getMethod('fixture')->getReturnType();

// Yields: lang.Nullable<?string|int>
```

## Names

```php
$t= Type::named('int|string|null', []);

// Before: lang.TypeUnion<int|string|void>
// After:  lang.Nullable<?int|string>
```