### PR TITLE
Add size() to both FileInputStream and FileOutputStream

### DIFF
--- a/src/main/php/io/streams/FileInputStream.class.php
+++ b/src/main/php/io/streams/FileInputStream.class.php
@@ -72,12 +72,9 @@ class FileInputStream implements InputStream, Seekable, Value {
     $this->file->seek($offset, $whence);
   }
 
-  /**
-   * Return current offset
-   *
-   * @return  int offset
-   */
-  public function tell() {
-    return $this->file->tell();
-  }
+  /** @return int */
+  public function tell() { return $this->file->tell(); }
+
+  /** @return int */
+  public function size() { return $this->file->size(); }
 }

--- a/src/main/php/io/streams/FileOutputStream.class.php
+++ b/src/main/php/io/streams/FileOutputStream.class.php
@@ -48,6 +48,9 @@ class FileOutputStream implements OutputStream, Seekable, Truncation, Value {
   /** @return int */
   public function tell() { return $this->file->tell(); }
 
+  /** @return int */
+  public function size() { return $this->file->size(); }
+
   /**
    * Truncate this buffer to a given new size.
    *

--- a/src/test/php/io/unittest/FileInputStreamTest.class.php
+++ b/src/test/php/io/unittest/FileInputStreamTest.class.php
@@ -55,6 +55,13 @@ class FileInputStreamTest {
   }
 
   #[Test]
+  public function size() {
+    with (new FileInputStream($this->tempFile()), function($stream) {
+      Assert::equals(30, $stream->size());
+    });
+  }
+
+  #[Test]
   public function delete() {
     $file= $this->tempFile();
     with (new FileInputStream($file), function($stream) use($file) {

--- a/src/test/php/io/unittest/FileOutputStreamTest.class.php
+++ b/src/test/php/io/unittest/FileOutputStreamTest.class.php
@@ -6,11 +6,12 @@ use lang\IllegalArgumentException;
 use test\{Assert, Expect, Test};
 
 class FileOutputStreamTest {
+  const INITIAL= 'Created by FileOutputStreamTest';
   private $files= [];
 
   /** @return io.TempFile */
   private function tempFile() {
-    $file= (new TempFile())->containing('Created by FileOutputStreamTest');
+    $file= (new TempFile())->containing(self::INITIAL);
     $this->files[]= $file;
     return $file;
   }
@@ -111,5 +112,40 @@ class FileOutputStreamTest {
       $file->close();
       Assert::equals('Exist', Files::read($file));
     });
+  }
+
+  #[Test]
+  public function size_initially() {
+    $stream= new FileOutputStream($this->tempFile());
+    Assert::equals(0, $stream->size());
+  }
+
+  #[Test]
+  public function size_after_writing() {
+    $stream= new FileOutputStream($this->tempFile());
+    $stream->write('Test');
+    Assert::equals(4, $stream->size());
+  }
+
+  #[Test]
+  public function size_after_truncation() {
+    $stream= new FileOutputStream($this->tempFile());
+    $stream->write('Test');
+    $stream->truncate(2);
+    Assert::equals(2, $stream->size());
+  }
+
+  #[Test]
+  public function size_when_opened_with_append() {
+    $file= $this->tempFile();
+    $file->open(File::APPEND);
+
+    $stream= new FileOutputStream($file);
+    $stream->write('Test');
+    $size= $stream->size();
+    $stream->close();
+
+    Assert::equals(strlen(self::INITIAL) + 4, $size);
+    Assert::equals(self::INITIAL.'Test', Files::read($file));
   }
 }


### PR DESCRIPTION
Example:

```php
use io\streams\{FileInputStream, FileOutputStream};

$in= new FileInputStream('README.md');
$in->size(); // Size of README.md on disk

$out= new FileOutputStream('test.json');
$out->write(/* ... */);
$out->size(); // Size of file after writing
```