### PR TITLE
Fix util.TimeZone::hasDst()

### DIFF
--- a/src/main/php/util/TimeZone.class.php
+++ b/src/main/php/util/TimeZone.class.php
@@ -92,10 +92,17 @@ class TimeZone implements Value {
   /**
    * Retrieve whether the timezone does have DST/non-DST mode
    *
-   * @return  bool
+   * @param  ?int $year
+   * @return bool
    */
-  public function hasDst() {
-    return (bool)sizeof(timezone_transitions_get($this->tz));
+  public function hasDst($year= null) {
+    $year ?? $year= idate('Y');
+    $t= timezone_transitions_get($this->tz, gmmktime(0, 0, 0, 1, 1, $year), gmmktime(0, 0, 0, 1, 1, $year + 1));
+
+    // Without DST: [2022-01-01 => UTC]
+    // With DST   : [2022-01-01 => CET, 2022-03-27 => CEST, 2022-10-30 => CET]
+    // With 2*DST : [1945-01-01 => CET, 1945-04-02 => CEST, 1945-05-24 => CEMT, 1945-09-24 => CEST, 1945-11-18 => CET]
+    return sizeof($t) > 1;
   }
 
   /**

--- a/src/test/php/net/xp_framework/unittest/util/TimeZoneTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/TimeZoneTest.class.php
@@ -85,7 +85,7 @@ class TimeZoneTest extends TestCase {
     new TimeZone('UNKNOWN');
   }
 
-  #[Test, Values([['Europe/Berlin', 2022, true], ['Europe/Berlin', 1977, false], ['Europe/Berlin', 1945, true], ['Atlantic/Reykjavik', 2022, false], ['Atlantic/Reykjavik', 1966, true], ['UTC', 2022, false]])]
+  #[Test, Values([['Europe/Berlin', 2022, true], ['Europe/Berlin', 1977, false], ['Europe/Berlin', 1945, true], ['Atlantic/Reykjavik', 2022, false], ['UTC', 2022, false]])]
   public function has_dst($name, $year, $expected) {
     $this->assertEquals($expected, TimeZone::getByName($name)->hasDst($year));
   }

--- a/src/test/php/net/xp_framework/unittest/util/TimeZoneTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/TimeZoneTest.class.php
@@ -85,6 +85,11 @@ class TimeZoneTest extends TestCase {
     new TimeZone('UNKNOWN');
   }
 
+  #[Test, Values([['Europe/Berlin', 2022, true], ['Europe/Berlin', 1977, false], ['Europe/Berlin', 1945, true], ['Atlantic/Reykjavik', 2022, false], ['Atlantic/Reykjavik', 1966, true], ['UTC', 2022, false]])]
+  public function has_dst($name, $year, $expected) {
+    $this->assertEquals($expected, TimeZone::getByName($name)->hasDst($year));
+  }
+
   #[Test]
   public function name_used_as_hashcode() {
     $this->assertEquals(


### PR DESCRIPTION
The `util.TimeZone::hasDst()` method was broken in multiple ways:

* First of all, it was always returning *true* - `timezone_transitions_get()` always returns at least one element
* Second, whether or not a timezone has daylight savings time depends on the year
* Third, odd situations like [Berlin, 1945](https://www.timeanddate.de/stadt/zeitumstellung/deutschland/berlin?year=1945) were not handled at all