### PR TITLE
Add support for generic methods

### DIFF
--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -334,12 +334,18 @@ function create($spec, ... $args) {
   // TYPE:= B "<" ARGS ">"
   // ARGS:= TYPE [ "," TYPE [ "," ... ]]
   $b= strpos($spec, '<');
-  $base= substr($spec, 4, $b- 4);
-  $typeargs= \lang\Type::forNames(substr($spec, $b+ 1, strrpos($spec, '>')- $b- 1));
+  $base= substr($spec, 4, $b - 4);
+
+  if ('self' === $base) {
+    $context= debug_backtrace(0, 2)[1]['class'];
+    $class= new \lang\XPClass(substr($context, 0, strcspn($context, "\xb7")));
+  } else {
+    $class= \lang\XPClass::forName($base);
+  }
   
   // Instantiate, passing the rest of any arguments passed to create()
   // BC: Wrap IllegalStateExceptions into IllegalArgumentExceptions
-  $class= \lang\XPClass::forName(strstr($base, '.') ? $base : \lang\XPClass::nameOf($base));
+  $typeargs= \lang\Type::forNames(substr($spec, $b+ 1, strrpos($spec, '>')- $b- 1));
   try {
     return $class->newGenericType($typeargs)->newInstance(...$args);
   } catch (\lang\IllegalStateException $e) {

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -344,12 +344,9 @@ function create($spec, ... $args) {
   }
   
   // Instantiate, passing the rest of any arguments passed to create()
-  // BC: Wrap IllegalStateExceptions into IllegalArgumentExceptions
   $typeargs= \lang\Type::forNames(substr($spec, $b+ 1, strrpos($spec, '>')- $b- 1));
   try {
     return $class->newGenericType($typeargs)->newInstance(...$args);
-  } catch (\lang\IllegalStateException $e) {
-    throw new \lang\IllegalArgumentException($e->getMessage());
   } catch (ReflectionException $e) {
     throw new \lang\IllegalAccessException($e->getMessage());
   }

--- a/src/main/php/lang.base.php
+++ b/src/main/php/lang.base.php
@@ -323,19 +323,17 @@ function newinstance($spec, $args, $def= null) {
 }
 // }}}
 
-// {{{ proto object create(string spec, var... $args)
+// {{{ proto object create(string type, var... $args)
 //     Creates a generic object
-function create($spec, ... $args) {
-  if (!is_string($spec)) {
-    throw new \lang\IllegalArgumentException('Create expects its first argument to be a string');
+function create(string $type, ... $args) {
+  if (false === ($b= strpos($type, '<'))) {
+    throw new \lang\IllegalArgumentException('Type '.$type.' does not have type arguments');
   }
 
-  // Parse type specification: "new " TYPE "()"?
+  // Parse type specification: "new " TYPE "()"
   // TYPE:= B "<" ARGS ">"
   // ARGS:= TYPE [ "," TYPE [ "," ... ]]
-  $b= strpos($spec, '<');
-  $base= substr($spec, 4, $b - 4);
-
+  $base= substr($type, 4, $b - 4);
   if ('self' === $base) {
     $context= debug_backtrace(0, 2)[1]['class'];
     $class= new \lang\XPClass(substr($context, 0, strcspn($context, "\xb7")));
@@ -344,7 +342,7 @@ function create($spec, ... $args) {
   }
   
   // Instantiate, passing the rest of any arguments passed to create()
-  $typeargs= \lang\Type::forNames(substr($spec, $b+ 1, strrpos($spec, '>')- $b- 1));
+  $typeargs= \lang\Type::forNames(substr($type, $b + 1, strrpos($type, '>') - $b - 1));
   try {
     return $class->newGenericType($typeargs)->newInstance(...$args);
   } catch (ReflectionException $e) {

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -5,29 +5,18 @@ use ReflectionClass;
 /**
  * Generate generic runtime types.
  *
+ * @test  lang.unittest.generics.GenericsTest
  * @test  lang.unittest.generics.GenericTypesTest
  */
 class GenericTypes {
 
-  /**
-   * Creates a generic type
-   *
-   * @param   lang.XPClass base
-   * @param   lang.Type[] arguments
-   * @return  lang.XPClass created type
-   */
-  public function newType(XPClass $base, array $arguments) {
+  /** Creates a generic type */
+  public function newType(XPClass $base, array $arguments): XPClass {
     return new XPClass(new ReflectionClass($this->newType0($base, $arguments)));
   }
 
-  /**
-   * Creates a generic type
-   *
-   * @param   lang.XPClass base
-   * @param   lang.Type[] arguments
-   * @return  string created type's literal
-   */
-  public function newType0($base, $arguments) {
+  /** Creates a generic type and returns the created type's literal */
+  public function newType0(XPClass $base, array $arguments): string {
     $reflect= $base->reflect();
     $generic= $reflect->getAttributes(Generic::class);
     if (empty($generic) || (($annotated= $generic[0]->getArguments()) && !isset($annotated['self']))) {

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -250,21 +250,16 @@ class GenericTypes {
               $meta[1][$m][DETAIL_RETURNS]= strtr($annotations['return'], $placeholders);
             }
             if (isset($annotations['params'])) {
-              $generic= [];
               $replace= $rewrite= ['...' => '[]'] + $placeholders;
               foreach ($typeargs as $placeholder => $p) {
                 $replace[$placeholder]= "\$__T[{$p}]";
               }
               foreach (Type::split($annotations['params']) as $j => $placeholder) {
-                if ('' === $placeholder) {
-                  $generic[]= null;
-                } else {
-                  $generic[]= strtr($placeholder, $replace);
-                  $meta[1][$m][DETAIL_ARGUMENTS][$j]= strtr($placeholder, $rewrite);
-                }
-              }
-              foreach ($generic as $j => $type) {
-                isset($type) && $src.= (
+                if ('' === $placeholder) continue;
+
+                $meta[1][$m][DETAIL_ARGUMENTS][$j]= strtr($placeholder, $rewrite);
+                $type= strtr($placeholder, $replace);
+                $src.= (
                   ' if ('.(isset($default[$j]) ? '('.$default[$j].' !== '.$parameters[$j].') && ' : '').
                   '!instance("'.$type.'", '.$parameters[$j].')) throw new \lang\IllegalArgumentException('.
                   '"Argument '.($j + 1).' passed to ".__METHOD__."'.

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang;
 
+use ReflectionClass;
+
 /**
  * Generate generic runtime types.
  *
@@ -15,7 +17,7 @@ class GenericTypes {
    * @return  lang.XPClass created type
    */
   public function newType(XPClass $base, array $arguments) {
-    return new XPClass(new \ReflectionClass($this->newType0($base, $arguments)));
+    return new XPClass(new ReflectionClass($this->newType0($base, $arguments)));
   }
 
   /**
@@ -334,7 +336,7 @@ class GenericTypes {
             foreach (Type::split($annotation[$counter]) as $j => $placeholder) {
               $iargs[]= Type::forName(strtr(ltrim($placeholder), $placeholders));
             }
-            $src.= '\\'.$this->newType0(new XPClass(new \ReflectionClass($rel)), $iargs);
+            $src.= '\\'.$this->newType0(new XPClass(new ReflectionClass($rel)), $iargs);
           } else {
             $src.= $rel;
           }

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -185,6 +185,13 @@ class GenericTypes {
             $m= $tokens[$i+ 2][1];
             $p= 0;
             $generic= $reflect->getMethod($m)->getAttributes(Generic::class);
+            $annotations= $generic ? $generic[0]->getArguments() : [];
+            $typeargs= [];
+            if (isset($annotations['self'])) {
+              foreach (Type::split($annotations['self']) as $p => $typearg) {
+                $typeargs[ltrim($typearg)]= $p;
+              }
+            }
           } else if (T_VARIABLE === $tokens[$i][0]) {
             $f= substr($tokens[$i][1], 1);
             $generic= $reflect->getProperty($f)->getAttributes(Generic::class);
@@ -193,6 +200,12 @@ class GenericTypes {
               $meta[0][$f][DETAIL_RETURNS]= strtr($annotations['var'], $placeholders);
             }
           } else if ('}' === $tokens[$i][0]) {
+            $reflect->isInterface() || $src.= (
+              'function __call($name, $arguments) {'.
+              '  $p= strpos($name, "<") ?: throw new \Error("Call to undefined method", $name);'.
+              '  return $this->{substr($name, 0, $p)}(\lang\Type::forNames(substr($name, $p + 1, -1)), ...$arguments);'.
+              '}'
+            );
             $src.= '}';
             break;
           } else if (T_CLOSE_TAG === $tokens[$i][0]) {
@@ -201,6 +214,10 @@ class GenericTypes {
         } else if (2 === $state[0]) {             // Method declaration
           if ('(' === $tokens[$i][0]) {
             $braces++;
+            if (1 === $braces && $typeargs) {
+              $src.= '($__T,';
+              continue;
+            }
           } else if (')' === $tokens[$i][0]) {
             $braces--;
             if (0 === $braces) {
@@ -238,7 +255,6 @@ class GenericTypes {
             array_shift($state);
             array_unshift($state, 4);
             $src.= '{';
-            $annotations= $generic ? $generic[0]->getArguments() : [];
             if (isset($annotations['return'])) {
               $meta[1][$m][DETAIL_RETURNS]= strtr($annotations['return'], $placeholders);
             }
@@ -278,8 +294,12 @@ class GenericTypes {
           } else if ('}' === $tokens[$i][0]) {
             $braces--;
             if (0 === $braces) array_shift($state);
-          } else if (T_VARIABLE === $tokens[$i][0] && isset($placeholders[$v= substr($tokens[$i][1], 1)])) {
-            $src.= 'self::$__generic["'.$v.'"]';
+          } else if (T_VARIABLE === $tokens[$i][0]) {
+            $v= substr($tokens[$i][1], 1);
+            $src.= isset($placeholders[$v])
+              ? 'self::$__generic["'.$v.'"]' :
+              (isset($typeargs[$v]) ? '$__T['.$typeargs[$v].']' : $tokens[$i][1])
+            ;
             continue;
           }
         } else if (5 === $state[0]) {             // Implements (class), Extends (interface)
@@ -322,7 +342,7 @@ class GenericTypes {
       }
 
       // Create class
-      // fputs(STDERR, "@* ".substr($src, 0, strpos($src, '{'))." -> $qname\n");
+      // var_dump([$qname => $src]);
       eval($src);
       if ($initialize) {
         foreach ($components as $i => $component) {

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -157,33 +157,33 @@ class GenericTypes {
             $counter= 0;
             $annotation= $annotated['implements'] ?? null;
             array_unshift($state, T_CLASS);
-            array_unshift($state, 5);
+            array_unshift($state, T_IMPLEMENTS);
           } else if ('{' === $tokens[$i][0]) {
             array_shift($state);
-            array_unshift($state, 1);
+            array_unshift($state, T_CLASS_C);
             $src.= ' { public static $__generic= [];';
             $initialize= true;
           }
           continue;
         } else if (T_INTERFACE === $state[0]) {
-          if (T_EXTENDS === $tokens[$i][0]) {
+          if (T_IMPLEMENTS === $tokens[$i][0]) {
             $src.= ' extends';
             $counter= 0;
             $annotation= $annotated['extends'] ?? null;
             array_unshift($state, T_INTERFACE);
-            array_unshift($state, 5);
+            array_unshift($state, T_IMPLEMENTS);
           } else if ('{' === $tokens[$i][0]) {
             array_shift($state);
-            array_unshift($state, 1);
+            array_unshift($state, T_CLASS_C);
             $src.= ' {';
           }
           continue;
-        } else if (1 === $state[0]) {             // Class body
+        } else if (T_CLASS_C === $state[0]) {
           if (T_FUNCTION === $tokens[$i][0]) {
             $braces= 0;
             $parameters= $default= [];
-            array_unshift($state, 3);
-            array_unshift($state, 2);
+            array_unshift($state, T_CALLABLE);
+            array_unshift($state, T_METHOD_C);
             $m= $tokens[$i+ 2][1];
             $p= 0;
             $generic= $reflect->getMethod($m)->getAttributes(Generic::class);
@@ -213,7 +213,7 @@ class GenericTypes {
           } else if (T_CLOSE_TAG === $tokens[$i][0]) {
             break;
           }
-        } else if (2 === $state[0]) {             // Method declaration
+        } else if (T_METHOD_C === $state[0]) {
           if ('(' === $tokens[$i][0]) {
             $braces++;
             if (1 === $braces && $typeargs) {
@@ -238,7 +238,7 @@ class GenericTypes {
           } else if (T_WHITESPACE !== $tokens[$i][0] && isset($default[$p])) {
             $default[$p].= is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i];
           }
-        } else if (3 === $state[0]) {             // Method body
+        } else if (T_CALLABLE === $state[0]) {
           if (';' === $tokens[$i][0]) {           // Abstract method
             $annotations= $generic ? $generic[0]->getArguments() : [];
             if (isset($annotations['return'])) {
@@ -255,7 +255,7 @@ class GenericTypes {
           } else if ('{' === $tokens[$i][0]) {
             $braces= 1;
             array_shift($state);
-            array_unshift($state, 4);
+            array_unshift($state, T_FUNCTION);
             $src.= '{';
             if (isset($annotations['return'])) {
               $meta[1][$m][DETAIL_RETURNS]= strtr($annotations['return'], $placeholders);
@@ -294,7 +294,7 @@ class GenericTypes {
             }
             continue;
           }
-        } else if (4 === $state[0]) {             // Method body
+        } else if (T_FUNCTION === $state[0]) {
           if ('{' === $tokens[$i][0] || T_CURLY_OPEN === $tokens[$i][0]) {
             $braces++;
           } else if ('}' === $tokens[$i][0]) {
@@ -321,7 +321,7 @@ class GenericTypes {
             ;
             continue;
           }
-        } else if (5 === $state[0]) {             // Implements (class), Extends (interface)
+        } else if (T_IMPLEMENTS === $state[0]) { // Implements (class), Extends (interface)
           if ('{' === $tokens[$i]) {
             array_shift($state);
             array_shift($state);

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -323,9 +323,9 @@ class GenericTypes {
               $i++;
             }
             $i--;
-            '\\' === $rel[0] || $rel= isset($imports[$rel]) ? $imports[$rel] : '\\'.$namespace.'\\'.$rel;
+            '\\' === $rel[0] || $rel= '\\'.($imports[$rel] ?? $namespace.'\\'.$rel);
           } else if (T_NAME_QUALIFIED === $tokens[$i][0]) {
-            $rel= isset($imports[$tokens[$i][1]]) ? $imports[$tokens[$i][1]] : '\\'.$namespace.'\\'.$tokens[$i][1];
+            $rel= '\\'.($imports[$tokens[$i][1]] ?? $namespace.'\\'.$tokens[$i][1]);
           } else if (T_NAME_FULLY_QUALIFIED === $tokens[$i][0]) {
             $rel= $tokens[$i][1];
           } else {

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -255,6 +255,7 @@ class GenericTypes {
               foreach ($typeargs as $placeholder => $p) {
                 $replace[$placeholder]= "\$__T[{$p}]";
               }
+              $replace['...']= '[]';
               foreach (Type::split($annotations['params']) as $j => $placeholder) {
                 if ('' === ($replaced= strtr($placeholder, $replace))) {
                   $generic[$j]= null;
@@ -264,17 +265,9 @@ class GenericTypes {
                 }
               }
               foreach ($generic as $j => $type) {
-                if (null === $type) {
-                  continue;
-                } else if ('...' === substr($type, -3)) {
-                  $verify= substr($generic[$j], 0, -3).'[]';
-                } else {
-                  $verify= $generic[$j];
-                }
-
-                $src.= (
+                isset($type) && $src.= (
                   ' if ('.(isset($default[$j]) ? '('.$default[$j].' !== '.$parameters[$j].') && ' : '').
-                  '!instance("'.$verify.'", '.$parameters[$j].')) throw new \lang\IllegalArgumentException('.
+                  '!instance("'.$type.'", '.$parameters[$j].')) throw new \lang\IllegalArgumentException('.
                   '"Argument '.($j + 1).' passed to ".__METHOD__."'.
                   ' must be of '.$type.', ".typeof('.$parameters[$j].')." given"'.
                   ');'

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -260,8 +260,12 @@ class GenericTypes {
             }
             if (isset($annotations['params'])) {
               $generic= [];
+              $replace= $placeholders;
+              foreach ($typeargs as $placeholder => $p) {
+                $replace[$placeholder]= "\$__T[{$p}]";
+              }
               foreach (Type::split($annotations['params']) as $j => $placeholder) {
-                if ('' === ($replaced= strtr($placeholder, $placeholders))) {
+                if ('' === ($replaced= strtr($placeholder, $replace))) {
                   $generic[$j]= null;
                 } else {
                   $meta[1][$m][DETAIL_ARGUMENTS][$j]= $replaced;
@@ -279,7 +283,7 @@ class GenericTypes {
 
                 $src.= (
                   ' if ('.(isset($default[$j]) ? '('.$default[$j].' !== '.$parameters[$j].') && ' : '').
-                  '!instance(\''.$verify.'\', '.$parameters[$j].')) throw new \lang\IllegalArgumentException('.
+                  '!instance("'.$verify.'", '.$parameters[$j].')) throw new \lang\IllegalArgumentException('.
                   '"Argument '.($j + 1).' passed to ".__METHOD__."'.
                   ' must be of '.$type.', ".typeof('.$parameters[$j].')." given"'.
                   ');'

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -251,17 +251,16 @@ class GenericTypes {
             }
             if (isset($annotations['params'])) {
               $generic= [];
-              $replace= $placeholders;
+              $replace= $rewrite= ['...' => '[]'] + $placeholders;
               foreach ($typeargs as $placeholder => $p) {
                 $replace[$placeholder]= "\$__T[{$p}]";
               }
-              $replace['...']= '[]';
               foreach (Type::split($annotations['params']) as $j => $placeholder) {
-                if ('' === ($replaced= strtr($placeholder, $replace))) {
-                  $generic[$j]= null;
+                if ('' === $placeholder) {
+                  $generic[]= null;
                 } else {
-                  $meta[1][$m][DETAIL_ARGUMENTS][$j]= $replaced;
-                  $generic[$j]= $replaced;
+                  $generic[]= strtr($placeholder, $replace);
+                  $meta[1][$m][DETAIL_ARGUMENTS][$j]= strtr($placeholder, $rewrite);
                 }
               }
               foreach ($generic as $j => $type) {

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -233,7 +233,7 @@ class GenericTypes {
           } else if (',' === $tokens[$i][0]) {
             // Skip
           } else if ('=' === $tokens[$i][0]) {
-            $p= sizeof($parameters)- 1;
+            $p= sizeof($parameters) - 1;
             $default[$p]= '';
           } else if (T_WHITESPACE !== $tokens[$i][0] && isset($default[$p])) {
             $default[$p].= is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i];
@@ -300,10 +300,23 @@ class GenericTypes {
           } else if ('}' === $tokens[$i][0]) {
             $braces--;
             if (0 === $braces) array_shift($state);
+          } else if ('"' === $tokens[$i][0]) {
+            array_unshift($state, T_STRING_VARNAME);
           } else if (T_VARIABLE === $tokens[$i][0]) {
             $v= substr($tokens[$i][1], 1);
             $src.= isset($placeholders[$v])
               ? 'self::$__generic["'.$v.'"]' :
+              (isset($typeargs[$v]) ? '$__T['.$typeargs[$v].']' : $tokens[$i][1])
+            ;
+            continue;
+          }
+        } else if (T_STRING_VARNAME === $state[0]) {
+          if ('"' === $tokens[$i][0]) {
+            array_shift($state);
+          } else if (T_VARIABLE === $tokens[$i][0]) {
+            $v= substr($tokens[$i][1], 1);
+            $src.= isset($placeholders[$v])
+              ? '".self::$__generic["'.$v.'"]."' :
               (isset($typeargs[$v]) ? '$__T['.$typeargs[$v].']' : $tokens[$i][1])
             ;
             continue;

--- a/src/main/php/lang/GenericTypes.class.php
+++ b/src/main/php/lang/GenericTypes.class.php
@@ -155,7 +155,7 @@ class GenericTypes {
           }
           continue;
         } else if (T_INTERFACE === $state[0]) {
-          if (T_IMPLEMENTS === $tokens[$i][0]) {
+          if (T_EXTENDS === $tokens[$i][0]) {
             $src.= ' extends';
             $counter= 0;
             $annotation= $annotated['extends'] ?? null;

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -323,7 +323,7 @@ class Type implements Value {
           $wildcard= true;
         } else {
           $t= self::named($arg, $context);
-          $wildcard= $t instanceof WildcardType;
+          $wildcard= $t instanceof WildcardType || $t instanceof TypeParameter;
           $components[]= $t;
         }
       }

--- a/src/main/php/lang/TypeParameter.class.php
+++ b/src/main/php/lang/TypeParameter.class.php
@@ -1,0 +1,11 @@
+<?php namespace lang;
+
+class TypeParameter extends Type {
+
+  static function __static() { }
+
+  /** @param string $name */ 
+  public function __construct($name) {
+    parent::__construct($name, null);
+  }
+}

--- a/src/test/php/lang/unittest/CreateTest.class.php
+++ b/src/test/php/lang/unittest/CreateTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\unittest;
 
-use lang\{IllegalArgumentException, XPClass};
+use lang\{IllegalArgumentException, IllegalStateException, XPClass};
 use test\{Assert, Expect, Test};
 
 class CreateTest {
@@ -28,7 +28,7 @@ class CreateTest {
     );
   }
 
-  #[Test, Expect(IllegalArgumentException::class)]
+  #[Test, Expect(IllegalStateException::class)]
   public function create_raises_exception_when_non_generic_given() {
     create('new lang.unittest.Name<string>');
   }

--- a/src/test/php/lang/unittest/CreateTest.class.php
+++ b/src/test/php/lang/unittest/CreateTest.class.php
@@ -28,6 +28,11 @@ class CreateTest {
     );
   }
 
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function create_raises_exception_when_type_args_missing() {
+    create('new lang.unittest.Lookup');
+  }
+
   #[Test, Expect(IllegalStateException::class)]
   public function create_raises_exception_when_non_generic_given() {
     create('new lang.unittest.Name<string>');

--- a/src/test/php/lang/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/unittest/GenericsTest.class.php
@@ -94,6 +94,16 @@ class GenericsTest {
     Assert::equals(['Hello', null], $fixture->elements);
   }
 
+  #[Test]
+  public function pass_union() {
+    $fixture= create('new lang.unittest.ListOf<int|float>')
+      ->append(1)
+      ->append(1.5)
+    ;
+
+    Assert::equals([1, 1.5], $fixture->elements);
+  }
+
   #[Test, Expect(IllegalArgumentException::class), Values([[[1]], [['Test', 1]], [[null, 'Test']]])]
   public function pass_invalid($arguments) {
     create('new lang.unittest.ListOf<string>', 'Hello')->extend($arguments);

--- a/src/test/php/lang/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/unittest/GenericsTest.class.php
@@ -93,4 +93,13 @@ class GenericsTest {
   public function pass_invalid_varargs($arguments) {
     create('new lang.unittest.ListOf<string>', ...$arguments);
   }
+
+  #[Test]
+  public function invoke_generic_method() {
+    $fixture= create('new lang.unittest.ListOf<string>', 'Hello', 'World!');
+    $mapped= $fixture->{'map<int>'}('strlen');
+
+    Assert::instance('lang.unittest.ListOf<int>', $mapped);
+    Assert::equals([5, 6], $mapped->elements);
+  }
 }

--- a/src/test/php/lang/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/unittest/GenericsTest.class.php
@@ -102,4 +102,9 @@ class GenericsTest {
     Assert::instance('lang.unittest.ListOf<int>', $mapped);
     Assert::equals([5, 6], $mapped->elements);
   }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function generic_method_invalid_argument() {
+    create('new lang.unittest.ListOf<string>')->{'map<int>'}(null);
+  }
 }

--- a/src/test/php/lang/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/unittest/GenericsTest.class.php
@@ -84,6 +84,16 @@ class GenericsTest {
     Assert::equals(['Hello', 'World', '!'], $fixture->elements);
   }
 
+  #[Test]
+  public function pass_nullable() {
+    $fixture= create('new lang.unittest.ListOf<?string>')
+      ->append('Hello')
+      ->append(null)
+    ;
+
+    Assert::equals(['Hello', null], $fixture->elements);
+  }
+
   #[Test, Expect(IllegalArgumentException::class), Values([[[1]], [['Test', 1]], [[null, 'Test']]])]
   public function pass_invalid($arguments) {
     create('new lang.unittest.ListOf<string>', 'Hello')->extend($arguments);

--- a/src/test/php/lang/unittest/GenericsTest.class.php
+++ b/src/test/php/lang/unittest/GenericsTest.class.php
@@ -103,6 +103,17 @@ class GenericsTest {
     Assert::equals([5, 6], $mapped->elements);
   }
 
+  #[Test]
+  public function generic_method_components() {
+    $fixture= create('new lang.unittest.Lookup<string, string>');
+    $fixture->put('greeting', 'Hello');
+    $fixture->put('person', 'Tester');
+    $mapped= $fixture->{'map<int>'}('strlen');
+
+    Assert::instance('lang.unittest.Lookup<string, int>', $mapped);
+    Assert::equals([5, 6], $mapped->values());
+  }
+
   #[Test, Expect(IllegalArgumentException::class)]
   public function generic_method_invalid_argument() {
     create('new lang.unittest.ListOf<string>')->{'map<int>'}(null);

--- a/src/test/php/lang/unittest/ListOf.class.php
+++ b/src/test/php/lang/unittest/ListOf.class.php
@@ -19,12 +19,24 @@ class ListOf {
   /**
    * Extends this list with all given arguments
    *
+   * @param   T element
+   * @return  self
+   */
+  #[Generic(params: 'T')]
+  public function append($element) {
+    $this->elements[]= $element;
+    return $this;
+  }
+
+  /**
+   * Extends this list with all given arguments
+   *
    * @param   T[] elements
    * @return  self
    */
   #[Generic(params: 'T[]')]
-  public function extend($args) {
-    $this->elements= array_merge($this->elements, $args);
+  public function extend($elements) {
+    $this->elements= array_merge($this->elements, $elements);
     return $this;
   }
 

--- a/src/test/php/lang/unittest/ListOf.class.php
+++ b/src/test/php/lang/unittest/ListOf.class.php
@@ -32,9 +32,9 @@ class ListOf {
    * Applies a given map function to all elements in this list,
    * returning a new list with the mapped elements.
    */
-  #[Generic(self: 'M', params: 'function(T): M')]
+  #[Generic(self: 'M', params: 'function(T): M', return: 'self<M>')]
   public function map($map) {
-    $m= create("new lang.unittest.ListOf<$M>");
+    $m= create("new self<$M>");
     foreach ($this->elements as $element) {
       $m->elements[]= $map($element);
     }

--- a/src/test/php/lang/unittest/ListOf.class.php
+++ b/src/test/php/lang/unittest/ListOf.class.php
@@ -29,6 +29,19 @@ class ListOf {
   }
 
   /**
+   * Applies a given map function to all elements in this list,
+   * returning a new list with the mapped elements.
+   */
+  #[Generic(self: 'M')]
+  public function map($map) {
+    $m= create("new lang.unittest.ListOf<$M>");
+    foreach ($this->elements as $element) {
+      $m->elements[]= $map($element);
+    }
+    return $m;
+  }
+
+  /**
    * Returns a list of all elements
    *
    * @return  T[] elements

--- a/src/test/php/lang/unittest/ListOf.class.php
+++ b/src/test/php/lang/unittest/ListOf.class.php
@@ -32,7 +32,7 @@ class ListOf {
    * Applies a given map function to all elements in this list,
    * returning a new list with the mapped elements.
    */
-  #[Generic(self: 'M')]
+  #[Generic(self: 'M', params: 'function(T): M')]
   public function map($map) {
     $m= create("new lang.unittest.ListOf<$M>");
     foreach ($this->elements as $element) {

--- a/src/test/php/lang/unittest/Lookup.class.php
+++ b/src/test/php/lang/unittest/Lookup.class.php
@@ -5,10 +5,10 @@ use util\{NoSuchElementException, Objects};
 
 #[Generic(self: 'K, V', parent: 'K, V')]
 class Lookup extends AbstractDictionary {
-  protected $size= 0;
+  private $size= 0;
 
   #[Generic(['var' => '[:V]'])]
-  protected $elements= [];
+  public $elements= [];
   
   /**
    * Put a key/value pairt
@@ -36,6 +36,19 @@ class Lookup extends AbstractDictionary {
       throw new NoSuchElementException('No such key '.Objects::stringOf($key));
     }
     return $this->elements[$offset];
+  }
+
+  /**
+   * Applies a given map function to all elements in this lookup,
+   * returning a new list with the mapped elements.
+   */
+  #[Generic(self: 'M', params: 'function(V): M', return: 'self<K, M>')]
+  public function map($map) {
+    $m= create("new self<$K, $M>");
+    foreach ($this->elements as $hash => $element) {
+      $m->elements[$hash]= $map($element);
+    }
+    return $m;
   }
 
   /**


### PR DESCRIPTION
This pull request adds the possibility to define methods with their own generic type arguments. Implemented via inserting typeargs as first parameter and `__call()`.

## Example

Declaration:
```php
use lang\Generic;

#[Generic(self: 'T')]
class ListOf {
  public private(set) $elements= [];

  #[Generic(params: 'T...')]
  public function __construct(... $args) {
    $this->elements= $args;
  }

  #[Generic(self: 'M', params: 'function(T): M', return: 'self<M>')]
  public function map($map) {
    $m= create("new self<$M>");
    foreach ($this->elements as $element) {
      $m->elements[]= $map($element);
    }
    return $m;
  }
}
```

Calls:
```php
$list= create('new ListOf<string>', 'Hello', 'World!');

// Returns a ListOf<int>
$lengths= $list->{'map<int>'}(strlen(...));

// Contains [5, 6]
$lengths->elements;
```

## Implementation status

* [x] Proof of concept
* [x] Argument verification
* [x] Reflection

## See also

* https://github.com/xp-lang/xp-generics/issues/3
* https://gist.github.com/hollyschilling/abcdd66dae18437f56bf56e350860b48