### PR TITLE
Use random_int() instead of mt_rand()

### DIFF
--- a/src/main/php/util/UUID.class.php
+++ b/src/main/php/util/UUID.class.php
@@ -56,11 +56,7 @@ use lang\FormatException;
 class UUID implements \lang\Value {
   const FORMAT = '%04x%04x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x';
 
-  public static
-    $NS_DNS                       = null,
-    $NS_URL                       = null,
-    $NS_OID                       = null,
-    $NS_X500                      = null;
+  public static $NS_DNS, $NS_URL, $NS_OID, $NS_X500;
 
   public
     $time_low                     = 0,
@@ -83,8 +79,8 @@ class UUID implements \lang\Value {
   /**
    * Create a UUID
    *
-   * @param   var $arg
-   * @throws  lang.FormatException in case str is not a valid UUID string
+   * @param  string|int[]|util.Bytes $arg
+   * @throws lang.FormatException in case str is not a valid UUID string
    */
   public function __construct($arg) {
     if ($arg instanceof Bytes) {
@@ -107,7 +103,8 @@ class UUID implements \lang\Value {
   /**
    * Populate instance members from a given string
    *
-   * @param   string
+   * @param  string
+   * @return void
    */
   private function populate($str) {
 
@@ -139,8 +136,8 @@ class UUID implements \lang\Value {
   /**
    * Create a version 1 UUID based upon time stamp and node identifier
    *
-   * @return  util.UUID
-   * @see     http://www.ietf.org/internet-drafts/draft-mealling-uuid-urn-00.txt section 4.1.4
+   * @see    https://datatracker.ietf.org/doc/rfc4122/ section 4.1.4
+   * @return self
    */
   public static function timeUUID() {
 
@@ -170,9 +167,9 @@ class UUID implements \lang\Value {
   /**
    * Create a version 3 UUID based upon a name and a given namespace
    *
-   * @param   util.UUID namespace
-   * @param   string name
-   * @return  util.UUID
+   * @param  self $namespace
+   * @param  string $name
+   * @return self
    */
   public static function md5UUID(self $namespace, $name) {
     $bytes= md5($namespace->getBytes().iconv(\xp::ENCODING, 'utf-8', $name));
@@ -190,9 +187,9 @@ class UUID implements \lang\Value {
   /**
    * Create a version 5 UUID based upon a name and a given namespace
    *
-   * @param   util.UUID namespace
-   * @param   string name
-   * @return  util.UUID
+   * @param  self $namespace
+   * @param  string $name
+   * @return self
    */
   public static function sha1UUID(self $namespace, $name) {
     $bytes= sha1($namespace->getBytes().iconv(\xp::ENCODING, 'utf-8', $name));
@@ -210,7 +207,7 @@ class UUID implements \lang\Value {
   /**
    * Create a version 4 UUID based upon random bits
    *
-   * @return  util.UUID
+   * @return self
    */
   public static function randomUUID() {
     return new self([
@@ -229,7 +226,7 @@ class UUID implements \lang\Value {
   /**
    * Returns version
    *
-   * @return  int
+   * @return int
    */
   public function version() {
     return $this->version;
@@ -238,7 +235,7 @@ class UUID implements \lang\Value {
   /**
    * Get bytes
    *
-   * @return  util.Bytes
+   * @return util.Bytes
    */
   public function getBytes() {
     return new Bytes(pack('H32', str_replace('-', '', $this->hashCode())));
@@ -247,18 +244,18 @@ class UUID implements \lang\Value {
   /**
    * Creates a urn representation
    *
-   * @return  string
+   * @return string
    */
   public function getUrn() {
     return 'urn:uuid:'.$this->hashCode();
   }
-  
+
   /**
    * Creates a string representation. 
    *
    * Example: `{f81d4fae-7dec-11d0-a765-00a0c91e6bf6}`
    *
-   * @return  string
+   * @return string
    */
   public function toString() {
     return '{'.$this->hashCode().'}';
@@ -269,7 +266,7 @@ class UUID implements \lang\Value {
    *
    * Example: `f81d4fae-7dec-11d0-a765-00a0c91e6bf6`
    *
-   * @return  string
+   * @return string
    */
   public function hashCode() {
     $r= (int)($this->time_low / 0x10000);

--- a/src/main/php/util/UUID.class.php
+++ b/src/main/php/util/UUID.class.php
@@ -147,7 +147,7 @@ class UUID implements \lang\Value {
     // Get timestamp and convert it to UTC (based Oct 15, 1582).
     sscanf(microtime(), '%f %d', $usec, $sec);
     $t= ($sec * 10000000) + ($usec * 10) + 122192928000000000;
-    $clock_seq= mt_rand();
+    $clock_seq= random_int(0, 2147483647);
     $h= md5(php_uname());
 
     return new self([
@@ -215,12 +215,12 @@ class UUID implements \lang\Value {
   public static function randomUUID() {
     return new self([
       4,
-      mt_rand(0, 0xffff) * 0x10000 + mt_rand(0, 0xffff),
-      mt_rand(0, 0xffff),
-      mt_rand(0, 0x0fff),
-      mt_rand(0, 0x3fff) | 0x8000,
+      random_int(0, 0xffff) * 0x10000 + random_int(0, 0xffff),
+      random_int(0, 0xffff),
+      random_int(0, 0x0fff),
+      random_int(0, 0x3fff) | 0x8000,
       sscanf(
-        sprintf('%04x%04x%04x', mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)),
+        sprintf('%04x%04x%04x', random_int(0, 0xffff), random_int(0, 0xffff), random_int(0, 0xffff)),
         '%02x%02x%02x%02x%02x%02x'
       )
     ]);

--- a/src/main/php/util/UUID.class.php
+++ b/src/main/php/util/UUID.class.php
@@ -49,9 +49,8 @@ use lang\FormatException;
  * $uuid->getBytes(); // new Bytes("k\xa7\xb8\x11\x9d\xad\x11\xd1\x80\xb4\x00\xc0O\xd40\xc8")
  * ```
  *
- * @test  xp://net.xp_framework.unittest.util.UUIDTest
- * @see   rfc://4122
- * @see   http://www.ietf.org/internet-drafts/draft-mealling-uuid-urn-00.txt
+ * @see   https://datatracker.ietf.org/doc/rfc4122/
+ * @test  net.xp_framework.unittest.util.UUIDTest
  */
 class UUID implements \lang\Value {
   const FORMAT = '%04x%04x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x';
@@ -136,7 +135,6 @@ class UUID implements \lang\Value {
   /**
    * Create a version 1 UUID based upon time stamp and node identifier
    *
-   * @see    https://datatracker.ietf.org/doc/rfc4122/ section 4.1.4
    * @return self
    */
   public static function timeUUID() {

--- a/src/main/php/util/UUID.class.php
+++ b/src/main/php/util/UUID.class.php
@@ -1,6 +1,6 @@
 <?php namespace util;
 
-use lang\FormatException;
+use lang\{FormatException, Value};
 
 /**
  * Encapsulates UUIDs (Universally Unique IDentifiers), also known as
@@ -52,7 +52,7 @@ use lang\FormatException;
  * @see   https://datatracker.ietf.org/doc/rfc4122/
  * @test  net.xp_framework.unittest.util.UUIDTest
  */
-class UUID implements \lang\Value {
+class UUID implements Value {
   const FORMAT = '%04x%04x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x';
 
   public static $NS_DNS, $NS_URL, $NS_OID, $NS_X500;


### PR DESCRIPTION
> As an example a [GitHub Search](https://github.com/search?q=%22four+most+significant+bits+holds+version+number+4%22+language%3APHP&type=code&l=PHP) reveals that UUIDv4 implementations based on a [highly-voted Y2010 StackOverflow answer](https://stackoverflow.com/a/2040279) that uses [mt_rand](http://www.php.net/mt_rand)() are not uncommon, as per above, UUID collisions are expected after 80000 requests if nothing else uses randomness within the request.
> [...]
> To clean up the API and to guide developers to better alternatives, the global Mt19937 should be deprecated and then removed. The function-based API will then provide just the random_int() function which is the “secure by default” choice based on the CSPRNG

See https://wiki.php.net/rfc/deprecations_php_8_3#global_mersenne_twister