### PR TITLE
Consistency in memory I/O

### DIFF
--- a/src/main/php/io/streams/MemoryInputStream.class.php
+++ b/src/main/php/io/streams/MemoryInputStream.class.php
@@ -1,12 +1,13 @@
 <?php namespace io\streams;
 
+use io\IOException;
 use lang\Value;
 use util\Comparison;
 
 /**
  * InputStream that reads from a given string.
  *
- * @test  net.xp_framework.unittest.io.streams.MemoryInputStreamTest
+ * @test  io.unittest.MemoryInputStreamTest
  */
 class MemoryInputStream implements InputStream, Seekable, Value {
   use Comparison;
@@ -57,29 +58,33 @@ class MemoryInputStream implements InputStream, Seekable, Value {
    *
    * @param  int $offset
    * @param  int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
-   * @throws io.IOException in case of error
+   * @throws io.IOException
    */
   public function seek($offset, $whence= SEEK_SET) {
+    $l= strlen($this->bytes);
     switch ($whence) {
       case SEEK_SET: $this->pos= $offset; break;
       case SEEK_CUR: $this->pos+= $offset; break;
-      case SEEK_END: $this->pos= strlen($this->bytes) + $offset; break;
+      case SEEK_END: $this->pos= $l + $offset; break;
+      default: throw new IOException('Unexpected whence '.$whence);
+    }
+
+    // Ensure we cannot seek *before* start
+    if ($this->pos < 0) {
+      $e= new IOException('Seek error, position '.$this->pos.', whence: '.$whence);
+      $this->pos= 0;
+      throw $e;
     }
   }
 
-  /**
-   * Return current offset
-   *
-   * @return int
-   */
+  /** @return int */
   public function tell() { return $this->pos; }
 
-  /**
-   * Return size
-   *
-   * @return int
-   */
+  /** @return int */
   public function size() { return strlen($this->bytes); }
+
+  /** @return string */
+  public function bytes() { return $this->bytes; }
 
   /** @return string */
   public function toString() {

--- a/src/main/php/io/streams/MemoryInputStream.class.php
+++ b/src/main/php/io/streams/MemoryInputStream.class.php
@@ -67,9 +67,8 @@ class MemoryInputStream implements InputStream, Seekable, Value {
 
     // Ensure we cannot seek *before* start
     if ($this->pos < 0) {
-      $e= new IOException('Seek error, position '.$this->pos.', whence: '.$whence);
       $this->pos= 0;
-      throw $e;
+      throw new IOException('Seek error, position '.$offset.', whence: '.$whence);
     }
   }
 

--- a/src/main/php/io/streams/MemoryInputStream.class.php
+++ b/src/main/php/io/streams/MemoryInputStream.class.php
@@ -15,11 +15,7 @@ class MemoryInputStream implements InputStream, Seekable, Value {
   protected $pos= 0;
   protected $bytes;
 
-  /**
-   * Constructor
-   *
-   * @param  string $bytes
-   */
+  /** @param string $bytes */
   public function __construct($bytes) {
     $this->bytes= (string)$bytes;
   }
@@ -59,13 +55,13 @@ class MemoryInputStream implements InputStream, Seekable, Value {
    * @param  int $offset
    * @param  int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
    * @throws io.IOException
+   * @return void
    */
   public function seek($offset, $whence= SEEK_SET) {
-    $l= strlen($this->bytes);
     switch ($whence) {
       case SEEK_SET: $this->pos= $offset; break;
       case SEEK_CUR: $this->pos+= $offset; break;
-      case SEEK_END: $this->pos= $l + $offset; break;
+      case SEEK_END: $this->pos= strlen($this->bytes) + $offset; break;
       default: throw new IOException('Unexpected whence '.$whence);
     }
 

--- a/src/main/php/io/streams/MemoryOutputStream.class.php
+++ b/src/main/php/io/streams/MemoryOutputStream.class.php
@@ -16,14 +16,15 @@ class MemoryOutputStream implements OutputStream, Seekable, Truncation, Value {
 
   /** @param string $bytes */
   public function __construct($bytes= '') {
-    $this->bytes= $bytes;
-    $this->pos= strlen($bytes);
+    $this->bytes= (string)$bytes;
+    $this->pos= strlen($this->bytes);
   }
 
   /**
    * Write a string
    *
    * @param  var $arg
+   * @return void
    */
   public function write($arg) {
     $l= strlen($arg);
@@ -66,6 +67,7 @@ class MemoryOutputStream implements OutputStream, Seekable, Truncation, Value {
    * @param  int $offset
    * @param  int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
    * @throws io.IOException
+   * @return void
    */
   public function seek($offset, $whence= SEEK_SET) {
     switch ($whence) {

--- a/src/main/php/io/streams/MemoryOutputStream.class.php
+++ b/src/main/php/io/streams/MemoryOutputStream.class.php
@@ -1,12 +1,13 @@
 <?php namespace io\streams;
 
+use io\IOException;
 use lang\Value;
 use util\Comparison;
 
 /**
  * OuputStream writes to memory, which can be retrieved via `bytes()`
  *
- * @test  net.xp_framework.unittest.io.streams.MemoryOutputStreamTest
+ * @test  io.unittest.MemoryOutputStreamTest
  */
 class MemoryOutputStream implements OutputStream, Seekable, Truncation, Value {
   use Comparison;
@@ -62,20 +63,31 @@ class MemoryOutputStream implements OutputStream, Seekable, Truncation, Value {
   /**
    * Seek to a given offset
    *
-   * @param   int $offset
-   * @param   int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
-   * @throws  io.IOException in case of error
+   * @param  int $offset
+   * @param  int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
+   * @throws io.IOException
    */
   public function seek($offset, $whence= SEEK_SET) {
     switch ($whence) {
       case SEEK_SET: $this->pos= $offset; break;
       case SEEK_CUR: $this->pos+= $offset; break;
       case SEEK_END: $this->pos= strlen($this->bytes) + $offset; break;
+      default: throw new IOException('Unexpected whence '.$whence);
+    }
+
+    // Ensure we cannot seek *before* start
+    if ($this->pos < 0) {
+      $e= new IOException('Seek error, position '.$this->pos.', whence: '.$whence);
+      $this->pos= 0;
+      throw $e;
     }
   }
 
   /** @return int */
   public function tell() { return $this->pos; }
+
+  /** @return int */
+  public function size() { return strlen($this->bytes); }
 
   /** @return string */
   public function bytes() { return $this->bytes; }

--- a/src/main/php/io/streams/MemoryOutputStream.class.php
+++ b/src/main/php/io/streams/MemoryOutputStream.class.php
@@ -79,9 +79,8 @@ class MemoryOutputStream implements OutputStream, Seekable, Truncation, Value {
 
     // Ensure we cannot seek *before* start
     if ($this->pos < 0) {
-      $e= new IOException('Seek error, position '.$this->pos.', whence: '.$whence);
       $this->pos= 0;
-      throw $e;
+      throw new IOException('Seek error, position '.$offset.', whence: '.$whence);
     }
   }
 

--- a/src/test/php/io/unittest/MemoryInputStreamTest.class.php
+++ b/src/test/php/io/unittest/MemoryInputStreamTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace io\unittest;
 
+use io\IOException;
 use io\streams\MemoryInputStream;
-use test\{Assert, Test};
+use test\{Assert, Expect, Test, Values};
 
 class MemoryInputStreamTest {
   const BUFFER= 'Hello World, how are you doing?';
@@ -9,22 +10,99 @@ class MemoryInputStreamTest {
   /** @return io.streams.MemoryInputStream */
   private function newFixture() { return new MemoryInputStream(self::BUFFER); }
 
-  #[Test]
-  public function readAll() {
-    $in= $this->newFixture();
-    Assert::equals(self::BUFFER, $in->read(strlen(self::BUFFER)));
-    Assert::equals(0, $in->available());
+  /** @return iterable */
+  private function seeks() {
+
+    // Start + offset
+    yield [SEEK_SET, 1, 1];
+    yield [SEEK_SET, 0, 0];
+
+    // Current position + offset
+    yield [SEEK_CUR, -1, 4];
+    yield [SEEK_CUR, 0, 5];
+    yield [SEEK_CUR, 1, 6];
+
+    // End + offset
+    yield [SEEK_END, -1, strlen(self::BUFFER) - 1];
+    yield [SEEK_END, 0, strlen(self::BUFFER)];
+    yield [SEEK_END, 1, strlen(self::BUFFER) + 1];
   }
 
   #[Test]
-  public function readChunk() {
+  public function size() {
+    Assert::equals(strlen(self::BUFFER), $this->newFixture()->size());
+  }
+
+  #[Test]
+  public function bytes() {
+    Assert::equals(self::BUFFER, $this->newFixture()->bytes());
+  }
+
+  #[Test]
+  public function initially_available() {
+    Assert::equals(strlen(self::BUFFER), $this->newFixture()->available());
+  }
+
+  #[Test]
+  public function read_all() {
+    Assert::equals(self::BUFFER, $this->newFixture()->read(strlen(self::BUFFER)));
+  }
+
+  #[Test]
+  public function read_chunk() {
     $in= $this->newFixture();
-    Assert::equals('Hello', $in->read(5));
+    Assert::equals('Hello', $this->newFixture()->read(5));
+  }
+
+  #[Test]
+  public function available_after_reading() {
+    $in= $this->newFixture();
+    $in->read(5);
     Assert::equals(strlen(self::BUFFER) - 5, $in->available());
   }
-  
+
   #[Test]
-  public function closingTwice() {
+  public function tell() {
+    Assert::equals(0, $this->newFixture()->tell());
+  }
+
+  #[Test]
+  public function tell_after_reading() {
+    $in= $this->newFixture();
+    $in->read(5);
+    Assert::equals(5, $in->tell());
+  }
+
+  #[Test]
+  public function seek() {
+    $in= $this->newFixture();
+    $in->read(5);
+    $in->seek(0);
+    Assert::equals('Hello', $in->read(5));
+  }
+
+  #[Test, Expect(IOException::class)]
+  public function seek_unknown_whence() {
+    $in= $this->newFixture();
+    $in->seek(0, 9999);
+  }
+
+  #[Test, Expect(IOException::class)]
+  public function seek_before_start() {
+    $in= $this->newFixture();
+    $in->seek(0, -1);
+  }
+
+  #[Test, Values(from: 'seeks')]
+  public function seeking_after_read($whence, $offset, $expected) {
+    $in= $this->newFixture();
+    $in->read(5);
+    $in->seek($offset, $whence);
+    Assert::equals($expected, $in->tell());
+  }
+
+  #[Test]
+  public function closing_twice() {
     $in= $this->newFixture();
     $in->close();
     $in->close();

--- a/src/test/php/io/unittest/MemoryOutputStreamTest.class.php
+++ b/src/test/php/io/unittest/MemoryOutputStreamTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace io\unittest;
 
+use io\IOException;
 use io\streams\MemoryOutputStream;
-use test\{Assert, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class MemoryOutputStreamTest {
 
@@ -12,19 +13,21 @@ class MemoryOutputStreamTest {
 
   #[Test]
   public function initially_empty() {
-    Assert::equals('', (new MemoryOutputStream())->bytes());
+    $out= new MemoryOutputStream();
+    Assert::equals('', $out->bytes());
   }
 
   #[Test]
   public function initial_value() {
-    Assert::equals('Test', (new MemoryOutputStream('Test'))->bytes());
+    $out= new MemoryOutputStream('Test');
+    Assert::equals('Test', $out->bytes());
   }
 
   #[Test]
   public function writing_a_string() {
     $out= new MemoryOutputStream();
-    $out->write('Hello');
-    Assert::equals('Hello', $out->bytes());
+    $out->write('Test');
+    Assert::equals('Test', $out->bytes());
   }
 
   #[Test]
@@ -45,6 +48,25 @@ class MemoryOutputStreamTest {
     $out= new MemoryOutputStream();
     $out->write('Hello');
     Assert::equals(5, $out->tell());
+  }
+
+  #[Test]
+  public function size() {
+    $out= new MemoryOutputStream();
+    Assert::equals(0, $out->size());
+  }
+
+  #[Test]
+  public function size_with_initial_value() {
+    $out= new MemoryOutputStream('Hello');
+    Assert::equals(5, $out->size());
+  }
+
+  #[Test]
+  public function size_after_writing() {
+    $out= new MemoryOutputStream();
+    $out->write('Hello');
+    Assert::equals(5, $out->size());
   }
 
   #[Test, Values([0, 1, 5])]
@@ -85,6 +107,16 @@ class MemoryOutputStreamTest {
     Assert::equals('Hell_', $out->bytes());
   }
 
+  #[Test, Expect(IOException::class)]
+  public function seek_unknown_whence() {
+    (new MemoryOutputStream(''))->seek(0, 9999);
+  }
+
+  #[Test, Expect(IOException::class)]
+  public function seek_before_start() {
+    (new MemoryOutputStream(''))->seek(-1);
+  }
+
   #[Test]
   public function overwriting() {
     $out= new MemoryOutputStream();
@@ -106,6 +138,7 @@ class MemoryOutputStreamTest {
   public function truncate_to_same_length() {
     $out= new MemoryOutputStream('Hello');
     $out->truncate(5);
+    Assert::equals(5, $out->size());
     Assert::equals('Hello', $out->bytes());
   }
 
@@ -113,6 +146,7 @@ class MemoryOutputStreamTest {
   public function truncate_to_zero() {
     $out= new MemoryOutputStream('Hello');
     $out->truncate(0);
+    Assert::equals(0, $out->size());
     Assert::equals('', $out->bytes());
   }
 
@@ -120,6 +154,7 @@ class MemoryOutputStreamTest {
   public function shorten_using_truncate() {
     $out= new MemoryOutputStream('Hello');
     $out->truncate(4);
+    Assert::equals(4, $out->size());
     Assert::equals('Hell', $out->bytes());
   }
 
@@ -127,6 +162,7 @@ class MemoryOutputStreamTest {
   public function lengthen_using_truncate() {
     $out= new MemoryOutputStream('Hello');
     $out->truncate(6);
+    Assert::equals(6, $out->size());
     Assert::equals("Hello\x00", $out->bytes());
   }
 


### PR DESCRIPTION
* [x] Seeking before start raises an IOException
* [x] Supplying an unknown whence mode raises an IOException
* [x] Added *size()* method to `MemoryOutputStream`
* [x] Added *bytes()* method to `MemoryInputStream`
* [x] Cast input to string inside `MemoryOutputStream`
* [x] API docs