### PR TITLE
I/O exceptions refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/src/main/php/io/File.class.php
+++ b/src/main/php/io/File.class.php
@@ -132,8 +132,8 @@ class File implements Channel, Value {
    *
    * @param   string mode one of the File::* constants
    * @return  self
-   * @throws  io.FileNotFoundException in case the file is not found
-   * @throws  io.IOException in case the file cannot be opened (e.g., lacking permissions)
+   * @throws  io.NotFound in case the file is not found
+   * @throws  io.OperationFailed in case the file cannot be opened (e.g., lacking permissions)
    */
   public function open($mode= self::READ): self {
     $this->mode= $mode;
@@ -141,12 +141,12 @@ class File implements Channel, Value {
       self::READ === $mode && 
       0 !== strncmp('php://', $this->uri, 6) &&
       !$this->exists()
-    ) throw new FileNotFoundException('File "'.$this->uri.'" not found');
+    ) throw new NotFound('File "'.$this->uri.'" not found');
     
     $this->_fd= fopen($this->uri, $this->mode);
     if (!$this->_fd) {
       $this->_fd= null;
-      $e= new IOException('Cannot open '.$this->uri.' mode '.$this->mode);
+      $e= new OperationFailed('Cannot open '.$this->uri.' mode '.$this->mode);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -164,11 +164,11 @@ class File implements Channel, Value {
    * Retrieve the file's size in bytes
    *
    * @return  int size filesize in bytes
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function size(): int {
     if (false === ($stat= $this->_fd ? fstat($this->_fd) : stat($this->uri))) {
-      $e= new IOException('Cannot get filesize for '.$this->uri);
+      $e= new OperationFailed('Cannot get filesize for '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -180,11 +180,11 @@ class File implements Channel, Value {
    *
    * @param   int $size Default 0
    * @return  bool
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function truncate(int $size= 0): bool {
     if (null === $this->_fd) {
-      throw new IOException('Cannot truncate file '.$this->uri);
+      throw new OperationFailed('Cannot truncate file '.$this->uri);
     }
 
     // OS vagaries: Windows does not retain file position!
@@ -197,7 +197,7 @@ class File implements Channel, Value {
     }
 
     if (false === $return) {
-      $e= new IOException('Cannot truncate file '.$this->uri);
+      $e= new OperationFailed('Cannot truncate file '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -216,11 +216,11 @@ class File implements Channel, Value {
    * On such filesystems this function will be useless. 
    *
    * @return  int The date the file was last accessed as a unix-timestamp
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function lastAccessed() {
     if (false === ($atime= fileatime($this->uri))) {
-      $e= new IOException('Cannot get atime for '.$this->uri);
+      $e= new OperationFailed('Cannot get atime for '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -231,11 +231,11 @@ class File implements Channel, Value {
    * Retrieve last modification time
    *
    * @return  int The date the file was last modified as a unix-timestamp
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function lastModified() {
     if (false === ($mtime= filemtime($this->uri))) {
-      $e= new IOException('Cannot get mtime for '.$this->uri);
+      $e= new OperationFailed('Cannot get mtime for '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -247,12 +247,12 @@ class File implements Channel, Value {
    *
    * @param   int time default -1 Unix-timestamp
    * @return  bool success
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function touch($time= -1) {
     if (-1 == $time) $time= time();
     if (false === touch($this->uri, $time)) {
-      $e= new IOException('Cannot set mtime for '.$this->uri);
+      $e= new OperationFailed('Cannot set mtime for '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -263,11 +263,11 @@ class File implements Channel, Value {
    * Retrieve when the file was created
    *
    * @return  int The date the file was created as a unix-timestamp
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function createdAt() {
     if (false === ($mtime= filectime($this->uri))) {
-      $e= new IOException('Cannot get mtime for '.$this->uri);
+      $e= new OperationFailed('Cannot get mtime for '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -283,7 +283,7 @@ class File implements Channel, Value {
    *
    * @param   int bytes default 4096 Max. amount of bytes to be read
    * @return  string Data read
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function readLine($bytes= 4096) {
     $bytes= $this->gets($bytes);
@@ -294,11 +294,11 @@ class File implements Channel, Value {
    * Read one char
    *
    * @return  string the character read
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function readChar() {
     if (null === $this->_fd || false === ($result= fgetc($this->_fd)) && !feof($this->_fd)) {
-      $e= new IOException('Cannot read 1 byte from '.$this->uri);
+      $e= new OperationFailed('Cannot read 1 byte from '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -313,12 +313,12 @@ class File implements Channel, Value {
    *
    * @param   int bytes default 4096 Max. amount of bytes to read
    * @return  string Data read
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function gets($bytes= 4096) {
     if (0 === $bytes) return '';
     if (null === $this->_fd || false === ($result= fgets($this->_fd, $bytes)) && !feof($this->_fd)) {
-      $e= new IOException('Cannot read '.$bytes.' bytes from '.$this->uri);
+      $e= new OperationFailed('Cannot read '.$bytes.' bytes from '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -330,12 +330,12 @@ class File implements Channel, Value {
    *
    * @param   int bytes default 4096 Max. amount of bytes to read
    * @return  string Data read
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function read($bytes= 4096) {
     if (0 === $bytes) return '';
     if (null === $this->_fd || false === ($result= fread($this->_fd, $bytes)) && !feof($this->_fd)) {
-      $e= new IOException('Cannot read '.$bytes.' bytes from '.$this->uri);
+      $e= new OperationFailed('Cannot read '.$bytes.' bytes from '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -347,11 +347,11 @@ class File implements Channel, Value {
    *
    * @param   string string data to write
    * @return  int number of bytes written
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function write($string) {
     if (null === $this->_fd || false === ($result= fwrite($this->_fd, $string))) {
-      $e= new IOException('Cannot write '.strlen($string).' bytes to '.$this->uri);
+      $e= new OperationFailed('Cannot write '.strlen($string).' bytes to '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -363,11 +363,11 @@ class File implements Channel, Value {
    *
    * @param   string string data default '' to write
    * @return  int number of bytes written
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function writeLine($string= '') {
     if (null === $this->_fd || false === ($result= fwrite($this->_fd, $string."\n"))) {
-      $e= new IOException('Cannot write '.(strlen($string)+ 1).' bytes to '.$this->uri);
+      $e= new OperationFailed('Cannot write '.(strlen($string)+ 1).' bytes to '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -382,12 +382,12 @@ class File implements Channel, Value {
    *
    * @see     php://feof
    * @return  bool TRUE when the end of the file is reached
-   * @throws  io.IOException in case of an error (e.g., the file's not been opened)
+   * @throws  io.OperationFailed in case of an error (e.g., the file's not been opened)
    */
   public function eof() {
     $result= feof($this->_fd);
     if (isset(\xp::$errors[__FILE__][__LINE__ - 1])) {
-      $e= new IOException('Cannot determine eof of '.$this->uri);
+      $e= new OperationFailed('Cannot determine eof of '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -401,11 +401,11 @@ class File implements Channel, Value {
    * This function is identical to a call of $f->seek(0, SEEK_SET)
    *
    * @return  bool TRUE if rewind suceeded
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function rewind() {
     if (null === $this->_fd || false === ($result= rewind($this->_fd))) {
-      $e= new IOException('Cannot rewind file pointer');
+      $e= new OperationFailed('Cannot rewind file pointer');
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -418,12 +418,12 @@ class File implements Channel, Value {
    * @param   int position default 0 The new position
    * @param   int mode default SEEK_SET 
    * @see     php://fseek
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    * @return  bool success
    */
   public function seek($position= 0, $mode= SEEK_SET) {
     if (null === $this->_fd || 0 != ($result= fseek($this->_fd, $position, $mode))) {
-      $e= new IOException('Seek error, position '.$position.' in mode '.$mode);
+      $e= new OperationFailed('Seek error, position '.$position.' in mode '.$mode);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -434,11 +434,11 @@ class File implements Channel, Value {
    * Retrieve file pointer position
    *
    * @return  int position
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function tell() {
     if (null === $this->_fd || false === ($result= ftell($this->_fd))) {
-      $e= new IOException('Cannot retrieve file pointer\'s position');
+      $e= new OperationFailed('Cannot retrieve file pointer\'s position');
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -462,7 +462,7 @@ class File implements Channel, Value {
    * errno condition).
    *
    * @param   int op operation (one of the predefined LOCK_* constants)
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    * @return  bool success
    * @see     php://flock
    */
@@ -480,7 +480,7 @@ class File implements Channel, Value {
           $mode-= $o;
         }
       }
-      $e= new IOException('Cannot lock file '.$this->uri.' w/ '.substr($os, 3));
+      $e= new OperationFailed('Cannot lock file '.$this->uri.' w/ '.substr($os, 3));
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -524,14 +524,14 @@ class File implements Channel, Value {
    * Close this file
    *
    * @return  bool success
-   * @throws  io.IOException if close fails
+   * @throws  io.OperationFailed if close fails
    */
   public function close() {
     if (!is_resource($this->_fd)) {
-      throw new IOException('Cannot close non-opened file '.$this->uri);
+      throw new OperationFailed('Cannot close non-opened file '.$this->uri);
     }
     if (false === fclose($this->_fd)) {
-      $e= new IOException('Cannot close file '.$this->uri);
+      $e= new OperationFailed('Cannot close file '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -547,7 +547,7 @@ class File implements Channel, Value {
    * close the file first
    *
    * @return  bool success
-   * @throws  io.IOException in case of an error (e.g., lack of permissions)
+   * @throws  io.OperationFailed in case of an error (e.g., lack of permissions)
    * @throws  lang.IllegalStateException in case the file is still open
    */
   public function unlink() {
@@ -555,7 +555,7 @@ class File implements Channel, Value {
       throw new IllegalStateException('File still open');
     }
     if (false === unlink($this->uri)) {
-      $e= new IOException('Cannot delete file '.$this->uri);
+      $e= new OperationFailed('Cannot delete file '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -570,7 +570,7 @@ class File implements Channel, Value {
    *
    * @param   var target where to move the file to, either a string, a File or a Folder
    * @return  bool success
-   * @throws  io.IOException in case of an error (e.g., lack of permissions)
+   * @throws  io.OperationFailed in case of an error (e.g., lack of permissions)
    * @throws  lang.IllegalStateException in case the file is still open
    */
   public function move($target) {
@@ -587,7 +587,7 @@ class File implements Channel, Value {
     }
     
     if (false === rename($this->uri, $uri)) {
-      $e= new IOException('Cannot move file '.$this->uri.' to '.$uri);
+      $e= new OperationFailed('Cannot move file '.$this->uri.' to '.$uri);
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -604,7 +604,7 @@ class File implements Channel, Value {
    *
    * @param   var target where to copy the file to, either a string, a File or a Folder
    * @return  bool success
-   * @throws  io.IOException in case of an error (e.g., lack of permissions)
+   * @throws  io.OperationFailed in case of an error (e.g., lack of permissions)
    * @throws  lang.IllegalStateException in case the file is still open
    */
   public function copy($target) {
@@ -621,7 +621,7 @@ class File implements Channel, Value {
     }
     
     if (false === copy($this->uri, $uri)) {
-      $e= new IOException('Cannot copy file '.$this->uri.' to '.$uri);
+      $e= new OperationFailed('Cannot copy file '.$this->uri.' to '.$uri);
       \xp::gc(__FILE__);
       throw $e;
     }

--- a/src/main/php/io/FileNotFoundException.class.php
+++ b/src/main/php/io/FileNotFoundException.class.php
@@ -2,6 +2,9 @@
 
 /**
  * Indicates the file could not be found
+ *
+ * @deprecated https://github.com/xp-framework/core/issues/363
  */
 class FileNotFoundException extends IOException {
+
 }

--- a/src/main/php/io/Files.class.php
+++ b/src/main/php/io/Files.class.php
@@ -18,8 +18,8 @@ class Files {
    *
    * @param  string|io.File $file
    * @return string file contents
-   * @throws io.IOException
-   * @throws io.FileNotFoundException
+   * @throws io.OperationFailed
+   * @throws io.NotFound
    */
   public static function read($file) {
     $f= $file instanceof File ? $file : new File($file);
@@ -57,7 +57,7 @@ class Files {
    * @param  string|io.File $file
    * @param  string $bytes
    * @return int
-   * @throws io.IOException
+   * @throws io.OperationFailed
    */
   public static function write($file, $bytes) {
     $f= $file instanceof File ? $file : new File($file);
@@ -80,7 +80,7 @@ class Files {
    * @param  string|io.File $file
    * @param  string $bytes
    * @return int
-   * @throws io.IOException
+   * @throws io.OperationFailed
    */
   public static function append($file, $bytes) {
     $f= $file instanceof File ? $file : new File($file);

--- a/src/main/php/io/Folder.class.php
+++ b/src/main/php/io/Folder.class.php
@@ -112,11 +112,11 @@ class Folder implements Value {
    *
    * @param   int permissions default 0700
    * @return  bool TRUE in case the creation succeeded or the directory already exists
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function create($permissions= 0700) {
     if ('' == (string)$this->uri) {
-      throw new IOException('Cannot create folder with empty name');
+      throw new OperationFailed('Cannot create folder with empty name');
     }
     
     // Border-case: Folder already exists
@@ -128,7 +128,7 @@ class Folder implements Value {
       if (is_dir($d= substr($this->uri, 0, ++$i))) continue;
       if (false === mkdir($d, $permissions)) {
         umask($umask);
-        throw new IOException(sprintf('mkdir("%s", %d) failed', $d, $permissions));
+        throw new OperationFailed(sprintf('mkdir("%s", %d) failed', $d, $permissions));
       }
     }
     umask($umask);
@@ -141,12 +141,12 @@ class Folder implements Value {
    * Warning: Stops at the first element that can't be deleted!
    *
    * @return  bool success
-   * @throws  io.IOException in case one of the entries could'nt be deleted
+   * @throws  io.OperationFailed in case one of the entries could'nt be deleted
    */
   public function unlink($uri= null) {
     $uri= null === $uri ? $this->uri : rtrim($uri, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
     if (false === ($d= opendir($uri))) {
-      throw new IOException('Directory '.$uri.' does not exist');
+      throw new OperationFailed('Directory '.$uri.' does not exist');
     }
 
     while (false !== ($e= readdir($d))) {
@@ -158,12 +158,12 @@ class Folder implements Value {
         $this->unlink($fn);
       } else if (false === unlink($fn)) {
         closedir($d);
-        throw new IOException("Deleting '{$fn}' failed");
+        throw new OperationFailed("Deleting '{$fn}' failed");
       }
     }
     closedir($d);
 
-    if (false === rmdir($uri)) throw new IOException("Deleting '{$uri}' failed");
+    if (false === rmdir($uri)) throw new OperationFailed("Deleting '{$uri}' failed");
     return true;
   }
 
@@ -174,7 +174,7 @@ class Folder implements Value {
    * close the directory first
    *
    * @return  bool success
-   * @throws  io.IOException in case of an error (e.g., lack of permissions)
+   * @throws  io.OperationFailed in case of an error (e.g., lack of permissions)
    * @throws  lang.IllegalStateException in case the directory is still open
    */
   public function move($target) {
@@ -182,7 +182,7 @@ class Folder implements Value {
       throw new IllegalStateException('Directory still open');
     }
     if (false === rename($this->uri, $target)) {
-      throw new IOException('Cannot move directory '.$this->uri.' to '.$target);
+      throw new OperationFailed('Cannot move directory '.$this->uri.' to '.$target);
     }
     return true;
   }
@@ -197,11 +197,11 @@ class Folder implements Value {
    * Retrieve when the folder was created
    *
    * @return  int The date the file was created as a unix-timestamp
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function createdAt() {
     if (false === ($mtime= filectime($this->uri))) {
-      throw new IOException('Cannot get mtime for '.$this->uri);
+      throw new OperationFailed('Cannot get mtime for '.$this->uri);
     }
     return $mtime;
   }
@@ -218,11 +218,11 @@ class Folder implements Value {
    * On such filesystems this function will be useless. 
    *
    * @return  int The date the file was last accessed as a unix-timestamp
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function lastAccessed() {
     if (false === ($atime= fileatime($this->uri))) {
-      throw new IOException('Cannot get atime for '.$this->uri);
+      throw new OperationFailed('Cannot get atime for '.$this->uri);
     }
     return $atime;
   }
@@ -231,11 +231,11 @@ class Folder implements Value {
    * Retrieve last modification time
    *
    * @return  int The date the file was last modified as a unix-timestamp
-   * @throws  io.IOException in case of an error
+   * @throws  io.OperationFailed in case of an error
    */
   public function lastModified() {
     if (false === ($mtime= filemtime($this->uri))) {
-      throw new IOException('Cannot get mtime for '.$this->uri);
+      throw new OperationFailed('Cannot get mtime for '.$this->uri);
     }
     return $mtime;
   }

--- a/src/main/php/io/Folder.class.php
+++ b/src/main/php/io/Folder.class.php
@@ -8,8 +8,8 @@ use lang\{IllegalStateException, Value};
  * Usage:
  * ```
  * $d= new Folder('/etc/');
- * while (false !== ($entry= $d->getEntry())) {
- *   printf("%s/%s\n", $d->uri, $entry);
+ * foreach ($d->entries() as $entry) {
+ *   echo $entry, "\n";
  * }
  * $d->close();
  * ```
@@ -17,12 +17,7 @@ use lang\{IllegalStateException, Value};
  * @test  io.unittest.FolderTest
  */
 class Folder implements Value {
-  public 
-    $uri      = '',
-    $dirname  = '',
-    $path     = '';
-  
-  private $_hdir = false;
+  public $uri, $dirname, $path;
     
   /**
    * Constructor
@@ -40,23 +35,6 @@ class Folder implements Value {
     }
 
     $this->setURI($composed.implode(DIRECTORY_SEPARATOR, $args));
-  }
-  
-  /**
-   * Destructor
-   */
-  public function __destruct() {
-    $this->close();
-  }
-  
-  /**
-   * Close directory
-   *
-   * @return void
-   */
-  public function close() {
-    if (false != $this->_hdir) $this->_hdir->close();
-    $this->_hdir= false;
   }
 
   /**
@@ -170,17 +148,10 @@ class Folder implements Value {
   /**
    * Move this directory
    *
-   * Warning: Open directories cannot be moved. Use the close() method to
-   * close the directory first
-   *
    * @return  bool success
    * @throws  io.OperationFailed in case of an error (e.g., lack of permissions)
-   * @throws  lang.IllegalStateException in case the directory is still open
    */
   public function move($target) {
-    if (is_resource($this->_hdir)) {
-      throw new IllegalStateException('Directory still open');
-    }
     if (false === rename($this->uri, $target)) {
       throw new OperationFailed('Cannot move directory '.$this->uri.' to '.$target);
     }

--- a/src/main/php/io/FolderEntries.class.php
+++ b/src/main/php/io/FolderEntries.class.php
@@ -31,11 +31,20 @@ class FolderEntries implements IteratorAggregate {
     return new Path($this->base, $name);
   }
 
-  /** Iterate over all entries */
+  /**
+   * Iterate over all entries
+   *
+   * @throws io.NotFound
+   * @throws io.OperationFailed
+   */
   public function getIterator(): Traversable {
     if (null === $this->handle) {
-      if (!is_resource($handle= opendir($this->base->asFolder()->getURI()))) {
-        $e= new OperationFailed('Cannot open folder '.$this->base);
+      $uri= $this->base->asURI();
+      if (!is_resource($handle= opendir($uri))) {
+        $e= file_exists($uri)
+          ? new OperationFailed('Cannot open folder '.$uri)
+          : new NotFound('Folder '.$uri.' does not exist')
+        ;
         \xp::gc(__FILE__);
         throw $e;
       }

--- a/src/main/php/io/FolderEntries.class.php
+++ b/src/main/php/io/FolderEntries.class.php
@@ -35,7 +35,7 @@ class FolderEntries implements IteratorAggregate {
   public function getIterator(): Traversable {
     if (null === $this->handle) {
       if (!is_resource($handle= opendir($this->base->asFolder()->getURI()))) {
-        $e= new IOException('Cannot open folder '.$this->base);
+        $e= new OperationFailed('Cannot open folder '.$this->base);
         \xp::gc(__FILE__);
         throw $e;
       }

--- a/src/main/php/io/IOException.class.php
+++ b/src/main/php/io/IOException.class.php
@@ -3,7 +3,9 @@
 /**
  * Signals that an I/O exception of some sort has occurred. This 
  * class is the general class of exceptions produced by failed or 
- * interrupted I/O operations. 
+ * interrupted I/O operations.
+ * 
+ * @deprecated https://github.com/xp-framework/core/issues/363
  */
 class IOException extends \lang\XPException {
 

--- a/src/main/php/io/NotFound.class.php
+++ b/src/main/php/io/NotFound.class.php
@@ -1,0 +1,6 @@
+<?php namespace io;
+
+/** Indicates an I/O element could not be found. */
+class NotFound extends OperationFailed {
+
+}

--- a/src/main/php/io/NotSupported.class.php
+++ b/src/main/php/io/NotSupported.class.php
@@ -1,0 +1,6 @@
+<?php namespace io;
+
+/** Indicates an I/O operation is not supported. */
+class NotSupported extends OperationFailed {
+
+}

--- a/src/main/php/io/OperationFailed.class.php
+++ b/src/main/php/io/OperationFailed.class.php
@@ -1,0 +1,8 @@
+<?php namespace io;
+
+use lang\XPException;
+
+/** Signals that an I/O opertation has failed */
+class OperationFailed extends XPException {
+
+}

--- a/src/main/php/io/OperationNotSupportedException.class.php
+++ b/src/main/php/io/OperationNotSupportedException.class.php
@@ -2,6 +2,8 @@
 
 /**
  * Indicates an operation is not supported
+ *
+ * @deprecated https://github.com/xp-framework/core/issues/363
  */
 class OperationNotSupportedException extends IOException {
 

--- a/src/main/php/io/OperationTimedOutException.class.php
+++ b/src/main/php/io/OperationTimedOutException.class.php
@@ -2,6 +2,8 @@
 
 /**
  * Indicates an operation timed out
+ *
+ * @deprecated https://github.com/xp-framework/core/issues/363
  */
 class OperationTimedOutException extends IOException {
 

--- a/src/main/php/io/TempFile.class.php
+++ b/src/main/php/io/TempFile.class.php
@@ -59,7 +59,7 @@ class TempFile extends File {
    *
    * @param  string $contents
    * @return self
-   * @throws io.IOException if an I/O error occurs
+   * @throws io.OperationFailed if an I/O error occurs
    * @throws lang.IllegalStateException if the file is open
    */
   public function containing($contents) {
@@ -68,7 +68,7 @@ class TempFile extends File {
     }
 
     if (false === file_put_contents($this->uri, $contents)) {
-      $e= new IOException('Cannot write to temporary file '.$this->uri);
+      $e= new OperationFailed('Cannot write to temporary file '.$this->uri);
       \xp::gc(__FILE__);
       throw $e;
     }

--- a/src/main/php/io/TimedOut.class.php
+++ b/src/main/php/io/TimedOut.class.php
@@ -1,0 +1,6 @@
+<?php namespace io;
+
+/** Indicates an I/O operation timed out. */
+class TimedOut extends OperationFailed {
+
+}

--- a/src/main/php/io/streams/Buffer.class.php
+++ b/src/main/php/io/streams/Buffer.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\{File, Folder, Path, TempFile, IOException};
+use io\{File, Folder, Path, TempFile, OperationFailed};
 use lang\IllegalArgumentException;
 
 /**
@@ -125,7 +125,7 @@ class Buffer implements InputStream, OutputStream, Seekable {
    * @param  int $offset
    * @param  int $whence SEEK_SET, SEEK_CUR or SEEK_END
    * @return void
-   * @throws io.IOException
+   * @throws io.OperationFailed
    */
   public function seek($offset, $whence= SEEK_SET) {
     switch ($whence) {
@@ -136,7 +136,7 @@ class Buffer implements InputStream, OutputStream, Seekable {
     }
 
     if ($position < 0) {
-      throw new IOException("Seek error, position {$offset} in mode {$whence}");
+      throw new OperationFailed("Seek error, position {$offset} in mode {$whence}");
     }
 
     $this->file ? $this->file->seek($position, SEEK_SET) : $this->pointer= $position;

--- a/src/main/php/io/streams/ChannelInputStream.class.php
+++ b/src/main/php/io/streams/ChannelInputStream.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\IOException;
+use io\OperationFailed;
 use lang\Value;
 use util\Comparison;
 
@@ -25,14 +25,14 @@ class ChannelInputStream implements InputStream, Value {
   public function __construct($arg) {
     if ('stdin' === $arg || 'input' === $arg) {
       if (!($this->fd= fopen('php://'.$arg, 'rb'))) {
-        throw new IOException('Could not open '.$arg.' channel for reading');
+        throw new OperationFailed('Could not open '.$arg.' channel for reading');
       }
       $this->name= $arg;
     } else if (is_resource($arg)) {
       $this->fd= $arg;
       $this->name= '#'.(int)$arg;
     } else {
-      throw new IOException('Expecting either stdin, input or a file descriptor '.typeof($arg).' given');
+      throw new OperationFailed('Expecting either stdin, input or a file descriptor '.typeof($arg).' given');
     }
   }
 
@@ -44,7 +44,7 @@ class ChannelInputStream implements InputStream, Value {
    */
   public function read($limit= 8192) {
     if (null === $this->fd || false === ($bytes= fread($this->fd, $limit))) {
-      $e= new IOException('Could not read '.$limit.' bytes from '.$this->name.' channel');
+      $e= new OperationFailed('Could not read '.$limit.' bytes from '.$this->name.' channel');
       \xp::gc(__FILE__);
       throw $e;
     }

--- a/src/main/php/io/streams/ChannelOutputStream.class.php
+++ b/src/main/php/io/streams/ChannelOutputStream.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\IOException;
+use io\OperationFailed;
 use lang\Value;
 use util\Comparison;
 
@@ -25,14 +25,14 @@ class ChannelOutputStream implements OutputStream, Value {
   public function __construct($arg) {
     if ('stdout' === $arg || 'stderr' === $arg || 'output' === $arg) {
       if (!($this->fd= fopen('php://'.$arg, 'wb'))) {
-        throw new IOException('Could not open '.$arg.' channel for writing');
+        throw new OperationFailed('Could not open '.$arg.' channel for writing');
       }
       $this->name= $arg;
     } else if (is_resource($arg)) {
       $this->fd= $arg;
       $this->name= '#'.(int)$arg;
     } else {
-      throw new IOException('Expecting either stdout, stderr, output or a file descriptor '.typeof($arg).' given');
+      throw new OperationFailed('Expecting either stdout, stderr, output or a file descriptor '.typeof($arg).' given');
     }
   }
 
@@ -43,7 +43,7 @@ class ChannelOutputStream implements OutputStream, Value {
    */
   public function write($arg) { 
     if (null === $this->fd || false === fwrite($this->fd, $arg)) {
-      $e= new IOException('Could not write '.strlen($arg).' bytes to '.$this->name.' channel');
+      $e= new OperationFailed('Could not write '.strlen($arg).' bytes to '.$this->name.' channel');
       \xp::gc(__FILE__);
       throw $e;
     }

--- a/src/main/php/io/streams/FileInputStream.class.php
+++ b/src/main/php/io/streams/FileInputStream.class.php
@@ -66,7 +66,7 @@ class FileInputStream implements InputStream, Seekable, Value {
    *
    * @param   int offset
    * @param   int whence default SEEK_SET (one of SEEK_[SET|CUR|END])
-   * @throws  io.IOException in case of error
+   * @throws  io.OperationFailed in case of error
    */
   public function seek($offset, $whence= SEEK_SET) {
     $this->file->seek($offset, $whence);

--- a/src/main/php/io/streams/FileOutputStream.class.php
+++ b/src/main/php/io/streams/FileOutputStream.class.php
@@ -39,7 +39,7 @@ class FileOutputStream implements OutputStream, Seekable, Truncation, Value {
    *
    * @param   int $offset
    * @param   int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
-   * @throws  io.IOException in case of error
+   * @throws  io.OperationFailed in case of error
    */
   public function seek($offset, $whence= SEEK_SET) {
     $this->file->seek($offset, $whence);

--- a/src/main/php/io/streams/MemoryInputStream.class.php
+++ b/src/main/php/io/streams/MemoryInputStream.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\IOException;
+use io\OperationFailed;
 use lang\Value;
 use util\Comparison;
 
@@ -54,7 +54,7 @@ class MemoryInputStream implements InputStream, Seekable, Value {
    *
    * @param  int $offset
    * @param  int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
-   * @throws io.IOException
+   * @throws io.OperationFailed
    * @return void
    */
   public function seek($offset, $whence= SEEK_SET) {
@@ -62,13 +62,13 @@ class MemoryInputStream implements InputStream, Seekable, Value {
       case SEEK_SET: $this->pos= $offset; break;
       case SEEK_CUR: $this->pos+= $offset; break;
       case SEEK_END: $this->pos= strlen($this->bytes) + $offset; break;
-      default: throw new IOException('Unexpected whence '.$whence);
+      default: throw new OperationFailed('Unexpected whence '.$whence);
     }
 
     // Ensure we cannot seek *before* start
     if ($this->pos < 0) {
       $this->pos= 0;
-      throw new IOException('Seek error, position '.$offset.', whence: '.$whence);
+      throw new OperationFailed('Seek error, position '.$offset.', whence: '.$whence);
     }
   }
 

--- a/src/main/php/io/streams/MemoryOutputStream.class.php
+++ b/src/main/php/io/streams/MemoryOutputStream.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\IOException;
+use io\OperationFailed;
 use lang\Value;
 use util\Comparison;
 
@@ -66,7 +66,7 @@ class MemoryOutputStream implements OutputStream, Seekable, Truncation, Value {
    *
    * @param  int $offset
    * @param  int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
-   * @throws io.IOException
+   * @throws io.OperationFailed
    * @return void
    */
   public function seek($offset, $whence= SEEK_SET) {
@@ -74,13 +74,13 @@ class MemoryOutputStream implements OutputStream, Seekable, Truncation, Value {
       case SEEK_SET: $this->pos= $offset; break;
       case SEEK_CUR: $this->pos+= $offset; break;
       case SEEK_END: $this->pos= strlen($this->bytes) + $offset; break;
-      default: throw new IOException('Unexpected whence '.$whence);
+      default: throw new OperationFailed('Unexpected whence '.$whence);
     }
 
     // Ensure we cannot seek *before* start
     if ($this->pos < 0) {
       $this->pos= 0;
-      throw new IOException('Seek error, position '.$offset.', whence: '.$whence);
+      throw new OperationFailed('Seek error, position '.$offset.', whence: '.$whence);
     }
   }
 

--- a/src/main/php/io/streams/Reader.class.php
+++ b/src/main/php/io/streams/Reader.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\{IOException, Channel};
+use io\{OperationFailed, Channel};
 use lang\{Closeable, Value, IllegalArgumentException};
 use util\Objects;
 
@@ -65,7 +65,7 @@ abstract class Reader implements InputStreamReader, Closeable, Value {
    * Reset to start.
    *
    * @return void
-   * @throws io.IOException in case the underlying stream does not support seeking
+   * @throws io.OperationFailed in case the underlying stream does not support seeking
    */
   public function reset() {
     if ($this->stream instanceof Seekable) {
@@ -73,7 +73,7 @@ abstract class Reader implements InputStreamReader, Closeable, Value {
       $this->beginning= true;
       $this->buf= '';
     } else {
-      throw new IOException('Underlying stream does not support seeking');
+      throw new OperationFailed('Underlying stream does not support seeking');
     }
   }
 

--- a/src/main/php/io/streams/Seekable.class.php
+++ b/src/main/php/io/streams/Seekable.class.php
@@ -12,7 +12,7 @@ interface Seekable {
    *
    * @param   int offset
    * @param   int whence default SEEK_SET (one of SEEK_[SET|CUR|END])
-   * @throws  io.IOException in case of error
+   * @throws  io.OperationFailed in case of error
    */
   public function seek($offset, $whence= SEEK_SET);
 

--- a/src/main/php/io/streams/SpooledInputStream.class.php
+++ b/src/main/php/io/streams/SpooledInputStream.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\IOException;
+use io\OperationFailed;
 use lang\Environment;
 
 /**
@@ -71,7 +71,7 @@ class SpooledInputStream implements InputStream, Seekable {
    * @param  int $offset
    * @param  int $whence SEEK_SET, SEEK_CUR or SEEK_END
    * @return void
-   * @throws io.IOException
+   * @throws io.OperationFailed
    */
   public function seek($offset, $whence= SEEK_SET) {
     switch ($whence) {
@@ -82,7 +82,7 @@ class SpooledInputStream implements InputStream, Seekable {
     }
 
     if ($position < 0) {
-      throw new IOException("Seek error, position {$offset} in mode {$whence}");
+      throw new OperationFailed("Seek error, position {$offset} in mode {$whence}");
     }
 
     // Read from underlying stream when seeking forward, clamping on EOF.

--- a/src/main/php/io/streams/StreamTransfer.class.php
+++ b/src/main/php/io/streams/StreamTransfer.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\IOException;
+use io\OperationFailed;
 use lang\Closeable;
 
 /**
@@ -36,7 +36,7 @@ class StreamTransfer implements Closeable {
    * Copy all available input from in
    *
    * @return int number of bytes copied
-   * @throws io.IOException
+   * @throws io.OperationFailed
    */
   public function transferAll() {
     $r= 0;
@@ -52,7 +52,7 @@ class StreamTransfer implements Closeable {
    * Transmit all available input from in, yielding control after each chunk.
    *
    * @return iterable
-   * @throws io.IOException
+   * @throws io.OperationFailed
    */
   public function transmit() {
     while ($this->in->available()) {
@@ -66,22 +66,22 @@ class StreamTransfer implements Closeable {
    * streams even if one of the close() calls yields an exception.
    *
    * @return void
-   * @throws io.IOException
+   * @throws io.OperationFailed
    */
   public function close() {
     $errors= '';
     try {
       $this->in->close();
-    } catch (IOException $e) {
+    } catch (OperationFailed $e) {
       $errors.= 'Could not close input stream: '.$e->getMessage().', ';
     }
     try {
       $this->out->close();
-    } catch (IOException $e) {
+    } catch (OperationFailed $e) {
       $errors.= 'Could not close output stream: '.$e->getMessage().', ';
     }
     if ($errors) {
-      throw new IOException(rtrim($errors, ', '));
+      throw new OperationFailed(rtrim($errors, ', '));
     }
   }
 

--- a/src/main/php/io/streams/Streams.class.php
+++ b/src/main/php/io/streams/Streams.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\{FileNotFoundException, OperationNotSupportedException, IOException};
+use io\{NotFound, NotSupported, OperationFailed};
 
 /**
  * Wraps I/O streams into PHP streams
@@ -25,7 +25,7 @@ abstract class Streams {
       }
 
       public function stream_write($data) {
-        throw new IOException('Cannot write to readable stream');
+        throw new OperationFailed('Cannot write to readable stream');
       }
 
       public function stream_read($count) {
@@ -55,11 +55,11 @@ abstract class Streams {
           parent::$streams[$this->id]->truncate($size);
           return true;
         }
-        throw new IOException('Cannot truncate underlying stream');
+        throw new OperationFailed('Cannot truncate underlying stream');
       }
 
       public function stream_read($count) {
-        throw new IOException('Cannot read from writeable stream');
+        throw new OperationFailed('Cannot read from writeable stream');
       }
 
       public function stream_flush() {
@@ -125,7 +125,7 @@ abstract class Streams {
    *
    * @param   io.streams.InputStream $s
    * @return  string
-   * @throws  io.IOException
+   * @throws  io.OperationFailed
    */
   public static function readAll(InputStream $s) {
     $r= '';
@@ -140,14 +140,14 @@ abstract class Streams {
    * @param   int $offset
    * @param   int $whence default SEEK_SET (one of SEEK_[SET|CUR|END])
    * @return  void
-   * @throws  io.IOException
-   * @throws  io.OperationNotSupportedException
+   * @throws  io.OperationFailed
+   * @throws  io.NotSupported
    */
   public static function seek(InputStream $s, $offset, $whence= SEEK_SET) {
     if ($s instanceof Seekable) {
       $s->seek($offset, $whence);
     } else {
-      throw new OperationNotSupportedException('Cannot seek instances of '.nameof($s));
+      throw new NotSupported('Cannot seek instances of '.nameof($s));
     }
   }
 
@@ -158,12 +158,12 @@ abstract class Streams {
    * @param   string mode
    * @param   int options
    * @param   string opened_path
-   * @throws  io.FileNotFoundException in case the given file cannot be found
+   * @throws  io.NotFound in case the given file cannot be found
    */
   public function stream_open($path, $mode, $options, $opened_path) {
     sscanf(urldecode($path), "iostr%c://%[^$]", $m, $this->id);
     if (!isset(self::$streams[$this->id])) {
-      throw new FileNotFoundException('Cannot open stream "'.$this->id.'" mode '.$mode);
+      throw new NotFound('Cannot open stream "'.$this->id.'" mode '.$mode);
     }
     return true;
   }
@@ -190,7 +190,7 @@ abstract class Streams {
    */
   public function stream_seek($offset, $whence) {
     if (!self::$streams[$this->id] instanceof Seekable) {
-      throw new IOException('Underlying stream does not support seeking');
+      throw new OperationFailed('Underlying stream does not support seeking');
     }
 
     self::$streams[$this->id]->seek($offset, $whence);
@@ -204,7 +204,7 @@ abstract class Streams {
    */
   public function stream_tell() {
     if (!self::$streams[$this->id] instanceof Seekable) {
-      throw new IOException('Underlying stream does not support seeking');
+      throw new OperationFailed('Underlying stream does not support seeking');
     }
     return self::$streams[$this->id]->tell();
   }

--- a/src/main/php/io/streams/Streams.class.php
+++ b/src/main/php/io/streams/Streams.class.php
@@ -25,7 +25,7 @@ abstract class Streams {
       }
 
       public function stream_write($data) {
-        throw new OperationFailed('Cannot write to readable stream');
+        throw new NotSupported('Cannot write to readable stream');
       }
 
       public function stream_read($count) {
@@ -55,11 +55,11 @@ abstract class Streams {
           parent::$streams[$this->id]->truncate($size);
           return true;
         }
-        throw new OperationFailed('Cannot truncate underlying stream');
+        throw new NotSupported('Cannot truncate underlying stream');
       }
 
       public function stream_read($count) {
-        throw new OperationFailed('Cannot read from writeable stream');
+        throw new NotSupported('Cannot read from writeable stream');
       }
 
       public function stream_flush() {

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -465,4 +465,12 @@ spl_autoload_register(function($class) {
   $cl->loadClass0($name);
   return true;
 });
+
+// https://github.com/xp-framework/core/issues/363
+if (PHP_VERSION_ID < 80600) {
+  class_alias(\io\OperationFailed::class, \io\IOException::class);
+  class_alias(\io\NotFound::class, \io\FileNotFoundException::class);
+  class_alias(\io\NotSupported::class, \io\OperationNotSupportedException::class);
+  class_alias(\io\TimedOut::class, \io\OperationTimedOutException::class);
+}
 // }}}

--- a/src/main/php/lang/Process.class.php
+++ b/src/main/php/lang/Process.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang;
 
-use io\{File, IOException};
+use io\{File, OperationFailed};
 
 /**
  * Process
@@ -43,16 +43,16 @@ class Process {
    * @param  ?string $cwd default NULL the working directory
    * @param  ?[:string] $env default NULL the environment
    * @param  var[] descriptors
-   * @throws io.IOException in case the command could not be executed
+   * @throws io.OperationFailed in case the command could not be executed
    */
   public function __construct($command= null, $arguments= [], $cwd= null, $env= null, $descriptors= []) {
     if (null === $command) return;
 
     // Short-circuit
     if ('' === $command) {
-      throw new IOException('Empty command not resolveable');
+      throw new OperationFailed('Empty command not resolveable');
     } else if (self::$DISABLED) {
-      throw new IOException('Process execution has been disabled');
+      throw new OperationFailed('Process execution has been disabled');
     }
 
     $cmd= CommandLine::forName(PHP_OS_FAMILY);
@@ -76,7 +76,7 @@ class Process {
 
       // Try creating a process from the given arguments and descriptors
       if (!is_resource($this->handle= proc_open($exec, $spec, $pipes, $cwd, $env, $options))) {
-        throw new IOException('Could not execute "'.$exec.'"');
+        throw new OperationFailed('Could not execute "'.$exec.'"');
       }
 
       $this->status= proc_get_status($this->handle);
@@ -99,7 +99,7 @@ class Process {
       return;
     }
 
-    throw new IOException('Could not find "'.$command.'" in path');
+    throw new OperationFailed('Could not find "'.$command.'" in path');
   }
 
   /**
@@ -110,7 +110,7 @@ class Process {
    * @param  ?[:string] $env default NULL the environment
    * @param  var[] $descriptors
    * @return self
-   * @throws io.IOException in case the command could not be executed
+   * @throws io.OperationFailed in case the command could not be executed
    */
   public function newInstance($arguments= [], $cwd= null, $env= null, $descriptors= []): self {
     return new self($this->status['exe'], $arguments, $cwd, $env, $descriptors);
@@ -222,7 +222,7 @@ class Process {
         if (0 !== $exit) {
           throw new IllegalStateException('Cannot find executable: '.implode('', $out));
         }
-      } catch (IOException $e) {
+      } catch (OperationFailed $e) {
         throw new IllegalStateException($e->getMessage());
       }
       $self->status['running?']= function() use($pid) {

--- a/src/main/php/util/Properties.class.php
+++ b/src/main/php/util/Properties.class.php
@@ -69,7 +69,7 @@ class Properties implements PropertyAccess, Value {
    * @param   io.streams.Reader|io.streams.InputStream|io.Channel|string $in
    * @param   ?string $charset the charset the stream is encoded in or NULL to trigger autodetection by BOM
    * @return  self
-   * @throws  io.IOException
+   * @throws  io.OperationFailed
    * @throws  lang.FormatException
    */
   public function load($in, $charset= 'utf-8'): self {
@@ -148,7 +148,7 @@ class Properties implements PropertyAccess, Value {
    *
    * @param   io.streams.Writer|io.streams.OutputStream|io.Channel|string $out
    * @param   string $charset
-   * @throws  io.IOException
+   * @throws  io.OperationFailed
    */
   public function store($out, $charset= 'utf-8') {
     $writer= $out instanceof Writer ? $out : new TextWriter($out, $charset);
@@ -184,7 +184,7 @@ class Properties implements PropertyAccess, Value {
    * Create the property file
    *
    * @return  void
-   * @throws  io.IOException if the property file could not be created
+   * @throws  io.OperationFailed if the property file could not be created
    */
   public function create() {
     if (null !== $this->_file) {
@@ -199,7 +199,7 @@ class Properties implements PropertyAccess, Value {
    * Helper method that loads the data from the file if needed
    *
    * @param   bool force default FALSE
-   * @throws  io.IOException
+   * @throws  io.OperationFailed
    */
   private function _load($force= false) {
     if ($force || null === $this->_data) {

--- a/src/main/php/util/Random.class.php
+++ b/src/main/php/util/Random.class.php
@@ -1,6 +1,6 @@
 <?php namespace util;
 
-use io\IOException;
+use io\OperationFailed;
 use lang\IllegalArgumentException;
 
 /**
@@ -84,11 +84,11 @@ class Random {
    *
    * @param  int $limit
    * @return string $bytes
-   * @throws io.IOException if there is a problem accessing the urandom character device
+   * @throws io.OperationFailed if there is a problem accessing the urandom character device
    */
   private static function urandom($limit) {
     if (!($f= fopen('/dev/urandom', 'r'))) {
-      $e= new IOException('Cannot access /dev/urandom');
+      $e= new OperationFailed('Cannot access /dev/urandom');
       \xp::gc(__FILE__);
       throw $e;
     }
@@ -97,7 +97,7 @@ class Random {
     $stat= fstat($f);
     if (($stat['mode'] & 0170000) !== 020000) {
       fclose($f);
-      throw new IOException('Not a character device: /dev/urandom');
+      throw new OperationFailed('Not a character device: /dev/urandom');
     }
 
     stream_set_read_buffer($f, 0);

--- a/src/main/php/util/cmd/SingleProcess.class.php
+++ b/src/main/php/util/cmd/SingleProcess.class.php
@@ -41,7 +41,7 @@ class SingleProcess {
     try {
       $this->lockfile->open(File::WRITE);
       $this->lockfile->lockExclusive();
-    } catch (\io\IOException $e) {
+    } catch (\io\OperationFailed $e) {
       $this->lockfile->close();
       return false;
     }

--- a/src/main/php/xp/xar/instruction/DiffInstruction.class.php
+++ b/src/main/php/xp/xar/instruction/DiffInstruction.class.php
@@ -1,7 +1,7 @@
 <?php namespace xp\xar\instruction;
 
 use xp\xar\Options;
-use io\{TempFile, File, IOException};
+use io\{TempFile, File, OperationFailed};
 use lang\{Process, IllegalArgumentException};
 use lang\archive\Archive;
 
@@ -109,7 +109,7 @@ class DiffInstruction extends AbstractInstruction {
         }
         
         $p->close();
-      } catch (IOException $e) {
+      } catch (OperationFailed $e) {
         $this->err->writeLine('!=> Invocation of `diff` program failed.');
         $templ->unlink();
         $tempr->unlink();

--- a/src/test/php/io/unittest/BlobTest.class.php
+++ b/src/test/php/io/unittest/BlobTest.class.php
@@ -2,7 +2,7 @@
 
 use ArrayObject;
 use io\streams\{MemoryInputStream, InputStream};
-use io\{Blob, OperationNotSupportedException};
+use io\{Blob, NotSupported};
 use lang\IllegalArgumentException;
 use test\verify\Runtime;
 use test\{Assert, Expect, Test, Values};
@@ -97,7 +97,7 @@ class BlobTest {
     });
     iterator_to_array($fixture->slices());
 
-    Assert::throws(OperationNotSupportedException::class, fn() => iterator_to_array($fixture->slices()));
+    Assert::throws(NotSupported::class, fn() => iterator_to_array($fixture->slices()));
   }
 
   /** @see https://bugs.php.net/bug.php?id=77069 */

--- a/src/test/php/io/unittest/BufferTest.class.php
+++ b/src/test/php/io/unittest/BufferTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\unittest;
 
 use io\streams\Buffer;
-use io\{File, TempFile, Folder, Path, Blob, IOException};
+use io\{File, TempFile, Folder, Path, Blob, OperationFailed};
 use lang\{Environment, IllegalArgumentException};
 use test\{Assert, Test, Values};
 
@@ -201,12 +201,12 @@ class BufferTest {
 
   #[Test]
   public function cannot_seek_before_start() {
-    Assert::throws(IOException::class, fn() => $this->newFixture()->seek(-1));
+    Assert::throws(OperationFailed::class, fn() => $this->newFixture()->seek(-1));
   }
 
   #[Test]
   public function cannot_seek_invalid_whence() {
-    Assert::throws(IOException::class, fn() => $this->newFixture()->seek(0, 6100));
+    Assert::throws(OperationFailed::class, fn() => $this->newFixture()->seek(0, 6100));
   }
 
   #[Test]

--- a/src/test/php/io/unittest/ChannelStreamTest.class.php
+++ b/src/test/php/io/unittest/ChannelStreamTest.class.php
@@ -1,48 +1,48 @@
 <?php namespace io\unittest;
 
-use io\IOException;
+use io\OperationFailed;
 use io\streams\{ChannelInputStream, ChannelOutputStream};
 use lang\Runnable;
 use test\{Assert, Expect, Test};
 
 class ChannelStreamTest {
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function invalidOutputChannelName() {
     new ChannelOutputStream('@@invalid@@');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function invalidInputChannelName() {
     new ChannelInputStream('@@invalid@@');
   }
   
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function stdinIsNotAnOutputStream() {
     new ChannelOutputStream('stdin');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function inputIsNotAnOutputStream() {
     new ChannelOutputStream('input');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function stdoutIsNotAnInputStream() {
     new ChannelInputStream('stdout');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function stderrIsNotAnInputStream() {
     new ChannelInputStream('stderr');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function outputIsNotAnInputStream() {
     new ChannelInputStream('outpit');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function writeToClosedChannel() {
     ChannelWrapper::capture(new class() implements Runnable {
       public function run() {
@@ -53,7 +53,7 @@ class ChannelStreamTest {
     });
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function readingFromClosedChannel() {
     ChannelWrapper::capture(new class() implements Runnable {
       public function run() {

--- a/src/test/php/io/unittest/FileInputStreamTest.class.php
+++ b/src/test/php/io/unittest/FileInputStreamTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\unittest;
 
 use io\streams\FileInputStream;
-use io\{FileNotFoundException, IOException, TempFile};
+use io\{NotFound, OperationFailed, TempFile};
 use test\{After, Assert, Expect, PrerequisitesNotMetError, Test};
 
 class FileInputStreamTest {
@@ -20,7 +20,7 @@ class FileInputStreamTest {
       try {
         $file->isOpen() && $file->close();
         $file->unlink();
-      } catch (IOException $ignored) {
+      } catch (OperationFailed $ignored) {
         // Can't really do anything about it...
       }
     }
@@ -71,12 +71,12 @@ class FileInputStreamTest {
     });
   }
 
-  #[Test, Expect(FileNotFoundException::class)]
+  #[Test, Expect(NotFound::class)]
   public function nonExistantFile() {
     new FileInputStream('::NON-EXISTANT::');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function readingAfterClose() {
     with (new FileInputStream($this->tempFile()), function($stream) {
       $stream->close();
@@ -84,7 +84,7 @@ class FileInputStreamTest {
     });
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function availableAfterClose() {
     with (new FileInputStream($this->tempFile()), function($stream) {
       $stream->close();

--- a/src/test/php/io/unittest/FileIntegrationTest.class.php
+++ b/src/test/php/io/unittest/FileIntegrationTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\unittest;
 
-use io\{File, FileNotFoundException, Folder, IOException};
+use io\{File, NotFound, Folder, OperationFailed};
 use lang\{Environment, IllegalStateException};
 use test\{After, Assert, Before, Expect, Ignore, Test};
 
@@ -58,7 +58,7 @@ class FileIntegrationTest {
    * @param   string data default NULL
    * @param   bool append default FALSE
    * @return  int number of written bytes or 0 if NULL data was given
-   * @throws  io.IOException
+   * @throws  io.OperationFailed
    */
   protected function writeData($file, $data= null, $append= false) {
     $file->open($append ? File::APPEND : File::WRITE);
@@ -113,7 +113,7 @@ class FileIntegrationTest {
     Assert::false($file->exists());
   }
   
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function cannotDeleteNonExistant() {
     $this->tempFile()->unlink();
   }
@@ -125,7 +125,7 @@ class FileIntegrationTest {
     $file->unlink();
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function cannotCloseUnopenedFile() {
     $this->tempFile()->close();
   }
@@ -291,7 +291,7 @@ class FileIntegrationTest {
     }
   }
 
-  #[Test, Expect(FileNotFoundException::class)]
+  #[Test, Expect(NotFound::class)]
   public function cannotOpenNonExistantForReading() {
     $this->tempFile()->open(File::READ);
   }

--- a/src/test/php/io/unittest/FileOutputStreamTest.class.php
+++ b/src/test/php/io/unittest/FileOutputStreamTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\unittest;
 
 use io\streams\FileOutputStream;
-use io\{File, Files, IOException, TempFile};
+use io\{File, Files, OperationFailed, TempFile};
 use lang\IllegalArgumentException;
 use test\{Assert, Expect, Test};
 
@@ -22,7 +22,7 @@ class FileOutputStreamTest {
       try {
         $file->isOpen() && $file->close();
         $file->unlink();
-      } catch (IOException $ignored) {
+      } catch (OperationFailed $ignored) {
         // Can't really do anything about it...
       }
     }
@@ -64,7 +64,7 @@ class FileOutputStreamTest {
     new FileOutputStream('');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function cannot_write_after_closing() {
     with (new FileOutputStream($this->tempFile()), function($stream) {
       $stream->close();

--- a/src/test/php/io/unittest/FolderEntriesTest.class.php
+++ b/src/test/php/io/unittest/FolderEntriesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\unittest;
 
-use io\{File, Folder, FolderEntries, Path};
+use io\{File, Folder, FolderEntries, Path, NotFound, OperationFailed};
 use lang\{Environment, IllegalArgumentException};
 use test\{After, Assert, Before, Expect, Test, Values};
 
@@ -86,6 +86,17 @@ class FolderEntriesTest {
       [$expected, $expected],
       [iterator_to_array($entries), iterator_to_array($entries)]
     );
+  }
+
+  #[Test, Expect(NotFound::class)]
+  public function entries_iteration_for_non_existant() {
+    iterator_to_array(new FolderEntries(new Folder($this->folder, '@non-existant@')));
+  }
+
+  #[Test, Expect(OperationFailed::class)]
+  public function entries_iteration_for_file() {
+    (new File($this->folder, 'file'))->touch();
+    iterator_to_array(new FolderEntries(new Folder($this->folder, 'file')));
   }
 
   #[Test]

--- a/src/test/php/io/unittest/FolderTest.class.php
+++ b/src/test/php/io/unittest/FolderTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\unittest;
 
-use io\{Folder, FolderEntries, File, Files, IOException, Path};
+use io\{Folder, FolderEntries, File, Files, OperationFailed, Path};
 use lang\Environment;
 use test\verify\Runtime;
 use test\{After, Assert, Expect, Test};
@@ -70,7 +70,7 @@ class FolderTest {
     Assert::false($f->exists());
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function unlink_nonexistant() {
     $f= new Folder($this->tempFolder());
     $f->unlink();
@@ -235,7 +235,7 @@ class FolderTest {
     Assert::instance(FolderEntries::class, (new Folder($this->tempFolder()))->entries());
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function entries_iteration_raises_exception_if_path_does_not_exist() {
     iterator_to_array((new Folder($this->tempFolder()))->entries());
   }

--- a/src/test/php/io/unittest/LinesInTest.class.php
+++ b/src/test/php/io/unittest/LinesInTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\unittest;
 
 use io\streams\{InputStream, LinesIn, MemoryInputStream, TextReader};
-use io\{File, IOException};
+use io\{File, OperationFailed};
 use lang\IllegalArgumentException;
 use test\{Assert, Expect, Test, Values};
 
@@ -82,8 +82,8 @@ class LinesInTest {
     Assert::equals([1 => 'A', 2 => 'B'], iterator_to_array($fixture));
     try {
       iterator_to_array($fixture);
-      $this->fail('No exception raised', null, 'io.IOException');
-    } catch (IOException $expected) {
+      $this->fail('No exception raised', null, 'io.OperationFailed');
+    } catch (OperationFailed $expected) {
       // OK
     }
   }

--- a/src/test/php/io/unittest/MemoryInputStreamTest.class.php
+++ b/src/test/php/io/unittest/MemoryInputStreamTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\unittest;
 
-use io\IOException;
+use io\OperationFailed;
 use io\streams\MemoryInputStream;
 use test\{Assert, Expect, Test, Values};
 
@@ -81,13 +81,13 @@ class MemoryInputStreamTest {
     Assert::equals('Hello', $in->read(5));
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function seek_unknown_whence() {
     $in= $this->newFixture();
     $in->seek(0, 9999);
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function seek_before_start() {
     $in= $this->newFixture();
     $in->seek(0, -1);

--- a/src/test/php/io/unittest/MemoryOutputStreamTest.class.php
+++ b/src/test/php/io/unittest/MemoryOutputStreamTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\unittest;
 
-use io\IOException;
+use io\OperationFailed;
 use io\streams\MemoryOutputStream;
 use test\{Assert, Expect, Test, Values};
 
@@ -107,12 +107,12 @@ class MemoryOutputStreamTest {
     Assert::equals('Hell_', $out->bytes());
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function seek_unknown_whence() {
     (new MemoryOutputStream(''))->seek(0, 9999);
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function seek_before_start() {
     (new MemoryOutputStream(''))->seek(-1);
   }

--- a/src/test/php/io/unittest/SpooledInputStreamTest.class.php
+++ b/src/test/php/io/unittest/SpooledInputStreamTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\unittest;
 
 use io\streams\{SpooledInputStream, MemoryInputStream, Streams};
-use io\{TempFile, Folder, Path, IOException};
+use io\{TempFile, Folder, Path, OperationFailed};
 use lang\Environment;
 use test\{Assert, Expect, Test, Values};
 
@@ -146,12 +146,12 @@ class SpooledInputStreamTest {
     $stream->close();
   }
 
-  #[Test, Expect(IOException::class), Values([SEEK_SET, SEEK_CUR])]
+  #[Test, Expect(OperationFailed::class), Values([SEEK_SET, SEEK_CUR])]
   public function cannot_seek_before_beginning_of_file($whence) {
     $this->newFixture()->seek(-1, $whence);
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function cannot_seek_with_invalid_whence() {
     $this->newFixture()->seek(0, 6100);
   }
@@ -161,7 +161,7 @@ class SpooledInputStreamTest {
     $stream= $this->newFixture();
     $stream->read(4);
 
-    Assert::throws(IOException::class, fn() => $stream->seek(-1));
+    Assert::throws(OperationFailed::class, fn() => $stream->seek(-1));
     Assert::equals(4, $stream->tell());
   }
 

--- a/src/test/php/io/unittest/StreamTransferTest.class.php
+++ b/src/test/php/io/unittest/StreamTransferTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\unittest;
 
-use io\IOException;
+use io\OperationFailed;
 use io\streams\{InputStream, MemoryInputStream, MemoryOutputStream, OutputStream, StreamTransfer};
 use test\{Assert, Test};
 
@@ -11,7 +11,7 @@ class StreamTransferTest {
     return new class() implements InputStream {
       public function read($length= 8192) { }
       public function available() { }
-      public function close() { throw new \io\IOException("Close error"); }
+      public function close() { throw new \io\OperationFailed("Close error"); }
     };
   }
 
@@ -30,7 +30,7 @@ class StreamTransferTest {
     return new class() implements OutputStream {
       public function write($data) { }
       public function flush() { }
-      public function close() { throw new IOException('Close error'); }
+      public function close() { throw new OperationFailed('Close error'); }
     };
   }
 
@@ -100,8 +100,8 @@ class StreamTransferTest {
 
     try {
       (new StreamTransfer($in, $out))->close();
-      $this->fail('Expected exception not caught', null, 'io.IOException');
-    } catch (IOException $expected) {
+      $this->fail('Expected exception not caught', null, 'io.OperationFailed');
+    } catch (OperationFailed $expected) {
       Assert::equals('Could not close output stream: Close error', $expected->getMessage());
     }
     
@@ -115,8 +115,8 @@ class StreamTransferTest {
 
     try {
       (new StreamTransfer($in, $out))->close();
-      $this->fail('Expected exception not caught', null, 'io.IOException');
-    } catch (IOException $expected) {
+      $this->fail('Expected exception not caught', null, 'io.OperationFailed');
+    } catch (OperationFailed $expected) {
       Assert::equals('Could not close input stream: Close error', $expected->getMessage());
     }
 
@@ -130,8 +130,8 @@ class StreamTransferTest {
 
     try {
       (new StreamTransfer($in, $out))->close();
-      $this->fail('Expected exception not caught', null, 'io.IOException');
-    } catch (IOException $expected) {
+      $this->fail('Expected exception not caught', null, 'io.OperationFailed');
+    } catch (OperationFailed $expected) {
       Assert::equals('Could not close input stream: Close error, Could not close output stream: Close error', $expected->getMessage());
     }
   }

--- a/src/test/php/io/unittest/StreamWrappingTest.class.php
+++ b/src/test/php/io/unittest/StreamWrappingTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\unittest;
 
-use io\IOException;
+use io\OperationFailed;
 use io\streams\{InputStream, MemoryInputStream, MemoryOutputStream, Streams};
 use test\{Assert, Expect, Test, Values};
 
@@ -140,13 +140,13 @@ class StreamWrappingTest {
     Assert::equals($buffer, $m->bytes());
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function reading_from_writeable_fd_raises_exception() {
     $fd= Streams::writeableFd(new MemoryOutputStream());
     fread($fd, 1024);
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function writing_to_readable_fd_raises_exception() {
     $fd= Streams::readableFd(new MemoryInputStream(''));
     fwrite($fd, 1024);
@@ -157,10 +157,10 @@ class StreamWrappingTest {
     Assert::equals($value, Streams::readAll(new MemoryInputStream($value)));
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function readAll_propagates_exception() {
     Streams::readAll(new class() implements InputStream {
-      public function read($limit= 8192) { throw new IOException('FAIL'); }
+      public function read($limit= 8192) { throw new OperationFailed('FAIL'); }
       public function available() { return 1; }
       public function close() { }
     });

--- a/src/test/php/io/unittest/TempFileTest.class.php
+++ b/src/test/php/io/unittest/TempFileTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\unittest;
 
-use io\{Path, Files, Folder, IOException, TempFile};
+use io\{Path, Files, Folder, OperationFailed, TempFile};
 use lang\{Environment, IllegalStateException};
 use test\{Assert, Test, Values};
 
@@ -60,8 +60,8 @@ class TempFileTest {
 
     try {
       $t->containing('Test');
-      $this->fail('No exception raised', null, IOException::class);
-    } catch (IOException $expected) {
+      $this->fail('No exception raised', null, OperationFailed::class);
+    } catch (OperationFailed $expected) {
       // OK
     } finally {
       $t->setPermissions(0600);

--- a/src/test/php/io/unittest/TextReaderTest.class.php
+++ b/src/test/php/io/unittest/TextReaderTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\unittest;
 
 use io\streams\{InputStream, LinesIn, MemoryInputStream, MemoryOutputStream, TextReader};
-use io\{Channel, IOException};
+use io\{Channel, OperationFailed};
 use lang\{FormatException, IllegalArgumentException};
 use test\{Assert, Expect, Test, Values};
 
@@ -344,7 +344,7 @@ class TextReaderTest {
     Assert::equals('ABC', $r->read(3));
   }
 
-  #[Test, Expect(class: IOException::class, message: 'Underlying stream does not support seeking')]
+  #[Test, Expect(class: OperationFailed::class, message: 'Underlying stream does not support seeking')]
   public function resetUnseekable() {
     $r= new TextReader($this->unseekableStream());
     $r->reset();
@@ -439,8 +439,8 @@ class TextReaderTest {
     Assert::equals([1 => 'A', 2 => 'B'], iterator_to_array($reader->lines()));
     try {
       iterator_to_array($reader->lines());
-      $this->fail('No exception raised', null, 'io.IOException');
-    } catch (\io\IOException $expected) {
+      $this->fail('No exception raised', null, 'io.OperationFailed');
+    } catch (\io\OperationFailed $expected) {
       // OK
     }
   }

--- a/src/test/php/lang/unittest/ProcessTest.class.php
+++ b/src/test/php/lang/unittest/ProcessTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\unittest;
 
 use io\streams\{MemoryOutputStream, Streams};
-use io\{IOException, TempFile};
+use io\{OperationFailed, TempFile};
 use lang\{Environment, IllegalStateException, Process, Runtime};
 use test\verify\Condition;
 use test\{Assert, AssertionFailedError, Expect, Test, Values};
@@ -158,17 +158,17 @@ class ProcessTest {
     }
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function runningNonExistantFile() {
     new Process(':FILE_DOES_NOT_EXIST:');
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function runningDirectory() {
     new Process(Environment::tempDir());
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function runningEmpty() {
     new Process('');
   }

--- a/src/test/php/util/unittest/FileBasedPropertiesTest.class.php
+++ b/src/test/php/util/unittest/FileBasedPropertiesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\unittest;
 
-use io\{IOException, TempFile};
+use io\{OperationFailed, TempFile};
 use test\{Assert, Expect, Test};
 use util\Properties;
 
@@ -23,7 +23,7 @@ class FileBasedPropertiesTest extends AbstractPropertiesTest {
     Assert::equals('value', $prop->readString('section', 'key'));
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(OperationFailed::class)]
   public function throws_error_when_reading() {
     $p= new Properties('@@does-not-exist.ini@@');
     $p->readString('section', 'key');


### PR DESCRIPTION
Part 1 of #363, resolving the name collision with PHP's `Io\IoException` class introduced as part of https://wiki.php.net/rfc/poll_api#exception_hierarchy in https://github.com/php/php-src/pull/19572

## Implementation status

* [x] Rename IOException -> OperationFailed
* [x] Rename FileNotFoundException -> NotFound
* [x] Rename OperationNotSupportedException -> NotSupported
* [x] Rename OperationTimedOutException -> TimedOut 
* [x] Adjust all code throwing and catching these inside `xp-framework/core`
* [x] Deprecate old classes (and schedule for removal in upcoming major release)
* [x] Provide class aliases for BC (for PHP < 8.6)

## Effects on userland code

When using PHP < 8.6, nothing will change for existing code: Raising and catching `io.IOException` will use the class alias:

```bash
$ XP_RT=8.5 xp -w 'new \io\IOException("Test")'
Exception io.OperationFailed (Test)
  at <main>::include() [line 163 of Code.class.php]
  at xp.runtime.Code::run(array[1]) [line 30 of Dump.class.php]
  at xp.runtime.Dump::main(array[1]) [line 389 of class-main.php]
```

For PHP 8.6, the native class will be thrown (and caught). For direct uses, this will continue to work, but using it for its base class character will break code as follows:

```php
use io\IOException;
use peer\SocketException;

try {
  throw new SocketException('...');
} catch (IOException $e) {
  // This will not longer be run, as SocketException doesn't inherit PHP's exception!
}
```

## The path forward

This means libraries should start migrating to the new class hierarchy based in `io.OperationFailed` now. This will create quite a bit of library releases; quite a few of which will also need to drop support for older XP core releases.

* [x] To further BC, we should backport this to XP11 and create a new release in this series
* [x] First, we will check - and if necessary - adapt XP compiler, reflection and testing libraries
* [ ] This will be followed by all other libraries in xp-forge, xp-lang and xp-framework. Although *technically* many will incur BC breaks, we will use feature releases in order not to create an update hell for users