### PR TITLE
Implement a limited in-memory buffer with filesystem overflow

### DIFF
--- a/src/main/php/io/streams/Buffer.class.php
+++ b/src/main/php/io/streams/Buffer.class.php
@@ -106,7 +106,10 @@ class Buffer implements InputStream, OutputStream {
 
   /** @return void */
   public function close() {
-    $this->file && $this->file->close();
+    if (null === $this->file || !$this->file->isOpen()) return;
+
+    $this->file->close();
+    $this->file->unlink();
   }
 
   /** Ensure file is closed */

--- a/src/main/php/io/streams/Buffer.class.php
+++ b/src/main/php/io/streams/Buffer.class.php
@@ -1,0 +1,116 @@
+<?php namespace io\streams;
+
+use io\{File, Folder};
+use lang\IllegalArgumentException;
+
+/**
+ * Buffers in memory up until a given threshold, using the file system once
+ * it's exceeded.
+ * 
+ * @see   https://github.com/xp-forge/web/issues/118
+ * @test  io.unittest.BufferTest
+ */
+class Buffer implements InputStream, OutputStream {
+  private $files, $threshold;
+  private $memory= '';
+  private $file= null;
+  private $size= 0;
+
+  /**
+   * Creates a new buffer
+   *
+   * @param  io.Folder|io.Path|string $files
+   * @param  int $threshold
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct($files, int $threshold) {
+    if ($threshold < 0) {
+      throw new IllegalArgumentException('Threshold must be >= 0');
+    }
+
+    $this->files= $files instanceof Folder ? $files->getURI() : (string)$files;
+    $this->threshold= $threshold;
+  }
+
+  /** Returns buffer size */
+  public function size(): int { return $this->size; }
+
+  /** @return ?io.File */
+  public function file() { return $this->file; }
+
+  /**
+   * Write a string
+   *
+   * @param  var $arg
+   * @return void
+   */
+  public function write($bytes) {
+    $this->size+= strlen($bytes);
+    if ($this->size <= $this->threshold) {
+      $this->memory.= $bytes;
+      return;
+    }
+
+    if (null === $this->file) {
+      $this->file= new File(tempnam($this->files, "b{$this->threshold}"));
+      $this->file->open(File::READWRITE);
+      $this->file->write($this->memory);
+      $this->memory= null;
+    }
+    $this->file->write($bytes);
+  }
+
+  /** @return void */
+  public function flush() {
+    $this->file && $this->file->flush();
+  }
+
+  /**
+   * Finish buffering
+   *
+   * @return void
+   */
+  public function finish() {
+    $this->file && $this->file->seek(0, SEEK_SET);
+  }
+
+  /** @return int */
+  public function available() {
+    return $this->file ? $this->size - $this->file->tell() : strlen($this->memory ?? '');
+  }
+
+  /**
+   * Read a string
+   *
+   * @param  int $limit
+   * @return ?string
+   */
+  public function read($limit= 8192) {
+    if ($this->file) {
+      $chunk= $this->file->read($limit);
+      return false === $chunk ? null : $chunk;
+    }
+
+    // Drain memory
+    if (null === $this->memory) {
+      $chunk= null;
+    } else if ($limit >= strlen($this->memory)) {
+      $chunk= $this->memory;
+      $this->memory= null;
+    } else {
+      $chunk= substr($this->memory, 0, $limit);
+      $this->memory= substr($this->memory, $limit);
+    }
+    return $chunk;
+  }
+
+  /** @return void */
+  public function close() {
+    $this->file && $this->file->close();
+  }
+
+  /** Ensure file is closed */
+  public function __destruct() {
+    $this->close();
+  }
+}

--- a/src/main/php/io/streams/Buffer.class.php
+++ b/src/main/php/io/streams/Buffer.class.php
@@ -95,21 +95,17 @@ class Buffer implements InputStream, OutputStream {
    * Read a string
    *
    * @param  int $limit
-   * @return ?string
+   * @return string
    */
   public function read($limit= 8192) {
     if ($this->file) {
       $this->draining || $this->file->seek(0, SEEK_SET) && $this->draining= true;
-      $chunk= $this->file->read($limit);
-      return false === $chunk ? null : $chunk;
-    } else if ($this->pointer < $this->size) {
+      return (string)$this->file->read($limit);
+    } else {
       $this->draining= true;
       $chunk= substr($this->memory, $this->pointer, $limit);
       $this->pointer+= strlen($chunk);
       return $chunk;
-    } else {
-      $this->draining= true;
-      return null;
     }
   }
 

--- a/src/main/php/io/streams/Buffer.class.php
+++ b/src/main/php/io/streams/Buffer.class.php
@@ -37,8 +37,11 @@ class Buffer implements InputStream, OutputStream {
   /** Returns buffer size */
   public function size(): int { return $this->size; }
 
-  /** @return ?io.File */
-  public function file() { return $this->file; }
+  /** Returns the underlying file, if any */
+  public function file(): ?File { return $this->file; }
+
+  /** Returns whether this buffer is draining */
+  public function draining(): bool { return $this->draining; }
 
   /**
    * Write a string

--- a/src/test/php/io/unittest/BufferTest.class.php
+++ b/src/test/php/io/unittest/BufferTest.class.php
@@ -24,7 +24,7 @@ class BufferTest {
     Assert::throws(IllegalArgumentException::class, fn() => new Buffer($this->temp, -1));
   }
 
-  #[Test, Values([0, 1, 127, 128])]
+  #[Test, Values([1, 127, 128])]
   public function uses_memory_under_threshold($length) {
     $bytes= str_repeat('*', $length);
 
@@ -59,6 +59,22 @@ class BufferTest {
     Assert::equals($bytes, $fixture->read());
     Assert::equals(0, $fixture->available());
     Assert::equals(null, $fixture->read());
+  }
+
+  #[Test, Values([127, 128, 129])]
+  public function reset($length) {
+    $bytes= str_repeat('*', $length);
+
+    $fixture= new Buffer($this->temp, self::THRESHOLD);
+    $fixture->write($bytes);
+
+    Assert::equals($length, $fixture->available());
+    Assert::equals($bytes, $fixture->read());
+
+    $fixture->reset();
+
+    Assert::equals($length, $fixture->available());
+    Assert::equals($bytes, $fixture->read());
   }
 
   #[Test]

--- a/src/test/php/io/unittest/BufferTest.class.php
+++ b/src/test/php/io/unittest/BufferTest.class.php
@@ -58,7 +58,7 @@ class BufferTest {
     Assert::equals($length, $fixture->available());
     Assert::equals($bytes, $fixture->read());
     Assert::equals(0, $fixture->available());
-    Assert::equals(null, $fixture->read());
+    Assert::equals('', $fixture->read());
   }
 
   #[Test, Values([127, 128, 129])]

--- a/src/test/php/io/unittest/BufferTest.class.php
+++ b/src/test/php/io/unittest/BufferTest.class.php
@@ -62,4 +62,24 @@ class BufferTest {
     Assert::equals(0, $fixture->available());
     Assert::equals(null, $fixture->read());
   }
+
+  #[Test]
+  public function file_deleted_on_close() {
+    $fixture= new Buffer($this->temp, 0);
+    $fixture->write('Test');
+    $fixture->finish();
+
+    $fixture->close();
+    Assert::false($fixture->file()->exists());
+  }
+
+  #[Test]
+  public function double_close() {
+    $fixture= new Buffer($this->temp, 0);
+    $fixture->write('Test');
+    $fixture->finish();
+
+    $fixture->close();
+    $fixture->close();
+  }
 }

--- a/src/test/php/io/unittest/BufferTest.class.php
+++ b/src/test/php/io/unittest/BufferTest.class.php
@@ -1,0 +1,65 @@
+<?php namespace io\unittest;
+
+use io\File;
+use io\streams\Buffer;
+use lang\{Environment, IllegalArgumentException};
+use test\{Assert, Before, Expect, Test, Values};
+
+class BufferTest {
+  const THRESHOLD= 128;
+  private $temp;
+
+  #[Before]
+  public function temp() {
+    $this->temp= Environment::tempDir();
+  }
+
+  #[Test]
+  public function can_create() {
+    new Buffer($this->temp, self::THRESHOLD);
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function threshold_must_be_larger_than_zero() {
+    new Buffer($this->temp, -1);
+  }
+
+  #[Test, Values([0, 1, 127, 128])]
+  public function uses_memory_under_threshold($length) {
+    $bytes= str_repeat('*', $length);
+
+    $fixture= new Buffer($this->temp, self::THRESHOLD);
+    $fixture->write($bytes);
+    $fixture->finish();
+
+    Assert::null($fixture->file());
+    Assert::equals($length, $fixture->size());
+    Assert::equals($bytes, $fixture->read());
+  }
+
+  #[Test, Values([129, 256, 1024])]
+  public function stores_file_when_exceeding_threshold($length) {
+    $bytes= str_repeat('*', $length);
+
+    $fixture= new Buffer($this->temp, self::THRESHOLD);
+    $fixture->write($bytes);
+    $fixture->finish();
+
+    Assert::instance(File::class, $fixture->file());
+    Assert::equals($length, $fixture->size());
+    Assert::equals($bytes, $fixture->read());
+  }
+
+  #[Test, Values([127, 128, 129])]
+  public function read_after_eof($length) {
+    $bytes= str_repeat('*', self::THRESHOLD + $length);
+
+    $fixture= new Buffer($this->temp, self::THRESHOLD);
+    $fixture->write($bytes);
+    $fixture->finish();
+
+    Assert::equals($bytes, $fixture->read());
+    Assert::equals(0, $fixture->available());
+    Assert::equals(null, $fixture->read());
+  }
+}

--- a/src/test/php/io/unittest/BufferTest.class.php
+++ b/src/test/php/io/unittest/BufferTest.class.php
@@ -81,8 +81,10 @@ class BufferTest {
   public function cannot_write_after_draining_started() {
     $fixture= new Buffer($this->temp, self::THRESHOLD);
     $fixture->write('Test');
+    Assert::false($fixture->draining());
 
     $fixture->read();
+    Assert::true($fixture->draining());
     Assert::throws(IllegalStateException::class, fn() => $fixture->write('Test'));
   }
 


### PR DESCRIPTION
Example:

```php
use io\streams\Buffer;
use lang\Environment;

$buffer= new Buffer(Environment::tempDir(), 1024);

// This will be written to memory as it's shorter than the threshold
$buffer->write('Slice #1');

// With this write, the buffer exceeds the threshold and is thus saved to a file
$buffer->write(str_repeat('*', 2048)); 

// Drain the buffer
while ($buffer->available()) {
  $chunk= $buffer->read();
}

// Close the buffer, removing the file created by the second write
$buffer->close();
```

Inspired by https://github.com/xp-forge/web/issues/118