### PR TITLE
Store original attribute names in DETAIL_TARGET_ANNO

### DIFF
--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -318,6 +318,7 @@ class ClassParser {
           } else {
             $type= $this->type($tokens, $i, $context, $imports);
             $annotation= lcfirst(false === ($p= strrpos($type, '.')) ? $type : substr($type, $p + 1));
+            $annotations[1][$annotation]= $type;
             $param= null;
             $value= null;
             $state= 1;
@@ -582,7 +583,8 @@ class ClassParser {
               4,                              // "/**\n"
               strpos($comment, '* @')- 2      // position of first details token
             ))),
-            DETAIL_ANNOTATIONS  => $annotations[0]
+            DETAIL_ANNOTATIONS  => $annotations[0],
+            DETAIL_TARGET_ANNO  => $annotations[1]
           ];
           $annotations= [0 => [], 1 => []];
           $comment= '';
@@ -599,7 +601,7 @@ class ClassParser {
             $parsed= '';
           }
           $f= substr($tokens[$i][1], 1);
-          $details[0][$f]= [DETAIL_ANNOTATIONS => $annotations[0]];
+          $details[0][$f]= [DETAIL_ANNOTATIONS => $annotations[0], DETAIL_TARGET_ANNO  => $annotations[1]];
           $annotations= [0 => [], 1 => []];
           $matches= null;
           if ('' === $comment) break;

--- a/src/main/php/lang/reflect/ClassParser.class.php
+++ b/src/main/php/lang/reflect/ClassParser.class.php
@@ -675,12 +675,14 @@ class ClassParser {
                 }
               }
             } else if (T_VARIABLE === $tokens[$i][0] && null !== $parsed) {
-              $details[1][$m][DETAIL_TARGET_ANNO][$tokens[$i][1]]= $this->parseAnnotations(
+              $annotations= $this->parseAnnotations(
                 $parsed,
                 $context,
                 $imports,
                 $tokens[$i][2] ?? -1
-              )[0];
+              );
+              $details[1][$m][DETAIL_TARGET_ANNO][$tokens[$i][1]]= $annotations[0];
+              $details[1][$m][DETAIL_TARGET_ANNO]+= $annotations[1];
               $parsed= null;
             }
           }

--- a/src/test/php/lang/unittest/AnnotationParsingTest.class.php
+++ b/src/test/php/lang/unittest/AnnotationParsingTest.class.php
@@ -213,7 +213,7 @@ class AnnotationParsingTest extends AbstractAnnotationParsingTest {
         'lang.unittest.SecondInterceptor',
       ]]], 1 => []],
       $this->parse("
-        #[Interceptors(['classes' => [
+        #[@interceptors(['classes' => [
           'lang.unittest.FirstInterceptor',
           'lang.unittest.SecondInterceptor',
         ]])]

--- a/src/test/php/lang/unittest/AttributeParsingTest.class.php
+++ b/src/test/php/lang/unittest/AttributeParsingTest.class.php
@@ -27,7 +27,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test, Values(['#[Hello]', '#[Hello()]'])]
   public function no_value($declaration) {
     Assert::equals(
-      [0 => ['hello' => null], 1 => []],
+      [0 => ['hello' => null], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse($declaration)
     );
   }
@@ -36,7 +36,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function sq_string_value() {
     Assert::equals(
-      [0 => ['hello' => 'World'], 1 => []],
+      [0 => ['hello' => 'World'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse("#[Hello('World')]")
     );
   }
@@ -44,7 +44,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function sq_string_value_with_equals_sign() {
     Assert::equals(
-      [0 => ['hello' => 'World=Welt'], 1 => []],
+      [0 => ['hello' => 'World=Welt'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse("#[Hello('World=Welt')]")
     );
   }
@@ -52,7 +52,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function sq_string_value_with_at_sign() {
     Assert::equals(
-      [0 => ['hello' => '@World'], 1 => []],
+      [0 => ['hello' => '@World'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse("#[Hello('@World')]")
     );
   }
@@ -60,7 +60,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function sq_string_value_with_annotation() {
     Assert::equals(
-      [0 => ['hello' => '@hello("World")'], 1 => []],
+      [0 => ['hello' => '@hello("World")'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse("#[Hello('@hello(\"World\")')]")
     );
   }
@@ -68,7 +68,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function sq_string_value_with_double_quotes() {
     Assert::equals(
-      [0 => ['hello' => 'said "he"'], 1 => []],
+      [0 => ['hello' => 'said "he"'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse("#[Hello('said \"he\"')]")
     );
   }
@@ -76,7 +76,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function sq_string_value_with_escaped_single_quotes() {
     Assert::equals(
-      [0 => ['hello' => "said 'he'"], 1 => []],
+      [0 => ['hello' => "said 'he'"], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse("#[Hello('said \'he\'')]")
     );
   }
@@ -84,7 +84,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function dq_string_value() {
     Assert::equals(
-      [0 => ['hello' => 'World'], 1 => []],
+      [0 => ['hello' => 'World'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse('#[Hello("World")]')
     );
   }
@@ -92,7 +92,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function dq_string_value_with_single_quote() {
     Assert::equals(
-      [0 => ['hello' => 'Beck\'s'], 1 => []],
+      [0 => ['hello' => 'Beck\'s'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse('#[Hello("Beck\'s")]')
     );
   }
@@ -100,7 +100,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function dq_string_value_with_escaped_double_quotes() {
     Assert::equals(
-      [0 => ['hello' => 'said "he"'], 1 => []],
+      [0 => ['hello' => 'said "he"'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse('#[Hello("said \"he\"")]')
     );
   }
@@ -108,7 +108,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function dq_string_value_with_escape_sequence() {
     Assert::equals(
-      [0 => ['hello' => "World\n"], 1 => []],
+      [0 => ['hello' => "World\n"], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse('#[Hello("World\n")]')
     );
   }
@@ -116,7 +116,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function dq_string_value_with_at_sign() {
     Assert::equals(
-      [0 => ['hello' => '@World'], 1 => []],
+      [0 => ['hello' => '@World'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse('#[Hello("@World")]')
     );
   }
@@ -124,7 +124,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function dq_string_value_with_annotation() {
     Assert::equals(
-      [0 => ['hello' => '@hello(\'World\')'], 1 => []],
+      [0 => ['hello' => '@hello(\'World\')'], 1 => ['hello' => 'lang.unittest.Hello']],
       $this->parse('#[Hello("@hello(\'World\')")]')
     );
   }
@@ -132,7 +132,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function int_value() {
     Assert::equals(
-      [0 => ['answer' => 42], 1 => []],
+      [0 => ['answer' => 42], 1 => ['answer' => 'lang.unittest.Answer']],
       $this->parse('#[Answer(42)]')
     );
   }
@@ -140,7 +140,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function double_value() {
     Assert::equals(
-      [0 => ['version' => 3.5], 1 => []],
+      [0 => ['version' => 3.5], 1 => ['version' => 'lang.unittest.Version']],
       $this->parse('#[Version(3.5)]')
     );
   }
@@ -148,7 +148,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function multi_value_using_array() {
     Assert::equals(
-      [0 => ['xmlMapping' => ['hw_server', 'server']], 1 => []],
+      [0 => ['xmlMapping' => ['hw_server', 'server']], 1 => ['xmlMapping' => 'lang.unittest.XmlMapping']],
       $this->parse("#[XmlMapping(['hw_server', 'server'])]")
     );
   }
@@ -156,7 +156,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function array_value() {
     Assert::equals(
-      [0 => ['versions' => [3.4, 3.5]], 1 => []],
+      [0 => ['versions' => [3.4, 3.5]], 1 => ['versions' => 'lang.unittest.Versions']],
       $this->parse('#[Versions([3.4, 3.5])]')
     );
   }
@@ -164,7 +164,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function array_value_with_nested_arrays() {
     Assert::equals(
-      [0 => ['versions' => [[3], [4]]], 1 => []],
+      [0 => ['versions' => [[3], [4]]], 1 => ['versions' => 'lang.unittest.Versions']],
       $this->parse('#[Versions([[3], [4]])]')
     );
   }
@@ -172,7 +172,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function array_value_with_strings_containing_braces() {
     Assert::equals(
-      [0 => ['versions' => ['(3..4]']], 1 => []],
+      [0 => ['versions' => ['(3..4]']], 1 => ['versions' => 'lang.unittest.Versions']],
       $this->parse('#[Versions(["(3..4]"])]')
     );
   }
@@ -180,7 +180,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function bool_true_value() {
     Assert::equals(
-      [0 => ['supported' => true], 1 => []],
+      [0 => ['supported' => true], 1 => ['supported' => 'lang.unittest.Supported']],
       $this->parse('#[Supported(true)]')
     );
   }
@@ -188,7 +188,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function bool_false_value() {
     Assert::equals(
-      [0 => ['supported' => false], 1 => []],
+      [0 => ['supported' => false], 1 => ['supported' => 'lang.unittest.Supported']],
       $this->parse('#[Supported(false)]')
     );
   }
@@ -196,7 +196,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function named_arguments() {
     Assert::equals(
-      [0 => ['config' => ['key' => 'value', 'times' => 5, 'disabled' => false, 'null' => null, 'list' => [1, 2]]], 1 => []],
+      [
+        0 => ['config' => ['key' => 'value', 'times' => 5, 'disabled' => false, 'null' => null, 'list' => [1, 2]]],
+        1 => ['config' => 'lang.unittest.Config']
+      ],
       $this->parse("#[Config(key: 'value', times: 5, disabled: false, null: null, list: [1, 2])]")
     );
     \xp::gc();
@@ -205,7 +208,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function map_value() {
     Assert::equals(
-      [0 => ['colors' => ['green' => '$10.50', 'red' => '$9.99']], 1 => []],
+      [0 => ['colors' => ['green' => '$10.50', 'red' => '$9.99']], 1 => ['colors' => 'lang.unittest.Colors']],
       $this->parse("#[Colors(['green' => '$10.50', 'red' => '$9.99'])]")
     );
   }
@@ -213,10 +216,13 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function multi_line_annotation() {
     Assert::equals(
-      [0 => ['interceptors' => ['classes' => [
-        'lang.unittest.FirstInterceptor',
-        'lang.unittest.SecondInterceptor',
-      ]]], 1 => []],
+      [
+        0 => ['interceptors' => ['classes' => [
+          'lang.unittest.FirstInterceptor',
+          'lang.unittest.SecondInterceptor',
+        ]]],
+        1 => ['interceptors' => 'lang.unittest.Interceptors']
+      ],
       $this->parse("
         #[Interceptors(classes: [
           'lang.unittest.FirstInterceptor',
@@ -229,7 +235,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function simple_XPath_annotation() {
     Assert::equals(
-      [0 => ['fromXml' => ['xpath' => '/parent/child/@attribute']], 1 => []],
+      [
+        0 => ['fromXml' => ['xpath' => '/parent/child/@attribute']],
+        1 => ['fromXml' => 'lang.unittest.FromXml']
+      ],
       $this->parse("#[FromXml(['xpath' => '/parent/child/@attribute'])]")
     );
   }
@@ -237,7 +246,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function complex_XPath_annotation() {
     Assert::equals(
-      [0 => ['fromXml' => ['xpath' => '/parent[@attr="value"]/child[@attr1="val1" and @attr2="val2"]']], 1 => []],
+      [
+        0 => ['fromXml' => ['xpath' => '/parent[@attr="value"]/child[@attr1="val1" and @attr2="val2"]']],
+        1 => ['fromXml' => 'lang.unittest.FromXml']
+      ],
       $this->parse("#[FromXml(['xpath' => '/parent[@attr=\"value\"]/child[@attr1=\"val1\" and @attr2=\"val2\"]'])]")
     );
   }
@@ -245,7 +257,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function string_with_equal_signs() {
     Assert::equals(
-      [0 => ['permission' => 'rn=login, rt=config'], 1 => []],
+      [0 => ['permission' => 'rn=login, rt=config'], 1 => ['permission' => 'lang.unittest.Permission']],
       $this->parse("#[Permission('rn=login, rt=config')]")
     );
   }
@@ -253,7 +265,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function string_assigned_without_whitespace() {
     Assert::equals(
-      [0 => ['arg' => ['name' => 'verbose', 'short' => 'v']], 1 => []],
+      [0 => ['arg' => ['name' => 'verbose', 'short' => 'v']], 1 => ['arg' => 'lang.unittest.Arg']],
       $this->parse("#[Arg(['name' => 'verbose', 'short' => 'v'])]")
     );
   }
@@ -261,7 +273,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function multiple_values_with_strings_and_equal_signs() {
     Assert::equals(
-      [0 => ['permission' => ['names' => ['rn=login, rt=config1', 'rn=login, rt=config2']]], 1 => []],
+      [
+        0 => ['permission' => ['names' => ['rn=login, rt=config1', 'rn=login, rt=config2']]],
+        1 => ['permission' => 'lang.unittest.Permission']
+      ],
       $this->parse("#[Permission(['names' => ['rn=login, rt=config1', 'rn=login, rt=config2']])]")
     );
   }
@@ -269,7 +284,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function unittest_annotation() {
     Assert::equals(
-      [0 => ['test' => NULL, 'ignore' => NULL, 'limit' => ['time' => 0.1, 'memory' => 100]], 1 => []],
+      [
+        0 => ['test' => NULL, 'ignore' => NULL, 'limit' => ['time' => 0.1, 'memory' => 100]],
+        1 => ['test' => 'lang.unittest.Test', 'ignore' => 'lang.unittest.Ignore', 'limit' => 'lang.unittest.Limit']
+      ],
       $this->parse("#[Test, Ignore, Limit(['time' => 0.1, 'memory' => 100])]")
     );
   }
@@ -277,7 +295,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function overloaded_annotation() {
     Assert::equals(
-      [0 => ['overloaded' => ['signatures' => [['string'], ['string', 'string']]]], 1 => []],
+      [
+        0 => ['overloaded' => ['signatures' => [['string'], ['string', 'string']]]],
+        1 => ['overloaded' => 'lang.unittest.Overloaded']
+      ],
       $this->parse('#[Overloaded(["signatures" => [["string"], ["string", "string"]]])]')
     );
   }
@@ -285,7 +306,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function overloaded_annotation_spanning_multiple_lines() {
     Assert::equals(
-      [0 => ['overloaded' => ['signatures' => [['string'], ['string', 'string']]]], 1 => []],
+      [
+        0 => ['overloaded' => ['signatures' => [['string'], ['string', 'string']]]],
+        1 => ['overloaded' => 'lang.unittest.Overloaded']
+      ],
       $this->parse(
         "#[Overloaded(['signatures' => [\n".
         "  ['string'],\n".
@@ -298,7 +322,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function map_value_with_short_syntax() {
     Assert::equals(
-      [0 => ['colors' => ['green' => '$10.50', 'red' => '$9.99']], 1 => []],
+      [
+        0 => ['colors' => ['green' => '$10.50', 'red' => '$9.99']],
+        1 => ['colors' => 'lang.unittest.Colors']
+      ],
       $this->parse("#[Colors(['green' => '$10.50', 'red' => '$9.99'])]")
     );
   }
@@ -306,7 +333,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function array_syntax_as_value() {
     Assert::equals(
-      [0 => ['permissions' => ['rn=login, rt=config', 'rn=admin, rt=config']], 1 => []],
+      [
+        0 => ['permissions' => ['rn=login, rt=config', 'rn=admin, rt=config']],
+        1 => ['permissions' => 'lang.unittest.Permissions']
+      ],
       $this->parse("#[Permissions(['rn=login, rt=config', 'rn=admin, rt=config'])]")
     );
   }
@@ -314,7 +344,10 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function array_syntax_as_key() {
     Assert::equals(
-      [0 => ['permissions' => ['names' => ['rn=login, rt=config', 'rn=admin, rt=config']]], 1 => []],
+      [
+        0 => ['permissions' => ['names' => ['rn=login, rt=config', 'rn=admin, rt=config']]],
+        1 => ['permissions' => 'lang.unittest.Permissions']
+      ],
       $this->parse("#[Permissions(['names' => ['rn=login, rt=config', 'rn=admin, rt=config']])]")
     );
   }
@@ -322,7 +355,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function nested_array_syntax() {
     Assert::equals(
-      [0 => ['values' => [[1, 1], [2, 2], [3, 3]]], 1 => []],
+      [0 => ['values' => [[1, 1], [2, 2], [3, 3]]], 1 => ['values' => 'lang.unittest.Values']],
       $this->parse("#[Values([[1, 1], [2, 2], [3, 3]])]")
     );
   }
@@ -330,7 +363,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function nested_array_syntax_as_key() {
     Assert::equals(
-      [0 => ['test' => ['values' => [[1, 1], [2, 2], [3, 3]]]], 1 => []],
+      [0 => ['test' => ['values' => [[1, 1], [2, 2], [3, 3]]]], 1 => ['test' => 'lang.unittest.Test']],
       $this->parse("#[Test(['values' => [[1, 1], [2, 2], [3, 3]]])]")
     );
   }
@@ -338,7 +371,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function negative_and_positive_floats_inside_array() {
     Assert::equals(
-      [0 => ['values' => [0.0, -1.5, +1.5]], 1 => []],
+      [0 => ['values' => [0.0, -1.5, +1.5]], 1 => ['values' => 'lang.unittest.Values']],
       $this->parse("#[Values([0.0, -1.5, +1.5])]")
     );
   }
@@ -346,7 +379,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_instance_value() {
     Assert::equals(
-      [0 => ['value' => new Name('hello')], 1 => []],
+      [0 => ['value' => new Name('hello')], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(new Name("hello"))]')
     );
   }
@@ -354,7 +387,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function imported_class_instance_value() {
     Assert::equals(
-      [0 => ['value' => new Name('hello')], 1 => []],
+      [0 => ['value' => new Name('hello')], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(new Name("hello"))]', ['Name' => 'lang.unittest.Name'])
     );
   }
@@ -362,7 +395,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function fully_qualified_class_instance_value() {
     Assert::equals(
-      [0 => ['value' => new Name('hello')], 1 => []],
+      [0 => ['value' => new Name('hello')], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(new \lang\unittest\Name("hello"))]')
     );
   }
@@ -376,7 +409,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_constant_via_self() {
     Assert::equals(
-      [0 => ['value' => 'constant'], 1 => []],
+      [0 => ['value' => 'constant'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(self::CONSTANT)]')
     );
   }
@@ -384,7 +417,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_constant_via_parent() {
     Assert::equals(
-      [0 => ['value' => 'constant'], 1 => []],
+      [0 => ['value' => 'constant'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(parent::PARENTS_CONSTANT)]')
     );
   }
@@ -392,7 +425,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_constant_via_classname() {
     Assert::equals(
-      [0 => ['value' => 'constant'], 1 => []],
+      [0 => ['value' => 'constant'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(AnnotationParsingTest::CONSTANT)]')
     );
   }
@@ -400,7 +433,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_constant_via_ns_classname() {
     Assert::equals(
-      [0 => ['value' => 'constant'], 1 => []],
+      [0 => ['value' => 'constant'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(\lang\unittest\AnnotationParsingTest::CONSTANT)]')
     );
   }
@@ -408,7 +441,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_constant_via_imported_classname() {
     Assert::equals(
-      [0 => ['value' => 'namespaced'], 1 => []],
+      [0 => ['value' => 'namespaced'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(Namespaced::CONSTANT)]')
     );
   }
@@ -416,7 +449,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_constant_via_self_in_map() {
     Assert::equals(
-      [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => []],
+      [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => ['map' => 'lang.unittest.Map']],
       $this->parse('#[Map(["key" => self::CONSTANT, "value" => "val"])]')
     );
   }
@@ -424,7 +457,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_constant_via_classname_in_map() {
     Assert::equals(
-      [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => []],
+      [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => ['map' => 'lang.unittest.Map']],
       $this->parse('#[Map(["key" => AnnotationParsingTest::CONSTANT, "value" => "val"])]')
     );
   }
@@ -432,7 +465,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_constant_via_ns_classname_in_map() {
     Assert::equals(
-      [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => []],
+      [0 => ['map' => ['key' => 'constant', 'value' => 'val']], 1 => ['map' => 'lang.unittest.Map']],
       $this->parse('#[Map(["key" => \lang\unittest\AnnotationParsingTest::CONSTANT, "value" => "val"])]')
     );
   }
@@ -440,7 +473,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_public_static_member() {
     Assert::equals(
-      [0 => ['value' => 'exposed'], 1 => []],
+      [0 => ['value' => 'exposed'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(eval: "self::\$exposed")]')
     );
   }
@@ -448,7 +481,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function parent_public_static_member() {
     Assert::equals(
-      [0 => ['value' => 'exposed'], 1 => []],
+      [0 => ['value' => 'exposed'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(eval: "parent::\$parentsExposed")]')
     );
   }
@@ -456,7 +489,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_protected_static_member() {
     Assert::equals(
-      [0 => ['value' => 'hidden'], 1 => []],
+      [0 => ['value' => 'hidden'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(eval: "self::\$hidden")]')
     );
   }
@@ -464,7 +497,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function parent_protected_static_member() {
     Assert::equals(
-      [0 => ['value' => 'hidden'], 1 => []],
+      [0 => ['value' => 'hidden'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(eval: "parent::\$parentsHidden")]')
     );
   }
@@ -472,7 +505,7 @@ class AttributeParsingTest extends AbstractAnnotationParsingTest {
   #[Test]
   public function class_private_static_member() {
     Assert::equals(
-      [0 => ['value' => 'internal'], 1 => []],
+      [0 => ['value' => 'internal'], 1 => ['value' => 'lang.unittest.Value']],
       $this->parse('#[Value(eval: "self::\$internal")]')
     );
   }

--- a/src/test/php/lang/unittest/ClassDetailsTest.class.php
+++ b/src/test/php/lang/unittest/ClassDetailsTest.class.php
@@ -30,7 +30,7 @@ class ClassDetailsTest {
   public function parses($kind) {
     $details= (new ClassParser())->parseDetails('<?php '.$kind.' Test { }');
     Assert::equals(
-      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => []],
+      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => [], DETAIL_TARGET_ANNO  => []],
       $details['class']
     );
   }
@@ -402,6 +402,40 @@ class ClassDetailsTest {
     ');
   }
 
+  #[Test]
+  public function php8_type_attributes_original_names() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      #[Value("test")]
+      class Test {
+      }
+    ');
+    Assert::equals(['value' => 'Value'], $actual['class'][DETAIL_TARGET_ANNO]);
+  }
+
+  #[Test]
+  public function php8_method_attributes_original_names() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      class Test {
+
+        #[Value("test")]
+        public function fixture() { }
+      }
+    ');
+    Assert::equals(['value' => 'Value'], $actual[1]['fixture'][DETAIL_TARGET_ANNO]);
+  }
+
+  #[Test]
+  public function php8_field_attributes_original_names() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      class Test {
+
+        #[Value("test")]
+        public $fixture;
+      }
+    ');
+    Assert::equals(['value' => 'Value'], $actual[0]['fixture'][DETAIL_TARGET_ANNO]);
+  }
+
   #[Test, Expect(class: ClassFormatException::class, message: '/Unexpected "," in eval/')]
   public function array_eval_cannot_have_multiple_arguments() {
     (new ClassParser())->parseDetails('<?php
@@ -536,7 +570,7 @@ class ClassDetailsTest {
       }
     ');
     Assert::equals(
-      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => []],
+      [DETAIL_COMMENT => '', DETAIL_ANNOTATIONS => [], DETAIL_TARGET_ANNO  => []],
       $details['class']
     );
   }
@@ -643,7 +677,7 @@ class ClassDetailsTest {
       }
     ');
     Assert::equals(
-      [DETAIL_COMMENT => 'Comment', DETAIL_ANNOTATIONS => []],
+      [DETAIL_COMMENT => 'Comment', DETAIL_ANNOTATIONS => [], DETAIL_TARGET_ANNO  => []],
       $details['class']
     );
   }

--- a/src/test/php/lang/unittest/ClassDetailsTest.class.php
+++ b/src/test/php/lang/unittest/ClassDetailsTest.class.php
@@ -436,6 +436,20 @@ class ClassDetailsTest {
     Assert::equals(['value' => 'Value'], $actual[0]['fixture'][DETAIL_TARGET_ANNO]);
   }
 
+  #[Test]
+  public function php8_param_attributes_original_names() {
+    $actual= (new ClassParser())->parseDetails('<?php
+      class Test {
+
+        public function fixture(
+          #[Value("test")]
+          $p
+        ) { }
+      }
+    ');
+    Assert::equals(['$p' => ['value' => 'test'], 'value' => 'Value'], $actual[1]['fixture'][DETAIL_TARGET_ANNO]);
+  }
+
   #[Test, Expect(class: ClassFormatException::class, message: '/Unexpected "," in eval/')]
   public function array_eval_cannot_have_multiple_arguments() {
     (new ClassParser())->parseDetails('<?php


### PR DESCRIPTION
This fixes a problem when using old and new reflection libraries in conjunction. This is due to the fact that both use `xp::$meta` for caching reasons, but fill it differently.

```php
<?php

use web\frontend\Handler;

#[Handler]
class Users {

}
```

### Before

Using the `lang.XPClass` annotation API will infer with the results returned by `lang.reflection.Type`:

```bash
# Return value as expected:
$ xp -w 'return [...\lang\Reflection::type("Users")->annotations()]'
[web.frontend.Handler => lang.reflection.Annotation<web.frontend.Handler([])>]

# The annotation name is only returned in lowercase!
$ xp -w '\lang\XPClass::forName("Users")->getAnnotations();
return [...\lang\Reflection::type("Users")->annotations()]'
[handler => lang.reflection.Annotation<handler([])>]
```

### After

The `lang.XPClass` annotation API now also records the original annotation names, and `lang.reflection.Type` now returns the expected annotation:

```bash
$ xp -w '\lang\XPClass::forName("Users")->getAnnotations();
return [...\lang\Reflection::type("Users")->annotations()]'
[web.frontend.Handler => lang.reflection.Annotation<web.frontend.Handler([])>]
```