### PR TITLE
Remove NULL handling in `Type::cast()`

### DIFF
--- a/src/main/php/lang/Primitive.class.php
+++ b/src/main/php/lang/Primitive.class.php
@@ -97,7 +97,7 @@ class Primitive extends Type {
    * @throws  lang.ClassCastException
    */
   public function cast($value) {
-    return null === $value ? null : $this->coerce($value, function($value) {
+    return $this->coerce($value, function($value) {
       throw new ClassCastException('Cannot cast to '.$this->getName().' from '.typeof($value)->getName());
     });
   }

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -45,8 +45,7 @@ class Type implements Value {
         throw new IllegalAccessException("Cannot instantiate an object from ".($args ? typeof($args[0])->getName() : "null"));
       }
       public function cast($value) {
-        if (is_object($value)) return $value;
-        throw new ClassCastException("Cannot cast ".typeof($value)->getName()." to the object type");
+        return (object)$value;
       }
       public function isAssignableFrom($type): bool {
         return $type instanceof self || $type instanceof XPClass;

--- a/src/main/php/lang/Type.class.php
+++ b/src/main/php/lang/Type.class.php
@@ -30,7 +30,7 @@ class Type implements Value {
         }
       }
       public function cast($value) {
-        return null === $value ? null : (array)$value;
+        return (array)$value;
       }
       public function isAssignableFrom($type): bool {
         return $type instanceof self || $type instanceof ArrayType || $type instanceof MapType;
@@ -45,7 +45,7 @@ class Type implements Value {
         throw new IllegalAccessException("Cannot instantiate an object from ".($args ? typeof($args[0])->getName() : "null"));
       }
       public function cast($value) {
-        if (null === $value || is_object($value)) return $value;
+        if (is_object($value)) return $value;
         throw new ClassCastException("Cannot cast ".typeof($value)->getName()." to the object type");
       }
       public function isAssignableFrom($type): bool {
@@ -61,7 +61,7 @@ class Type implements Value {
         throw new IllegalAccessException("Cannot instantiate a callable from ".($args ? typeof($args[0])->getName() : "null"));
       }
       public function cast($value) {
-        if (null === $value || is_callable($value)) return $value;
+        if (is_callable($value)) return $value;
         throw new ClassCastException("Cannot cast ".typeof($value)->getName()." to the callable type");
       }
       public function isAssignableFrom($type): bool {
@@ -77,7 +77,7 @@ class Type implements Value {
         throw new IllegalAccessException("Cannot instantiate an iterable from ".($args ? typeof($args[0])->getName() : "null"));
       }
       public function cast($value) {
-        if (null === $value || $value instanceof \Traversable || is_array($value)) return $value;
+        if (is_iterable($value)) return $value;
         throw new ClassCastException("Cannot cast ".typeof($value)->getName()." to the iterable type");
       }
       public function isAssignableFrom($type): bool {

--- a/src/main/php/lang/XPClass.class.php
+++ b/src/main/php/lang/XPClass.class.php
@@ -172,8 +172,6 @@ class XPClass extends Type {
    * @throws  lang.ClassCastException
    */
   public function cast($value) {
-    if (null === $value) return null;
-
     $literal= literal($this->name);
     if ($value instanceof $literal) {
       return $value;

--- a/src/test/php/lang/unittest/ClassCastingTest.class.php
+++ b/src/test/php/lang/unittest/ClassCastingTest.class.php
@@ -30,9 +30,9 @@ class ClassCastingTest extends BaseTest {
     typeof($this)->cast(Type::$VOID);
   }
 
-  #[Test]
+  #[Test, Expect(ClassCastException::class)]
   public function thisClassCastingNull() {
-    Assert::null(typeof($this)->cast(null));
+    typeof($this)->cast(null);
   }
 
   #[Test, Expect(ClassCastException::class)]

--- a/src/test/php/lang/unittest/PrimitiveTest.class.php
+++ b/src/test/php/lang/unittest/PrimitiveTest.class.php
@@ -156,22 +156,22 @@ class PrimitiveTest {
     Assert::equals($expected, Primitive::$BOOL->newInstance($value));
   }
 
-  #[Test, Values([['', ''], ['Test', 'Test'], [null, null], ['0', 0], ['-1', -1], ['0.5', 0.5], ['', false], ['1', true]])]
+  #[Test, Values([['', ''], ['Test', 'Test'], ['', null], ['0', 0], ['-1', -1], ['0.5', 0.5], ['', false], ['1', true]])]
   public function cast_of_string($expected, $value) {
     Assert::equals($expected, Primitive::$STRING->cast($value));
   }
 
-  #[Test, Values([[0, ''], [0, 'Test'], [2, '2'], [123, '123'], [0xFF, '0xFF'], [0755, '0755'], [null, null], [0, 0], [-1, -1], [0, 0.5], [0, false], [1, true]])]
+  #[Test, Values([[0, ''], [0, 'Test'], [2, '2'], [123, '123'], [0xFF, '0xFF'], [0755, '0755'], [0, null], [0, 0], [-1, -1], [0, 0.5], [0, false], [1, true]])]
   public function cast_of_int($expected, $value) {
     Assert::equals($expected, Primitive::$INT->cast($value));
   }
 
-  #[Test, Values([[0.0, ''], [0.0, 'Test'], [123.0, '123'], [0.0, '0xFF'], [755.0, '0755'], [null, null], [0.0, 0], [-1.0, -1], [0.5, 0.5], [0.0, false]])]
+  #[Test, Values([[0.0, ''], [0.0, 'Test'], [123.0, '123'], [0.0, '0xFF'], [755.0, '0755'], [0.0, null], [0.0, 0], [-1.0, -1], [0.5, 0.5], [0.0, false]])]
   public function cast_of_double($expected, $value) {
     Assert::equals($expected, Primitive::$FLOAT->cast($value));
   }
 
-  #[Test, Values([[false, ''], [true, 'Test'], [null, null], [false, 0], [true, -1], [true, 0.5], [false, false], [true, true]])]
+  #[Test, Values([[false, ''], [true, 'Test'], [false, null], [false, 0], [true, -1], [true, 0.5], [false, false], [true, true]])]
   public function cast_of_bool($expected, $value) {
     Assert::equals($expected, Primitive::$BOOL->cast($value));
   }

--- a/src/test/php/lang/unittest/TypeTest.class.php
+++ b/src/test/php/lang/unittest/TypeTest.class.php
@@ -377,7 +377,7 @@ class TypeTest {
 
   #[Test]
   public function array_type_union_cast_null() {
-    Assert::equals(null, Type::$ARRAY->cast(null));
+    Assert::equals([], Type::$ARRAY->cast(null));
   }
 
   #[Test, Values(from: 'callables')]
@@ -395,9 +395,9 @@ class TypeTest {
     Assert::equals($value, Type::$CALLABLE->cast($value));
   }
 
-  #[Test]
+  #[Test, Expect(ClassCastException::class)]
   public function callable_type_union_cast_null() {
-    Assert::equals(null, Type::$CALLABLE->cast(null));
+    Type::$CALLABLE->cast(null);
   }
 
   #[Test]
@@ -441,10 +441,11 @@ class TypeTest {
     Assert::equals($value, Type::$ITERABLE->cast($value));
   }
 
-  #[Test]
+  #[Test, Expect(ClassCastException::class)]
   public function iterable_type_union_cast_null() {
-    Assert::null(Type::$ITERABLE->cast(null));
+    Type::$ITERABLE->cast(null);
   }
+
   #[Test, Values(eval: '[[new Name("test")], [new \ArrayObject([])]]')]
   public function object_type_union_isInstance($value) {
     Assert::true(Type::$OBJECT->isInstance($value));
@@ -455,7 +456,7 @@ class TypeTest {
     Assert::true(Type::$OBJECT->isInstance($value));
   }
 
-  #[Test, Values(eval: '[[null], [new Name("test")], [new \ArrayObject([])]]')]
+  #[Test, Values(eval: '[[new Name("test")], [new \ArrayObject([])]]')]
   public function object_type_union_cast($value) {
     Assert::equals($value, Type::$OBJECT->cast($value));
   }


### PR DESCRIPTION
This pull request changes the special handling in `Type::Cast()` which will return *null*  when *null* is given, and changes it to work like the cast operators in PHP. The old behavior can be achieved with nullable types.

## Examples

Primitives:

```php
use lang\Primitive;

// Both now return an empty string
$r= (string)null; 
$r= Primitve::$STRING->cast(null);
```

Arrays:

```php
use lang\Type;

// Both now return an empty array
$r= (array)null;
$r= Type::$ARRAY->cast(null);
```

Objects:

```php
use lang\Type;

// Both now return an empty object
$r= (object)null;
$r= Type::$OBJECT->cast(null);
```

