### PR TITLE
Defer `date.timezone` checks until the util.Date class is used

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -412,9 +412,6 @@ if (!function_exists('enum_exists')) {
 // {{{ main
 error_reporting(E_ALL);
 set_error_handler('__error');
-if (!date_default_timezone_set(ltrim(get_cfg_var('date.timezone'), ':'))) {
-  throw new \Exception('[xp::core] date.timezone not configured properly.', 0x3d);
-}
 
 // If iconv is not available but mbstring is, create snap-in replacements
 if (!defined('ICONV_IMPL')) {

--- a/src/main/php/util/Date.class.php
+++ b/src/main/php/util/Date.class.php
@@ -5,7 +5,7 @@ use lang\{IllegalArgumentException, IllegalStateException, Value};
 /**
  * The class Date represents a specific instant in time.
  *
- * @test  xp://net.xp_framework.unittest.util.DateTest
+ * @test  net.xp_framework.unittest.util.DateTest
  */
 class Date implements Value {
   const DEFAULT_FORMAT= 'Y-m-d H:i:sO';
@@ -36,8 +36,8 @@ class Date implements Value {
    * - If no timezone has been given as second parameter, the system's default
    *   timezone is used.
    *
-   * @param  int|string|php.DateTime $in
-   * @param  string $timezone default NULL string of timezone
+   * @param  ?int|string|php.DateTime $in
+   * @param  util.TimeZone $timezone default NULL string of timezone
    * @throws lang.IllegalArgumentException in case the date is unparseable
    */
   public function __construct($in= null, TimeZone $timezone= null) {

--- a/src/main/php/util/Date.class.php
+++ b/src/main/php/util/Date.class.php
@@ -1,17 +1,23 @@
 <?php namespace util;
 
-use lang\IllegalArgumentException;
+use lang\{IllegalArgumentException, IllegalStateException, Value};
 
 /**
  * The class Date represents a specific instant in time.
  *
  * @test  xp://net.xp_framework.unittest.util.DateTest
  */
-class Date implements \lang\Value {
+class Date implements Value {
   const DEFAULT_FORMAT= 'Y-m-d H:i:sO';
 
   /** @type php.DateTime */
   private $handle;
+
+  static function __static() {
+    if (!date_default_timezone_set(ltrim(get_cfg_var('date.timezone'), ':'))) {
+      throw new IllegalStateException('[xp::core] date.timezone not configured properly.');
+    }
+  }
 
   /**
    * Constructor. Creates a new date object through either a

--- a/src/test/php/net/xp_framework/unittest/core/BootstrapTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/core/BootstrapTest.class.php
@@ -61,7 +61,7 @@ class BootstrapTest extends \unittest\TestCase {
 
   #[Test, Values(['', 'Foo/Bar'])]
   public function invalid_timezone($tz) {
-    $r= $this->runWith(Runtime::getInstance()->startupOptions()->withSetting('date.timezone', $tz));
+    $r= $this->runWith(Runtime::getInstance()->startupOptions()->withSetting('date.timezone', $tz), 'new \util\Date();');
     $this->assertTrue(
       (bool)strstr($r[1].$r[2], '[xp::core] date.timezone not configured properly.'),
       Objects::stringOf(['out' => $r[1], 'err' => $r[2]])


### PR DESCRIPTION
Currently, the XP Framework checks whether `date.timezone` is configured properly to ensure all the date functionality works as expected; and raises an exception during bootstrapping if not. This prevents any XP core functionality, even those not reliant on dates, from working if no timezone is set. This pull request moves the check to the static initializer for `util.Date`.

/cc @mikey179