### PR TITLE
Deprecate Random::MTRAND

### DIFF
--- a/src/main/php/util/Random.class.php
+++ b/src/main/php/util/Random.class.php
@@ -43,9 +43,6 @@ class Random {
     if (function_exists('openssl_random_pseudo_bytes')) {
       self::$sources[self::OPENSSL]= ['bytes' => [self::class, self::OPENSSL], 'ints' => null];
     }
-
-    // The Mersenne Twister algorithm is always available but deprecated
-    self::$sources[self::MTRAND]= ['bytes' => [self::class, self::MTRAND], 'ints' => 'mt_rand'];
   }
 
   /**
@@ -60,6 +57,12 @@ class Random {
       if (isset(self::$sources[$source])) {
         $this->bytes= self::$sources[$source]['bytes'];
         $this->ints= self::$sources[$source]['ints'] ?: [$this, 'random'];
+        $this->source= $source;
+        return;
+      } else if (self::MTRAND === $source) {
+        trigger_error('MT19937 is deprecated', E_USER_DEPRECATED);
+        $this->bytes= [self::class, self::MTRAND];
+        $this->ints= 'mt_rand';
         $this->source= $source;
         return;
       }

--- a/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
@@ -62,9 +62,11 @@ class RandomTest extends TestCase {
     $this->assertEquals(20, (new Random(Random::URANDOM))->bytes(20)->size());
   }
 
+  /** @deprecated */
   #[Test]
   public function mtrand_bytes() {
     $this->assertEquals(20, (new Random(Random::MTRAND))->bytes(20)->size());
+    \xp::gc();
   }
 
   #[Test, Expect(IllegalArgumentException::class), Values([-1, 0])]
@@ -102,10 +104,12 @@ class RandomTest extends TestCase {
     $this->assertTrue($random >= 0 && $random <= 10);
   }
 
+  /** @deprecated */
   #[Test]
   public function mtrand_int() {
     $random= (new Random(Random::MTRAND))->int(0, 10);
     $this->assertTrue($random >= 0 && $random <= 10);
+    \xp::gc();
   }
 
   #[Test, Expect(IllegalArgumentException::class), Values([10, 11])]

--- a/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
+++ b/src/test/php/net/xp_framework/unittest/util/RandomTest.class.php
@@ -47,7 +47,7 @@ class RandomTest extends TestCase {
     $this->assertEquals(20, (new Random(Random::FAST))->bytes(20)->size());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(function() { return (function_exists("random_bytes") || function_exists("openssl_random_pseudo_bytes"));})')]
+  #[Test]
   public function secure_bytes() {
     $this->assertEquals(20, (new Random(Random::SECURE))->bytes(20)->size());
   }


### PR DESCRIPTION
## Motivation

> As an example a [GitHub Search](https://github.com/search?q=%22four+most+significant+bits+holds+version+number+4%22+language%3APHP&type=code&l=PHP) reveals that UUIDv4 implementations based on a [highly-voted Y2010 StackOverflow answer](https://stackoverflow.com/a/2040279) that uses [mt_rand](http://www.php.net/mt_rand)() are not uncommon, as per above, UUID collisions are expected after 80000 requests if nothing else uses randomness within the request.
> [...]
> To clean up the API and to guide developers to better alternatives, the global Mt19937 should be deprecated and then removed. The function-based API will then provide just the random_int() function which is the “secure by default” choice based on the CSPRNG

See https://wiki.php.net/rfc/deprecations_php_8_3#global_mersenne_twister

## Effect

`Random::MTRAND` is only ever used if *explicitely* specified as a source to the `util.Random` constructor. The sources `::SECURE`, `::FAST` and `::BEST` are all aliased to `random_bytes()` / `random_int()`.

## Future scope

We can incorporate PHP 8.2's https://www.php.net/manual/de/class.random-randomizer.php class and its engines as a source, see https://wiki.php.net/rfc/rng_extension