### PR TITLE
Accept strings or util.TimeZone instances

### DIFF
--- a/src/main/php/util/Date.class.php
+++ b/src/main/php/util/Date.class.php
@@ -210,11 +210,20 @@ class Date implements Value {
    *
    * @see    php://date
    * @param  string $format default Date::DEFAULT_FORMAT format-string
-   * @param  ?util.TimeZone $outtz default NULL
+   * @param  ?string|util.TimeZone $timezone
    * @return string the formatted date
    */
-  public function toString(string $format= self::DEFAULT_FORMAT, ?TimeZone $outtz= null): string {
-    return date_format(($outtz === null ? $this : $outtz->translate($this))->handle, $format);
+  public function toString(string $format= self::DEFAULT_FORMAT, $timezone= null): string {
+    if (null === $timezone) {
+      $handle= $this->handle;
+    } else if ($timezone instanceof TimeZone) {
+      $handle= clone $this->handle;
+      date_timezone_set($handle, $timezone->getHandle());
+    } else {
+      $handle= clone $this->handle;
+      date_timezone_set($handle, new DateTimeZone($timezone));
+    }
+    return date_format($handle, $format);
   }
   
   /**
@@ -225,11 +234,11 @@ class Date implements Value {
    *
    * @see    php://strftime
    * @param  string $format
-   * @param  ?util.TimeZone $outtz default NULL
+   * @param  ?string|util.TimeZone $timezone
    * @return string
    * @throws lang.IllegalArgumentException if unsupported token has been given
    */
-  public function format(string $format, ?TimeZone $outtz= null): string {
+  public function format(string $format, $timezone= null): string {
     static $replace= [
       '%d' => 'd',
       '%m' => 'm',
@@ -264,6 +273,15 @@ class Date implements Value {
       '%%' => '%'
     ];
 
-    return date_format(($outtz === null ? $this : $outtz->translate($this))->handle, strtr($format, $replace));
+    if (null === $timezone) {
+      $handle= $this->handle;
+    } else if ($timezone instanceof TimeZone) {
+      $handle= clone $this->handle;
+      date_timezone_set($handle, $timezone->getHandle());
+    } else {
+      $handle= clone $this->handle;
+      date_timezone_set($handle, new DateTimeZone($timezone));
+    }
+    return date_format($handle, strtr($format, $replace));
   }
 }

--- a/src/main/php/util/Date.class.php
+++ b/src/main/php/util/Date.class.php
@@ -236,7 +236,6 @@ class Date implements Value {
    * @param  string $format
    * @param  ?string|util.TimeZone $timezone
    * @return string
-   * @throws lang.IllegalArgumentException if unsupported token has been given
    */
   public function format(string $format, $timezone= null): string {
     static $replace= [

--- a/src/main/php/util/Date.class.php
+++ b/src/main/php/util/Date.class.php
@@ -1,6 +1,6 @@
 <?php namespace util;
 
-use DateTime;
+use DateTime, DateTimeZone;
 use lang\{IllegalArgumentException, IllegalStateException, Value};
 
 /**
@@ -38,12 +38,20 @@ class Date implements Value {
    *   timezone is used.
    *
    * @param  ?int|float|string|DateTime $in
-   * @param  ?util.TimeZone $timezone default NULL string of timezone
+   * @param  ?string|util.TimeZone $timezone
    * @throws lang.IllegalArgumentException in case the date is unparseable
    */
-  public function __construct($in= null, ?TimeZone $timezone= null) {
+  public function __construct($in= null, $timezone= null) {
+    if (null === $timezone) {
+      $tz= null;
+    } else if ($timezone instanceof TimeZone) {
+      $tz= $timezone->getHandle();
+    } else {
+      $tz= new DateTimeZone($timezone);
+    }
+
     if (null === $in) {
-      $this->handle= date_create('now', $timezone ? $timezone->getHandle() : null);
+      $this->handle= date_create('now', $tz);
     } else if ($in instanceof DateTime) {
       $this->handle= $in;
     } else if (is_int($in) || (string)(int)$in === $in) {
@@ -51,15 +59,15 @@ class Date implements Value {
       // Specially mark timestamps for parsing (we assume here that strings
       // containing only digits are timestamps)
       $this->handle= date_create('@'.$in);
-      $timezone && date_timezone_set($this->handle, $timezone->getHandle());
+      $tz && date_timezone_set($this->handle, $tz);
     } else if (is_float($in)) {
 
       // Timestamps with microseconds are defined as `"@" "-"? [0-9]+ "." [0-9]{0,6}`,
       // see https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative
       $this->handle= date_create('@'.sprintf('%.6f', $in));
-      $timezone && date_timezone_set($this->handle, $timezone->getHandle());
+      $tz && date_timezone_set($this->handle, $tz);
     } else {
-      if (false === ($this->handle= date_create($in ?? 'now', $timezone ? $timezone->getHandle() : null))) {
+      if (false === ($this->handle= date_create($in ?? 'now', $tz))) {
         throw new IllegalArgumentException('Given argument is neither a timestamp nor a well-formed timestring: '.Objects::stringOf($in));
       }
     }
@@ -96,13 +104,16 @@ class Date implements Value {
    * @param  int $hour
    * @param  int $minute
    * @param  int $second
-   * @param  ?util.TimeZone $tz default NULL
+   * @param  ?string|util.TimeZone $timezone
    * @return self
    */
-  public static function create($year, $month, $day, $hour, $minute, $second, ?TimeZone $tz= null): self {
-    $date= date_create();
-    if ($tz) {
-      date_timezone_set($date, $tz->getHandle());
+  public static function create($year, $month, $day, $hour, $minute, $second, $timezone= null): self {
+    if (null === $timezone) {
+      $date= date_create();
+    } else if ($timezone instanceof TimeZone) {
+      $date= date_create('now', $timezone->getHandle());
+    } else {
+      $date= date_create('now', new DateTimeZone($timezone));
     }
 
     try {
@@ -133,9 +144,9 @@ class Date implements Value {
     return $cmp instanceof self && $this->getTime() === $cmp->getTime();
   }
   
-  /** Static method to get current date/time */
-  public static function now(?TimeZone $tz= null): self {
-    return new self(null, $tz);
+  /** @param ?string|util.TimeZone $timezone */
+  public static function now($timezone= null): self {
+    return new self(null, $timezone);
   }
   
   /** Compare this date to another date */

--- a/src/test/php/util/unittest/DateTest.class.php
+++ b/src/test/php/util/unittest/DateTest.class.php
@@ -279,21 +279,29 @@ class DateTest {
   }
   
   #[Test]
-  public function toStringOutput() {
-    $date= new Date('2007-11-10 20:15+0100');
-    Assert::equals('2007-11-10 20:15:00+0100', $date->toString());
-    Assert::equals('2007-11-10 19:15:00+0000', $date->toString(Date::DEFAULT_FORMAT, new TimeZone('GMT')));
+  public function string_representation() {
+    Assert::equals(
+      '2007-11-10 20:15:00+0100',
+      (new Date('2007-11-10 20:15+0100'))->toString(Date::DEFAULT_FORMAT)
+    );
   }
   
+  #[Test, Values(from: 'timezones')]
+  public function string_representation_with_timezone($timezone) {
+    Assert::equals(
+      '2007-11-10 20:15:00+0100',
+      (new Date('2007-11-10 19:15+0000'))->toString(Date::DEFAULT_FORMAT, $timezone)
+    );
+  }
+
   #[Test]
-  public function toStringOutputPreserved() {
+  public function timezone_preserved_during_serialization() {
     $date= unserialize(serialize(new Date('2007-11-10 20:15+0100')));
     Assert::equals('2007-11-10 20:15:00+0100', $date->toString());
-    Assert::equals('2007-11-10 19:15:00+0000', $date->toString(Date::DEFAULT_FORMAT, new TimeZone('GMT')));
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
-  public function malformedInputString() {
+  public function malformed_input_string() {
     new Date('@@not-a-date@@');
   }
 
@@ -320,10 +328,7 @@ class DateTest {
   #[Test]
   public function constructorBrokenAfterException() {
     Date::now();
-    try {
-      new Date('bogus');
-      $this->fail('No exception raised', null, IllegalArgumentException::class);
-    } catch (\lang\IllegalArgumentException $expected) { }
+    Assert::throws(IllegalArgumentException::class, fn() => new Date('bogus'));
     Date::now();
   }
   

--- a/src/test/php/util/unittest/DateTest.class.php
+++ b/src/test/php/util/unittest/DateTest.class.php
@@ -7,6 +7,12 @@ use util\{Date, TimeZone};
 class DateTest {
   private $nowTime, $nowDate, $refDate, $tz;
 
+  /** @return iterable  */
+  private function timezones() {
+    yield 'Europe/Berlin';
+    yield new TimeZone('Europe/Berlin');
+  }
+
   #[Before]
   public function setUp() {
 
@@ -51,11 +57,11 @@ class DateTest {
     $this->assertDateEquals('2007-08-23T12:35:47+00:00', new Date(1187872547));
   }
   
-  #[Test]
-  public function constructorUnixtimestampWithTz() {
-    $this->assertDateEquals('2007-08-23T14:35:47+02:00', new Date(1187872547, new TimeZone('Europe/Berlin')));
+  #[Test, Values(from: 'timezones')]
+  public function constructorUnixtimestampWithTz($tz) {
+    $this->assertDateEquals('2007-08-23T14:35:47+02:00', new Date(1187872547, $tz));
   }
-  
+
   #[Test]
   public function constructorParseTz() {
     $date= new Date('2007-01-01 01:00:00 Europe/Berlin');
@@ -157,7 +163,12 @@ class DateTest {
     // Test with a date before 1971
     Assert::equals(-44668800, Date::create(1968, 8, 2, 0, 0, 0)->getTime());
   }
-  
+
+  #[Test, Values(from: 'timezones')]
+  public function create_date_with_timezone($tz) {
+    Assert::equals(-44672400, Date::create(1968, 8, 2, 0, 0, 0, $tz)->getTime());
+  }
+
   #[Test]
   public function pre1970() {
     $this->assertDateEquals('1969-02-01T00:00:00+00:00', new Date('01.02.1969'));


### PR DESCRIPTION
Following the paradigm: **Be liberal in what you accept**, all of these methods now accept `?string|util.TimeZone` instead of just `?TimeZone`:

* [x] `util.Date`'s constructor
* [x] `util.Date::now()`
* [x] `util.Date::create(...)`
* [x] The `format()` method
* [x] In `toString()`