### PR TITLE
Replace spl_object_hash() with spl_object_id()

### DIFF
--- a/src/main/php/io/File.class.php
+++ b/src/main/php/io/File.class.php
@@ -124,7 +124,7 @@ class File implements Channel, Value {
     );
     $this->path= substr($uri, 0, $p);
     $this->filename= ltrim(substr($uri, $p), '/'.DIRECTORY_SEPARATOR);
-    $this->extension= (false === ($pe= strrpos($this->filename, '.', $s))) ? null : substr($this->filename, $pe+ 1);
+    $this->extension= (false === ($pe= strrpos($this->filename, '.'))) ? null : substr($this->filename, $pe + 1);
   }
 
   /**

--- a/src/main/php/io/streams/Streams.class.php
+++ b/src/main/php/io/streams/Streams.class.php
@@ -79,7 +79,7 @@ abstract class Streams {
    * @return  resource
    */
   public static function readableFd(InputStream $s) { 
-    $hash= spl_object_hash($s);
+    $hash= spl_object_id($s);
     self::$streams[$hash]= $s;
     return fopen('iostrr://'.$hash, 'rb');
   }
@@ -91,7 +91,7 @@ abstract class Streams {
    * @return  string
    */
   public static function readableUri(InputStream $s) { 
-    $hash= spl_object_hash($s);
+    $hash= spl_object_id($s);
     self::$streams[$hash]= $s;
     return 'iostrr://'.$hash;
   }
@@ -103,7 +103,7 @@ abstract class Streams {
    * @return  resource
    */
   public static function writeableFd(OutputStream $s) { 
-    $hash= spl_object_hash($s);
+    $hash= spl_object_id($s);
     self::$streams[$hash]= $s;
     return fopen('iostrw://'.$hash, 'wb');
   }
@@ -115,7 +115,7 @@ abstract class Streams {
    * @return  resource
    */
   public static function writeableUri(OutputStream $s) { 
-    $hash= spl_object_hash($s);
+    $hash= spl_object_id($s);
     self::$streams[$hash]= $s;
     return 'iostrw://'.$hash;
   }

--- a/src/main/php/lang/Value.class.php
+++ b/src/main/php/lang/Value.class.php
@@ -20,7 +20,6 @@ interface Value {
   /**
    * Calculates a hashcode and makes this value useable in e.g. collections.
    *
-   * @see    php://spl_object_id
    * @return string
    */
   public function hashCode();

--- a/src/main/php/lang/Value.class.php
+++ b/src/main/php/lang/Value.class.php
@@ -20,7 +20,7 @@ interface Value {
   /**
    * Calculates a hashcode and makes this value useable in e.g. collections.
    *
-   * @see    php://spl_object_hash
+   * @see    php://spl_object_id
    * @return string
    */
   public function hashCode();

--- a/src/main/php/util/Objects.class.php
+++ b/src/main/php/util/Objects.class.php
@@ -105,7 +105,7 @@ abstract class Objects {
       }
       return '<function('.substr($sig, 2).')>';
     } else if (is_object($val)) {
-      $hash= spl_object_hash($val);
+      $hash= spl_object_id($val);
       if (isset($protect[$hash])) return '->{:recursion:}';
       $protect[$hash]= true;
       $r= nameof($val)." {\n";
@@ -126,7 +126,7 @@ abstract class Objects {
     } else if ($val instanceof Value) {
       return $val->hashCode();
     } else if ($val instanceof \Closure) {
-      return spl_object_hash($val);
+      return spl_object_id($val);
     } else if (is_array($val)) {
       $s= '';
       foreach ($val as $key => $value) {
@@ -134,7 +134,7 @@ abstract class Objects {
       }
       return $s;
     } else {
-      return is_object($val) ? spl_object_hash($val) : serialize($val);
+      return is_object($val) ? spl_object_id($val) : serialize($val);
     }
   }
 }

--- a/src/test/php/util/unittest/ObjectsTest.class.php
+++ b/src/test/php/util/unittest/ObjectsTest.class.php
@@ -29,7 +29,7 @@ class ObjectsTest {
       [[1, 2, 3], '|0:i:1;|1:i:2;|2:i:3;'],
       [[null, null], '|0:N;|1:N;'],
       [[['Nested'], ['Array']], '|0:|0:s:6:"Nested";|1:|0:s:5:"Array";'],
-      [[self::$func], '|0:'.spl_object_hash(self::$func)]
+      [[self::$func], '|0:'.spl_object_id(self::$func)]
     ];
   }
 
@@ -37,7 +37,7 @@ class ObjectsTest {
   public function maps() {
     return [
       [['one' => 'two'], '|one:s:3:"two";'],
-      [['func' => self::$func], '|func:'.spl_object_hash(self::$func)]
+      [['func' => self::$func], '|func:'.spl_object_id(self::$func)]
     ];
   }
 
@@ -383,12 +383,12 @@ class ObjectsTest {
   }
 
   #[Test, Values(from: 'natives')]
-  public function hashOf_calls_spl_object_hash_on_natives($val) {
-    Assert::equals(spl_object_hash($val), Objects::hashOf($val));
+  public function hashOf_calls_spl_object_id_on_natives($val) {
+    Assert::equals((string)spl_object_id($val), Objects::hashOf($val));
   }
 
   #[Test]
   public function function_hash() {
-    Assert::equals(spl_object_hash(self::$func), Objects::hashOf(self::$func));
+    Assert::equals((string)spl_object_id(self::$func), Objects::hashOf(self::$func));
   }
 }


### PR DESCRIPTION
Quoting https://externals.io/message/131452#131487:

> Is spl_object_hash() still useful? The string it creates used to be
> quite a bit more complex, but eventually it became equivalent to
>
> `str_pad(dechex(spl_object_id($obj)), 16, '0', STR_PAD_LEFT).'0000000000000000'`
>
> I.e., it provides exactly the same content as spl_object_id, but in a
> much more obtuse way. For anyone needing that format, the polyfill is
> just above.

Forward compatibility, see #368