### PR TITLE
Support `eval` array notation inside attributes

### DIFF
--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -355,8 +355,16 @@ class ClassParser {
 
             if ('eval' === $key) {              // Attribute(eval: '...') vs. Attribute(name: ...)
               while ($i++ < $s && ':' === $tokens[$i] || T_WHITESPACE === $tokens[$i][0]) { }
+
               $code= $this->value($tokens, $i, $context, $imports);
-              $eval= token_get_all('<?php '.$code);
+              if (is_string($code)) {
+                $eval= token_get_all('<?php '.$code);
+              } else if (1 === sizeof($code)) {
+                $eval= token_get_all('<?php '.current($code));
+              } else {
+                throw new IllegalStateException('Unexpected "," in eval');
+              }
+
               $j= 1;
               $value= $this->value($eval, $j, $context, $imports);
             } else {

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -359,12 +359,16 @@ class ClassParser {
               $code= $this->value($tokens, $i, $context, $imports);
               if (is_string($code)) {
                 $eval= token_get_all('<?php '.$code);
+              } else if (is_string(key($code))) {
+                $pairs= '';
+                foreach ($code as $named => $expr) {
+                  $pairs.= "'".strtr($named, ["'" => "\\'"])."'=>{$expr},";
+                }
+                $eval= token_get_all('<?php ['.$pairs.']');
               } else if (1 !== sizeof($code)) {
                 throw new IllegalStateException('Unexpected "," in eval');
-              } else if (0 === key($code)) {
-                $eval= token_get_all('<?php '.current($code));
               } else {
-                $eval= token_get_all('<?php [\''.strtr(key($code), ["'" => "\\'"]).'\'=>'.current($code).']');
+                $eval= token_get_all('<?php '.current($code));
               }
 
               $j= 1;

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -359,10 +359,12 @@ class ClassParser {
               $code= $this->value($tokens, $i, $context, $imports);
               if (is_string($code)) {
                 $eval= token_get_all('<?php '.$code);
-              } else if (1 === sizeof($code)) {
+              } else if (1 !== sizeof($code)) {
+                throw new IllegalStateException('Unexpected "," in eval');
+              } else if (0 === key($code)) {
                 $eval= token_get_all('<?php '.current($code));
               } else {
-                throw new IllegalStateException('Unexpected "," in eval');
+                $eval= token_get_all('<?php [\''.strtr(key($code), ["'" => "\\'"]).'\'=>'.current($code).']');
               }
 
               $j= 1;

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -362,6 +362,16 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[Test]
+  public function php8_attributes_with_named_array_eval_argument() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[Value(eval: ["func" => "function() { return \"test\"; }"])]
+      class Test {
+      }
+    ');
+    $this->assertEquals('test', $actual['class'][DETAIL_ANNOTATIONS]['value']['func']());
+  }
+
+  #[Test]
   public function absolute_compound_php8_attributes() {
     $actual= (new ClassParser())->parseDetails('<?php
       #[\unittest\annotations\Test]

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -352,6 +352,16 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[Test]
+  public function php8_attributes_with_array_eval_argument() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[Value(eval: ["function() { return \"test\"; }"])]
+      class Test {
+      }
+    ');
+    $this->assertEquals('test', $actual['class'][DETAIL_ANNOTATIONS]['value']());
+  }
+
+  #[Test]
   public function absolute_compound_php8_attributes() {
     $actual= (new ClassParser())->parseDetails('<?php
       #[\unittest\annotations\Test]
@@ -369,6 +379,24 @@ class ClassDetailsTest extends \unittest\TestCase {
       }
     ');
     $this->assertEquals(['test' => null], $actual['class'][DETAIL_ANNOTATIONS]);
+  }
+
+  #[Test, Expect(class: ClassFormatException::class, withMessage: 'Unexpected ","')]
+  public function php8_attributes_cannot_have_multiple_arguments() {
+    (new ClassParser())->parseDetails('<?php
+      #[Value(1, 2)]
+      class Test {
+      }
+    ');
+  }
+
+  #[Test, Expect(class: ClassFormatException::class, withMessage: 'Unexpected "," in eval')]
+  public function array_eval_cannot_have_multiple_arguments() {
+    (new ClassParser())->parseDetails('<?php
+      #[Value(eval: ["1", "2"])]
+      class Test {
+      }
+    ');
   }
 
   #[Test]

--- a/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/reflection/ClassDetailsTest.class.php
@@ -372,6 +372,16 @@ class ClassDetailsTest extends \unittest\TestCase {
   }
 
   #[Test]
+  public function php8_attributes_with_multiple_named_array_eval_arguments() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[Value(eval: ["one" => "1", "two" => "2"])]
+      class Test {
+      }
+    ');
+    $this->assertEquals(['one' => 1, 'two' => 2], $actual['class'][DETAIL_ANNOTATIONS]['value']);
+  }
+
+  #[Test]
   public function absolute_compound_php8_attributes() {
     $actual= (new ClassParser())->parseDetails('<?php
       #[\unittest\annotations\Test]


### PR DESCRIPTION
This pull request makes it possible to use array notation inside attributes as follows:

```php
// Currently supported
#[Callback(eval: 'fn() => ...')]
class A { }

(new XPClass(A::class))->getAnnotation('callback'); // Closure{}

// Additionally supported
#[Callback(eval: ['fn() => ...'])]
class B { }

(new XPClass(B::class))->getAnnotation('callback'); // Closure{}

// Using named arguments
#[Callback(eval: ['function' => 'fn() => ...'])]
class C { }

(new XPClass(C::class))->getAnnotation('callback'); // ['function' => Closure{}]
```

Together with xp-framework/reflection#35, this is a prerequisite for extracting reflection code as proposed by xp-framework/rfc#338.

* * * 
⚠️ This does not offer full support because the XP Framework core annotation API is built around a *single-value* paradigm instead of *multiple arguments*. The following raises an exception:

```php
// Unsupported
#[Callbacks(eval: ['fn() => ...', 'fn() => ...'])]
class A { }

(new XPClass(A::class))->getAnnotation('callbacks'); // *** Parse error
```
...just like PHP 8 attributes with multiple arguments do.

👉 However, this PR makes it possible to use array notation for single values or multiple named arguments without risking `ClassFormatException`s, ensuring partial compatibility.
* * * 
It also enables us to emit simpler code in the XP Compiler, where we current have a special-case handling for when exactly one unnamed argument exists. The simplification that can be applied there is along the lines of the following:

```diff
- if (1 === sizeof($annotation->arguments) && 0 === key($annotation->arguments)) {
-   // ...
- } else {
-   foreach ($annotation->arguments as $key => $argument) {
-     // ...
-   }
- }
+ foreach ($annotation->arguments as $key => $argument) {
+   // ...
+ }
```